### PR TITLE
Standardize user login session key

### DIFF
--- a/includes/navigation.php
+++ b/includes/navigation.php
@@ -73,7 +73,7 @@
 <? // END OF THE MIDDLE OF TOP NAV ?>
 
 
-  <? if($_SESSION(['user_logged_in']){ ?>
+  <? if(isset($_SESSION['user_logged_in'])){ ?>
     <ul class="navbar-nav navbar-nav-icons flex-row">
       <li class="nav-item dropdown">
         <a class="nav-link" href="#" style="min-width: 2.25rem" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-bs-auto-close="outside"><span class="d-block" style="height:20px;width:20px;"><span data-feather="bell" style="height:20px;width:20px;"></span></span></a>
@@ -254,7 +254,7 @@
   <? } ?>
 
   <? // USER IS NOT AUTHENTICATED OR LOGGED IN
-  if(!$_SESSION(['user_logged_in']){ ?>
+  if(!isset($_SESSION['user_logged_in'])){ ?>
     <? // LOGIN BUTTON ?>
     <li class="nav-item mr-4">
       <a href="<? echo getURLDir(); ?>module/user/login.php" class="nav-link btn btn-sm btn-success font-weight-bold text-white">Login</a>

--- a/includes/php_header.php
+++ b/includes/php_header.php
@@ -9,7 +9,7 @@ $today_date = date('Y-m-d');
 $date_today = date("l, F j, Y");
 $tomorrow = date('l, F j, Y',strtotime("$today +1 days"));
 
-if($_SESSION(['user_logged_in'])){
+if (isset($_SESSION['user_logged_in'])) {
 
   // STRINGS AREN'T FUN IN MySQL QUERIES
   $email = $_SESSION['this_user_email'];
@@ -41,7 +41,7 @@ if($_SESSION(['user_logged_in'])){
     $this_user_name = $this_user_first_name . " " . $this_user_last_name;
   } // END THIS_USER
 
-  $is_logged_in = $_SESSION['logged_in'] ?? false;
+  $is_logged_in = $_SESSION['user_logged_in'] ?? false;
   $is_admin = ($_SESSION['type'] ?? '') === 'ADMIN';
 }
 


### PR DESCRIPTION
## Summary
- Fix session login checks in header and navigation
- Consolidate login state to `user_logged_in` session key

## Testing
- `php -l includes/php_header.php`
- `php -d short_open_tag=1 -l includes/navigation.php`


------
https://chatgpt.com/codex/tasks/task_e_68929b3da4308333a54966bbc607d9c5