### PR TITLE
Redirect unauthenticated module access

### DIFF
--- a/includes/php_header.php
+++ b/includes/php_header.php
@@ -12,6 +12,14 @@ $tomorrow = date('l, F j, Y',strtotime("$today +1 days"));
 $is_logged_in = isset($_SESSION['user_logged_in']) ? $_SESSION['user_logged_in'] : false;
 $is_admin = $is_logged_in && (($_SESSION['type'] ?? '') === 'ADMIN');
 
+if (!$is_logged_in) {
+  $requestUri = $_SERVER['REQUEST_URI'] ?? '';
+  if (strpos($requestUri, '/module/') !== false && strpos($requestUri, '/module/users/') === false) {
+    header('Location: ' . getURLDir() . 'module/users/index.php?action=login');
+    exit;
+  }
+}
+
 if ($is_logged_in) {
 
   // STRINGS AREN'T FUN IN MySQL QUERIES

--- a/module/README.md
+++ b/module/README.md
@@ -1,0 +1,7 @@
+# Modules
+
+Each module must include `includes/php_header.php` in its `index.php` to enforce authentication. This ensures unauthenticated users are redirected to the login page.
+
+```php
+require_once '../../includes/php_header.php';
+```


### PR DESCRIPTION
## Summary
- Redirect unauthenticated module requests to the login page via `php_header.php`.
- Document that each module's `index.php` must include `php_header.php` for authentication in `module/README.md`.

## Testing
- `php -l includes/php_header.php`


------
https://chatgpt.com/codex/tasks/task_e_6892b2cec7948333af35c5abb5666e6d