### PR TITLE
Add .gitignore for common development artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Logs and temporary files
+*.log
+*.tmp
+
+# OS generated files
+.DS_Store
+
+# Node
+node_modules/
+package-lock.json
+
+# XAMPP-specific files
+xampp/
+xamppfiles/
+php.ini
+my.cnf
+config.inc.php


### PR DESCRIPTION
## Summary
- add root .gitignore to exclude logs, temp files, OS junk, Node artifacts and XAMPP configs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68929ed8224c83338e76913e127d130c