### PR TITLE
Add audit logging helper

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -4,4 +4,19 @@ function getURLDir(){
   return '/Atlis/';
 }
 
+// Records CRUD actions into the audit_log table
+function audit_log($pdo, $userId, $table, $recordId, $action, $details){
+  $sql = "INSERT INTO audit_log (user_id, user_updated, table_name, record_id, action, details)
+          VALUES (:user_id, :user_updated, :table_name, :record_id, :action, :details)";
+  $stmt = $pdo->prepare($sql);
+  $stmt->execute([
+    ':user_id' => $userId,
+    ':user_updated' => $userId,
+    ':table_name' => $table,
+    ':record_id' => $recordId,
+    ':action' => $action,
+    ':details' => $details,
+  ]);
+}
+
 ?>


### PR DESCRIPTION
## Summary
- implement audit_log helper using direct INSERT into audit_log table
- remove redundant functions include since config already loads helpers

## Testing
- `php -l includes/functions.php`
- `php -l includes/php_header.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_6892a9b0e85883338180729fe87adf11