### PR TITLE
Use Phoenix authentication cards with login/logout audit logging and email 2FA

### DIFF
--- a/_SQL/003_users_2fa.sql
+++ b/_SQL/003_users_2fa.sql
@@ -1,0 +1,16 @@
+CREATE TABLE `users_2fa` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT CURRENT_TIMESTAMP,
+  `date_updated` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `memo` text DEFAULT NULL,
+  `code` varchar(6) NOT NULL,
+  `expires_at` datetime NOT NULL,
+  `used` tinyint(1) DEFAULT 0,
+  PRIMARY KEY (`id`),
+  KEY `fk_users_2fa_user_id` (`user_id`),
+  KEY `fk_users_2fa_user_updated` (`user_updated`),
+  CONSTRAINT `fk_users_2fa_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+  CONSTRAINT `fk_users_2fa_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/module/users/functions/logout.php
+++ b/module/users/functions/logout.php
@@ -2,9 +2,28 @@
 if (session_status() !== PHP_SESSION_ACTIVE) {
   session_start();
 }
+
+// Ensure database and helper functions are available
+require_once '../../../includes/config.php';
+
+// Capture current user ID via session email before destroying session
+$userId = null;
+if (!empty($_SESSION['this_user_email'])) {
+  $stmt = $pdo->prepare('SELECT id FROM users WHERE email = :email');
+  $stmt->bindParam(':email', $_SESSION['this_user_email'], PDO::PARAM_STR);
+  $stmt->execute();
+  $userId = $stmt->fetchColumn();
+}
+
+// Log the logout action if the user was identified
+if ($userId) {
+  audit_log($pdo, $userId, 'users', $userId, 'LOGOUT', 'User logged out');
+}
+
+// Clear session and destroy
 $_SESSION = [];
 session_unset();
 session_destroy();
-header('Location: ../index.php?action=login');
-exit;
+session_regenerate_id(true);
+
 ?>

--- a/module/users/functions/verify_2fa.php
+++ b/module/users/functions/verify_2fa.php
@@ -1,0 +1,33 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) {
+  session_start();
+}
+require_once '../../../includes/config.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  $code = $_POST['code'] ?? '';
+  $userId = $_SESSION['2fa_user_id'] ?? null;
+  if ($userId) {
+    $stmt = $pdo->prepare('SELECT id FROM users_2fa WHERE user_id = :user_id AND code = :code AND used = 0 AND expires_at > NOW() ORDER BY id DESC LIMIT 1');
+    $stmt->execute([':user_id' => $userId, ':code' => $code]);
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
+    if ($row) {
+      $pdo->prepare('UPDATE users_2fa SET used = 1 WHERE id = :id')->execute([':id' => $row['id']]);
+      $stmt = $pdo->prepare('SELECT email, type FROM users WHERE id = :id');
+      $stmt->execute([':id' => $userId]);
+      $user = $stmt->fetch(PDO::FETCH_ASSOC);
+      $_SESSION['user_logged_in'] = true;
+      $_SESSION['this_user_email'] = $user['email'];
+      $_SESSION['type'] = $user['type'];
+      audit_log($pdo, $userId, 'users', $userId, 'LOGIN', 'User logged in');
+      session_regenerate_id(true);
+      unset($_SESSION['2fa_user_id'], $_SESSION['2fa_user_email']);
+      header('Location: ' . getURLDir());
+      exit;
+    }
+  }
+}
+
+header('Location: ../index.php?action=2fa&error=1');
+exit;
+?>

--- a/module/users/include/2fa.php
+++ b/module/users/include/2fa.php
@@ -1,0 +1,41 @@
+<?php
+$error = $_GET['error'] ?? '';
+$email = $_SESSION['2fa_user_email'] ?? '';
+$masked = $email ? preg_replace('/(^[^@]{3})([^@]*)(@.*$)/', '$1****$3', $email) : '';
+if (!$email) {
+  header('Location: index.php?action=login');
+  exit;
+}
+?>
+<main class="main" id="top">
+  <div class="container-fluid bg-body-tertiary dark__bg-gray-1200">
+    <div class="bg-holder bg-auth-card-overlay" style="background-image:url(<?php echo getURLDir(); ?>assets/img/bg/37.png);"></div>
+    <div class="row flex-center position-relative min-vh-100 g-0 py-5">
+      <div class="col-11 col-sm-10 col-xl-8">
+        <div class="card border border-translucent auth-card">
+          <div class="card-body pe-md-0">
+            <div class="row align-items-center gx-0 gy-7">
+              <div class="col mx-auto">
+                <div class="auth-form-box text-center">
+                  <div class="text-center mb-7">
+                    <h3 class="text-body-highlight">Enter the verification code</h3>
+                    <p class="text-body-tertiary">We sent a 6-digit code to <?php echo htmlspecialchars($masked); ?></p>
+                    <?php if ($error) { ?>
+                    <div class="alert alert-danger" role="alert">Invalid or expired code.</div>
+                    <?php } ?>
+                  </div>
+                  <form method="post" action="<?php echo getURLDir(); ?>module/users/functions/verify_2fa.php">
+                    <div class="mb-4">
+                      <input class="form-control text-center" id="code" type="text" name="code" maxlength="6" placeholder="123456" required />
+                    </div>
+                    <button class="btn btn-primary w-100 mb-3" type="submit">Verify</button>
+                  </form>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/module/users/include/login.php
+++ b/module/users/include/login.php
@@ -1,18 +1,55 @@
-<div class="container py-5">
-  <div class="row justify-content-center">
-    <div class="col-md-4">
-      <h2 class="mb-4">Login</h2>
-      <form method="post" action="../functions/login.php">
-        <div class="mb-3">
-          <label for="email" class="form-label">Email</label>
-          <input type="email" class="form-control" id="email" name="email" required>
+<?php
+$error = $_GET['error'] ?? '';
+?>
+<main class="main" id="top">
+<div class="container-fluid bg-body-tertiary dark__bg-gray-1200">
+  <div class="bg-holder bg-auth-card-overlay" style="background-image:url(<?php echo getURLDir(); ?>assets/img/bg/37.png);"></div>
+  <div class="row flex-center position-relative min-vh-100 g-0 py-5">
+    <div class="col-11 col-sm-10 col-xl-8">
+      <div class="card border border-translucent auth-card">
+        <div class="card-body pe-md-0">
+          <div class="row align-items-center gx-0 gy-7">
+            <div class="col mx-auto">
+              <div class="auth-form-box">
+                <div class="text-center mb-7">
+                  <h3 class="text-body-highlight">Sign In</h3>
+                  <p class="text-body-tertiary">Get access to your account</p>
+                  <?php if ($error) { ?>
+                  <div class="alert alert-danger" role="alert">Invalid email or password.</div>
+                  <?php } ?>
+                </div>
+                <form method="post" action="<?php echo getURLDir(); ?>module/users/functions/login.php">
+                  <div class="mb-3 text-start">
+                    <label class="form-label" for="email">Email address</label>
+                    <div class="form-icon-container">
+                      <input class="form-control form-icon-input" id="email" type="email" name="email" placeholder="name@example.com" required />
+                      <span class="fas fa-user text-body fs-9 form-icon"></span>
+                    </div>
+                  </div>
+                  <div class="mb-3 text-start">
+                    <label class="form-label" for="password">Password</label>
+                    <div class="form-icon-container" data-password="data-password">
+                      <input class="form-control form-icon-input pe-6" id="password" type="password" name="password" placeholder="Password" data-password-input="data-password-input" required />
+                      <span class="fas fa-key text-body fs-9 form-icon"></span>
+                      <button class="btn px-3 py-0 h-100 position-absolute top-0 end-0 fs-7 text-body-tertiary" type="button" data-password-toggle="data-password-toggle"><span class="uil uil-eye show"></span><span class="uil uil-eye-slash hide"></span></button>
+                    </div>
+                  </div>
+                  <div class="row flex-between-center mb-7">
+                    <div class="col-auto">
+                      <div class="form-check mb-0">
+                        <input class="form-check-input" id="basic-checkbox" type="checkbox" name="remember" />
+                        <label class="form-check-label mb-0" for="basic-checkbox">Remember me</label>
+                      </div>
+                    </div>
+                  </div>
+                  <button class="btn btn-primary w-100 mb-3" type="submit">Sign In</button>
+                </form>
+              </div>
+            </div>
+          </div>
         </div>
-        <div class="mb-3">
-          <label for="password" class="form-label">Password</label>
-          <input type="password" class="form-control" id="password" name="password" required>
-        </div>
-        <button type="submit" class="btn btn-primary">Login</button>
-      </form>
+      </div>
     </div>
   </div>
 </div>
+</main>

--- a/module/users/include/logout.php
+++ b/module/users/include/logout.php
@@ -1,0 +1,29 @@
+<main class="main" id="top">
+  <div class="container-fluid bg-body-tertiary dark__bg-gray-1200">
+    <div class="bg-holder bg-auth-card-overlay" style="background-image:url(<?php echo getURLDir(); ?>assets/img/bg/37.png);"></div>
+    <div class="row flex-center position-relative min-vh-100 g-0 py-5">
+      <div class="col-11 col-sm-10 col-xl-8">
+        <div class="card border border-translucent auth-card">
+          <div class="card-body pe-md-0">
+            <div class="row align-items-center gx-0 gy-7">
+              <div class="col mx-auto">
+                <div class="auth-form-box text-center">
+                  <div class="mb-7">
+                    <img class="mb-7 d-dark-none" src="<?php echo getURLDir(); ?>assets/img/spot-illustrations/1.png" alt="phoenix" />
+                    <img class="mb-7 d-light-none" src="<?php echo getURLDir(); ?>assets/img/spot-illustrations/dark_1.png" alt="phoenix" />
+                    <h4 class="text-body-highlight">Come back soon!</h4>
+                    <p class="text-body-tertiary">Thanks for using Atlisware.<br />You are now signed out.</p>
+                  </div>
+                  <div class="d-grid">
+                    <a class="btn btn-primary" href="<?php echo getURLDir(); ?>module/users/index.php?action=login"><span class="fas fa-angle-left me-2"></span>Go to sign in page</a>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>
+

--- a/module/users/index.php
+++ b/module/users/index.php
@@ -5,16 +5,33 @@ $action = $_GET['action'] ?? '';
 
 if ($action === 'logout') {
   require 'functions/logout.php';
+  require '../../includes/html_header.php';
+  require 'include/logout.php';
+  require '../../includes/js_footer.php';
   exit;
 }
 
-if ($is_logged_in && $action === 'login') {
+if ($is_logged_in && in_array($action, ['login', '2fa'])) {
   header('Location: ' . getURLDir());
   exit;
 }
 
-if (!$is_logged_in && $action !== 'login') {
-  header('Location: index.php?action=login');
+if (!$is_logged_in && !in_array($action, ['login', '2fa'])) {
+  header('Location: ' . getURLDir() . 'module/users/index.php?action=login');
+  exit;
+}
+
+if ($action === 'login') {
+  require '../../includes/html_header.php';
+  require 'include/login.php';
+  require '../../includes/js_footer.php';
+  exit;
+}
+
+if ($action === '2fa') {
+  require '../../includes/html_header.php';
+  require 'include/2fa.php';
+  require '../../includes/js_footer.php';
   exit;
 }
 
@@ -24,11 +41,7 @@ require '../../includes/html_header.php';
   <?php require "../../includes/left_navigation.php"; ?>
   <?php require "../../includes/navigation.php"; ?>
   <div id="main_content" class="content">
-    <?php
-    if ($action === 'login') {
-      require 'include/login.php';
-    }
-    ?>
+    <?php require 'include/home.php'; ?>
     <?php require '../../includes/html_footer.php'; ?>
   </div>
 </main>


### PR DESCRIPTION
## Summary
- Generate and email 6-digit codes on login to enforce two-factor authentication.
- Store verification codes in new `users_2fa` table and validate them before completing sign-in.
- Serve a Phoenix-styled 2FA form and route unauthenticated users through it.

## Testing
- `php -l module/users/functions/login.php`
- `php -l module/users/functions/verify_2fa.php`
- `php -l module/users/include/login.php`
- `php -l module/users/include/2fa.php`
- `php -l module/users/functions/logout.php`
- `php -l module/users/index.php`
- `php -l module/users/include/logout.php`


------
https://chatgpt.com/codex/tasks/task_e_6892c5cadedc83338c1c4716a6b651b6