### PR TITLE
Add initial agency CRM admin module and schema

### DIFF
--- a/_SQL/006_module_agency.sql
+++ b/_SQL/006_module_agency.sql
@@ -1,0 +1,89 @@
+-- Tables for Organization, Agency, Division
+CREATE TABLE `module_organization` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT CURRENT_TIMESTAMP,
+  `date_updated` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `memo` text DEFAULT NULL,
+  `name` varchar(255) NOT NULL,
+  `main_person` int(11) DEFAULT NULL,
+  `status` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `fk_module_organization_user_id` (`user_id`),
+  KEY `fk_module_organization_user_updated` (`user_updated`),
+  KEY `fk_module_organization_main_person` (`main_person`),
+  KEY `fk_module_organization_status` (`status`),
+  CONSTRAINT `fk_module_organization_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+  CONSTRAINT `fk_module_organization_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`),
+  CONSTRAINT `fk_module_organization_main_person` FOREIGN KEY (`main_person`) REFERENCES `person` (`id`),
+  CONSTRAINT `fk_module_organization_status` FOREIGN KEY (`status`) REFERENCES `module_lookup_list_items` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `module_agency` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT CURRENT_TIMESTAMP,
+  `date_updated` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `memo` text DEFAULT NULL,
+  `organization_id` int(11) NOT NULL,
+  `name` varchar(255) NOT NULL,
+  `main_person` int(11) DEFAULT NULL,
+  `status` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `fk_module_agency_user_id` (`user_id`),
+  KEY `fk_module_agency_user_updated` (`user_updated`),
+  KEY `fk_module_agency_organization_id` (`organization_id`),
+  KEY `fk_module_agency_main_person` (`main_person`),
+  KEY `fk_module_agency_status` (`status`),
+  CONSTRAINT `fk_module_agency_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+  CONSTRAINT `fk_module_agency_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`),
+  CONSTRAINT `fk_module_agency_organization_id` FOREIGN KEY (`organization_id`) REFERENCES `module_organization` (`id`),
+  CONSTRAINT `fk_module_agency_main_person` FOREIGN KEY (`main_person`) REFERENCES `person` (`id`),
+  CONSTRAINT `fk_module_agency_status` FOREIGN KEY (`status`) REFERENCES `module_lookup_list_items` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `module_division` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT CURRENT_TIMESTAMP,
+  `date_updated` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `memo` text DEFAULT NULL,
+  `agency_id` int(11) NOT NULL,
+  `name` varchar(255) NOT NULL,
+  `main_person` int(11) DEFAULT NULL,
+  `status` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `fk_module_division_user_id` (`user_id`),
+  KEY `fk_module_division_user_updated` (`user_updated`),
+  KEY `fk_module_division_agency_id` (`agency_id`),
+  KEY `fk_module_division_main_person` (`main_person`),
+  KEY `fk_module_division_status` (`status`),
+  CONSTRAINT `fk_module_division_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+  CONSTRAINT `fk_module_division_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`),
+  CONSTRAINT `fk_module_division_agency_id` FOREIGN KEY (`agency_id`) REFERENCES `module_agency` (`id`),
+  CONSTRAINT `fk_module_division_main_person` FOREIGN KEY (`main_person`) REFERENCES `person` (`id`),
+  CONSTRAINT `fk_module_division_status` FOREIGN KEY (`status`) REFERENCES `module_lookup_list_items` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- Lookup lists for statuses
+INSERT INTO `module_lookup_lists` (`name`, `description`) VALUES
+('ORGANIZATION_STATUS','Status values for organizations'),
+('AGENCY_STATUS','Status values for agencies'),
+('DIVISION_STATUS','Status values for divisions');
+
+-- Seed status items
+INSERT INTO `module_lookup_list_items` (`list_id`, `label`, `value`, `sort_order`)
+SELECT l.id, 'Active', 'active', 1 FROM module_lookup_lists l WHERE l.name = 'ORGANIZATION_STATUS';
+INSERT INTO `module_lookup_list_items` (`list_id`, `label`, `value`, `sort_order`)
+SELECT l.id, 'Inactive', 'inactive', 2 FROM module_lookup_lists l WHERE l.name = 'ORGANIZATION_STATUS';
+INSERT INTO `module_lookup_list_items` (`list_id`, `label`, `value`, `sort_order`)
+SELECT l.id, 'Active', 'active', 1 FROM module_lookup_lists l WHERE l.name = 'AGENCY_STATUS';
+INSERT INTO `module_lookup_list_items` (`list_id`, `label`, `value`, `sort_order`)
+SELECT l.id, 'Inactive', 'inactive', 2 FROM module_lookup_lists l WHERE l.name = 'AGENCY_STATUS';
+INSERT INTO `module_lookup_list_items` (`list_id`, `label`, `value`, `sort_order`)
+SELECT l.id, 'Active', 'active', 1 FROM module_lookup_lists l WHERE l.name = 'DIVISION_STATUS';
+INSERT INTO `module_lookup_list_items` (`list_id`, `label`, `value`, `sort_order`)
+SELECT l.id, 'Inactive', 'inactive', 2 FROM module_lookup_lists l WHERE l.name = 'DIVISION_STATUS';

--- a/_SQL/atlis.sql
+++ b/_SQL/atlis.sql
@@ -81,6 +81,116 @@ CREATE TABLE `users` (
   `last_login` datetime DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `module_lookup_lists`
+--
+
+CREATE TABLE `module_lookup_lists` (
+  `id` int(11) NOT NULL,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT current_timestamp(),
+  `date_updated` datetime DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  `memo` text DEFAULT NULL,
+  `name` varchar(255) NOT NULL,
+  `description` text DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `module_lookup_list_items`
+--
+
+CREATE TABLE `module_lookup_list_items` (
+  `id` int(11) NOT NULL,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT current_timestamp(),
+  `date_updated` datetime DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  `memo` text DEFAULT NULL,
+  `list_id` int(11) NOT NULL,
+  `label` varchar(255) NOT NULL,
+  `value` varchar(255) DEFAULT NULL,
+  `sort_order` int(11) DEFAULT 0
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `module_lookup_list_item_attributes`
+--
+
+CREATE TABLE `module_lookup_list_item_attributes` (
+  `id` int(11) NOT NULL,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT current_timestamp(),
+  `date_updated` datetime DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  `memo` text DEFAULT NULL,
+  `item_id` int(11) NOT NULL,
+  `attr_key` varchar(100) NOT NULL,
+  `attr_value` text DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `module_organization`
+--
+
+CREATE TABLE `module_organization` (
+  `id` int(11) NOT NULL,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT current_timestamp(),
+  `date_updated` datetime DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  `memo` text DEFAULT NULL,
+  `name` varchar(255) NOT NULL,
+  `main_person` int(11) DEFAULT NULL,
+  `status` int(11) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `module_agency`
+--
+
+CREATE TABLE `module_agency` (
+  `id` int(11) NOT NULL,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT current_timestamp(),
+  `date_updated` datetime DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  `memo` text DEFAULT NULL,
+  `organization_id` int(11) NOT NULL,
+  `name` varchar(255) NOT NULL,
+  `main_person` int(11) DEFAULT NULL,
+  `status` int(11) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `module_division`
+--
+
+CREATE TABLE `module_division` (
+  `id` int(11) NOT NULL,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT current_timestamp(),
+  `date_updated` datetime DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  `memo` text DEFAULT NULL,
+  `agency_id` int(11) NOT NULL,
+  `name` varchar(255) NOT NULL,
+  `main_person` int(11) DEFAULT NULL,
+  `status` int(11) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
 --
 -- Indexes for dumped tables
 --
@@ -112,6 +222,67 @@ ALTER TABLE `users`
   ADD KEY `fk_users_user_updated` (`user_updated`);
 
 --
+-- Indexes for table `module_lookup_lists`
+--
+ALTER TABLE `module_lookup_lists`
+  ADD PRIMARY KEY (`id`),
+  ADD UNIQUE KEY `uq_module_lookup_lists_name` (`name`),
+  ADD KEY `fk_module_lookup_lists_user_id` (`user_id`),
+  ADD KEY `fk_module_lookup_lists_user_updated` (`user_updated`);
+
+--
+-- Indexes for table `module_lookup_list_items`
+--
+ALTER TABLE `module_lookup_list_items`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `fk_module_lookup_list_items_list_id` (`list_id`),
+  ADD KEY `fk_module_lookup_list_items_user_id` (`user_id`),
+  ADD KEY `fk_module_lookup_list_items_user_updated` (`user_updated`),
+  ADD KEY `idx_module_lookup_list_items_label` (`label`);
+
+--
+-- Indexes for table `module_lookup_list_item_attributes`
+--
+ALTER TABLE `module_lookup_list_item_attributes`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `fk_module_lookup_item_attributes_item_id` (`item_id`),
+  ADD KEY `fk_module_lookup_item_attributes_user_id` (`user_id`),
+  ADD KEY `fk_module_lookup_item_attributes_user_updated` (`user_updated`),
+  ADD KEY `idx_module_lookup_item_attributes_key` (`attr_key`);
+
+--
+-- Indexes for table `module_organization`
+--
+ALTER TABLE `module_organization`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `fk_module_organization_user_id` (`user_id`),
+  ADD KEY `fk_module_organization_user_updated` (`user_updated`),
+  ADD KEY `fk_module_organization_main_person` (`main_person`),
+  ADD KEY `fk_module_organization_status` (`status`);
+
+--
+-- Indexes for table `module_agency`
+--
+ALTER TABLE `module_agency`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `fk_module_agency_user_id` (`user_id`),
+  ADD KEY `fk_module_agency_user_updated` (`user_updated`),
+  ADD KEY `fk_module_agency_organization_id` (`organization_id`),
+  ADD KEY `fk_module_agency_main_person` (`main_person`),
+  ADD KEY `fk_module_agency_status` (`status`);
+
+--
+-- Indexes for table `module_division`
+--
+ALTER TABLE `module_division`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `fk_module_division_user_id` (`user_id`),
+  ADD KEY `fk_module_division_user_updated` (`user_updated`),
+  ADD KEY `fk_module_division_agency_id` (`agency_id`),
+  ADD KEY `fk_module_division_main_person` (`main_person`),
+  ADD KEY `fk_module_division_status` (`status`);
+
+--
 -- AUTO_INCREMENT for dumped tables
 --
 
@@ -131,6 +302,42 @@ ALTER TABLE `person`
 -- AUTO_INCREMENT for table `users`
 --
 ALTER TABLE `users`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT for table `module_lookup_lists`
+--
+ALTER TABLE `module_lookup_lists`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT for table `module_lookup_list_items`
+--
+ALTER TABLE `module_lookup_list_items`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT for table `module_lookup_list_item_attributes`
+--
+ALTER TABLE `module_lookup_list_item_attributes`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT for table `module_organization`
+--
+ALTER TABLE `module_organization`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT for table `module_agency`
+--
+ALTER TABLE `module_agency`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT for table `module_division`
+--
+ALTER TABLE `module_division`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
 
 --
@@ -157,6 +364,58 @@ ALTER TABLE `person`
 ALTER TABLE `users`
   ADD CONSTRAINT `fk_users_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
   ADD CONSTRAINT `fk_users_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`);
+
+--
+-- Constraints for table `module_lookup_lists`
+--
+ALTER TABLE `module_lookup_lists`
+  ADD CONSTRAINT `fk_module_lookup_lists_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+  ADD CONSTRAINT `fk_module_lookup_lists_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`);
+
+--
+-- Constraints for table `module_lookup_list_items`
+--
+ALTER TABLE `module_lookup_list_items`
+  ADD CONSTRAINT `fk_module_lookup_list_items_list_id` FOREIGN KEY (`list_id`) REFERENCES `module_lookup_lists` (`id`),
+  ADD CONSTRAINT `fk_module_lookup_list_items_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+  ADD CONSTRAINT `fk_module_lookup_list_items_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`);
+
+--
+-- Constraints for table `module_lookup_list_item_attributes`
+--
+ALTER TABLE `module_lookup_list_item_attributes`
+  ADD CONSTRAINT `fk_module_lookup_item_attributes_item_id` FOREIGN KEY (`item_id`) REFERENCES `module_lookup_list_items` (`id`),
+  ADD CONSTRAINT `fk_module_lookup_item_attributes_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+  ADD CONSTRAINT `fk_module_lookup_item_attributes_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`);
+
+--
+-- Constraints for table `module_organization`
+--
+ALTER TABLE `module_organization`
+  ADD CONSTRAINT `fk_module_organization_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+  ADD CONSTRAINT `fk_module_organization_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`),
+  ADD CONSTRAINT `fk_module_organization_main_person` FOREIGN KEY (`main_person`) REFERENCES `person` (`id`),
+  ADD CONSTRAINT `fk_module_organization_status` FOREIGN KEY (`status`) REFERENCES `module_lookup_list_items` (`id`);
+
+--
+-- Constraints for table `module_agency`
+--
+ALTER TABLE `module_agency`
+  ADD CONSTRAINT `fk_module_agency_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+  ADD CONSTRAINT `fk_module_agency_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`),
+  ADD CONSTRAINT `fk_module_agency_organization_id` FOREIGN KEY (`organization_id`) REFERENCES `module_organization` (`id`),
+  ADD CONSTRAINT `fk_module_agency_main_person` FOREIGN KEY (`main_person`) REFERENCES `person` (`id`),
+  ADD CONSTRAINT `fk_module_agency_status` FOREIGN KEY (`status`) REFERENCES `module_lookup_list_items` (`id`);
+
+--
+-- Constraints for table `module_division`
+--
+ALTER TABLE `module_division`
+  ADD CONSTRAINT `fk_module_division_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+  ADD CONSTRAINT `fk_module_division_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`),
+  ADD CONSTRAINT `fk_module_division_agency_id` FOREIGN KEY (`agency_id`) REFERENCES `module_agency` (`id`),
+  ADD CONSTRAINT `fk_module_division_main_person` FOREIGN KEY (`main_person`) REFERENCES `person` (`id`),
+  ADD CONSTRAINT `fk_module_division_status` FOREIGN KEY (`status`) REFERENCES `module_lookup_list_items` (`id`);
 COMMIT;
 
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;

--- a/admin/agency/agencies.php
+++ b/admin/agency/agencies.php
@@ -1,0 +1,56 @@
+<?php
+require '../admin_header.php';
+
+$organization_id = isset($_GET['organization_id']) ? (int)$_GET['organization_id'] : 0;
+if(!$organization_id) {
+  die('Organization ID required');
+}
+
+$orgStmt = $pdo->prepare('SELECT name FROM module_organization WHERE id = :id');
+$orgStmt->execute([':id'=>$organization_id]);
+$organization = $orgStmt->fetch(PDO::FETCH_ASSOC);
+if(!$organization) {
+  die('Organization not found');
+}
+
+$stmt = $pdo->prepare('SELECT id, name FROM module_agency WHERE organization_id = :org_id ORDER BY name');
+$stmt->execute([':org_id'=>$organization_id]);
+$agencies = $stmt->fetchAll(PDO::FETCH_ASSOC);
+?>
+<h2 class="mb-4">Agencies for <?= htmlspecialchars($organization['name']); ?></h2>
+<a href="agency_edit.php?organization_id=<?= $organization_id; ?>" class="btn btn-sm btn-primary mb-3">Add Agency</a>
+<div id="agencies" data-list='{"valueNames":["id","name"],"page":10,"pagination":true}'>
+  <div class="row justify-content-between g-2 mb-3">
+    <div class="col-auto">
+      <input class="form-control form-control-sm search" placeholder="Search" />
+    </div>
+  </div>
+  <div class="table-responsive">
+    <table class="table table-striped table-sm mb-0">
+      <thead>
+        <tr>
+          <th class="sort" data-sort="id">ID</th>
+          <th class="sort" data-sort="name">Name</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody class="list">
+        <?php foreach($agencies as $a): ?>
+          <tr>
+            <td class="id"><?= htmlspecialchars($a['id']); ?></td>
+            <td class="name"><?= htmlspecialchars($a['name']); ?></td>
+            <td>
+              <a class="btn btn-sm btn-secondary" href="agency_edit.php?id=<?= $a['id']; ?>&organization_id=<?= $organization_id; ?>">Edit</a>
+              <a class="btn btn-sm btn-info" href="divisions.php?agency_id=<?= $a['id']; ?>">Divisions</a>
+            </td>
+          </tr>
+        <?php endforeach; ?>
+      </tbody>
+    </table>
+  </div>
+  <div class="d-flex justify-content-between align-items-center mt-3">
+    <p class="mb-0" data-list-info></p>
+    <ul class="pagination mb-0"></ul>
+  </div>
+</div>
+<?php require '../admin_footer.php'; ?>

--- a/admin/agency/agency_edit.php
+++ b/admin/agency/agency_edit.php
@@ -1,0 +1,89 @@
+<?php
+require '../admin_header.php';
+
+$token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
+$_SESSION['csrf_token'] = $token;
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$organization_id = isset($_GET['organization_id']) ? (int)$_GET['organization_id'] : 0;
+if(!$organization_id && $id){
+  $stmtOrg = $pdo->prepare('SELECT organization_id FROM module_agency WHERE id = :id');
+  $stmtOrg->execute([':id'=>$id]);
+  $organization_id = (int)$stmtOrg->fetchColumn();
+}
+if(!$organization_id){
+  die('Organization ID required');
+}
+
+$orgStmt = $pdo->prepare('SELECT name FROM module_organization WHERE id = :id');
+$orgStmt->execute([':id'=>$organization_id]);
+$organization = $orgStmt->fetch(PDO::FETCH_ASSOC);
+if(!$organization) { die('Organization not found'); }
+
+$name = '';
+$main_person = null;
+$status = null;
+$message = '';
+
+if($_SERVER['REQUEST_METHOD'] === 'POST') {
+  if(!hash_equals($token, $_POST['csrf_token'] ?? '')) {
+    die('Invalid CSRF token');
+  }
+  $name = trim($_POST['name'] ?? '');
+  $main_person = !empty($_POST['main_person']) ? (int)$_POST['main_person'] : null;
+  $status = !empty($_POST['status']) ? (int)$_POST['status'] : null;
+  if($id){
+    $stmt = $pdo->prepare('UPDATE module_agency SET name = :name, main_person = :main_person, status = :status WHERE id = :id');
+    $stmt->execute([':name'=>$name, ':main_person'=>$main_person, ':status'=>$status, ':id'=>$id]);
+    audit_log($pdo, $this_user_id, 'module_agency', $id, 'UPDATE', 'Updated agency');
+    $message = 'Agency updated.';
+  } else {
+    $stmt = $pdo->prepare('INSERT INTO module_agency (organization_id, name, main_person, status) VALUES (:organization_id, :name, :main_person, :status)');
+    $stmt->execute([':organization_id'=>$organization_id, ':name'=>$name, ':main_person'=>$main_person, ':status'=>$status]);
+    $id = $pdo->lastInsertId();
+    audit_log($pdo, $this_user_id, 'module_agency', $id, 'CREATE', 'Created agency');
+    $message = 'Agency added.';
+  }
+}
+
+if($id && $_SERVER['REQUEST_METHOD'] !== 'POST') {
+  $stmt = $pdo->prepare('SELECT name, main_person, status FROM module_agency WHERE id = :id');
+  $stmt->execute([':id'=>$id]);
+  $row = $stmt->fetch(PDO::FETCH_ASSOC);
+  if($row){
+    $name = $row['name'];
+    $main_person = $row['main_person'];
+    $status = $row['status'];
+  }
+}
+
+// Fetch status list
+$statusStmt = $pdo->prepare("SELECT li.id, li.label FROM module_lookup_list_items li JOIN module_lookup_lists l ON li.list_id = l.id WHERE l.name = 'AGENCY_STATUS' ORDER BY li.sort_order, li.label");
+$statusStmt->execute();
+$statuses = $statusStmt->fetchAll(PDO::FETCH_ASSOC);
+?>
+<h2 class="mb-4"><?= $id ? 'Edit' : 'Add'; ?> Agency for <?= htmlspecialchars($organization['name']); ?></h2>
+<?php if($message){ echo '<div class="alert alert-success">'.htmlspecialchars($message).'</div>'; } ?>
+<form method="post">
+  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+  <div class="mb-3">
+    <label class="form-label">Name</label>
+    <input type="text" name="name" class="form-control" value="<?= htmlspecialchars($name); ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Main Person ID</label>
+    <input type="number" name="main_person" class="form-control" value="<?= htmlspecialchars($main_person); ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Status</label>
+    <select name="status" class="form-select">
+      <option value="">--</option>
+      <?php foreach($statuses as $s): ?>
+        <option value="<?= $s['id']; ?>" <?= $status == $s['id'] ? 'selected' : ''; ?>><?= htmlspecialchars($s['label']); ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <button type="submit" class="btn btn-primary">Save</button>
+  <a href="agencies.php?organization_id=<?= $organization_id; ?>" class="btn btn-secondary">Back</a>
+</form>
+<?php require '../admin_footer.php'; ?>

--- a/admin/agency/division_edit.php
+++ b/admin/agency/division_edit.php
@@ -1,0 +1,87 @@
+<?php
+require '../admin_header.php';
+
+$token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
+$_SESSION['csrf_token'] = $token;
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$agency_id = isset($_GET['agency_id']) ? (int)$_GET['agency_id'] : 0;
+if(!$agency_id && $id){
+  $stmtAgency = $pdo->prepare('SELECT agency_id FROM module_division WHERE id = :id');
+  $stmtAgency->execute([':id'=>$id]);
+  $agency_id = (int)$stmtAgency->fetchColumn();
+}
+if(!$agency_id){ die('Agency ID required'); }
+
+$agencyStmt = $pdo->prepare('SELECT name FROM module_agency WHERE id = :id');
+$agencyStmt->execute([':id'=>$agency_id]);
+$agency = $agencyStmt->fetch(PDO::FETCH_ASSOC);
+if(!$agency){ die('Agency not found'); }
+
+$name = '';
+$main_person = null;
+$status = null;
+$message = '';
+
+if($_SERVER['REQUEST_METHOD'] === 'POST') {
+  if(!hash_equals($token, $_POST['csrf_token'] ?? '')) {
+    die('Invalid CSRF token');
+  }
+  $name = trim($_POST['name'] ?? '');
+  $main_person = !empty($_POST['main_person']) ? (int)$_POST['main_person'] : null;
+  $status = !empty($_POST['status']) ? (int)$_POST['status'] : null;
+  if($id){
+    $stmt = $pdo->prepare('UPDATE module_division SET name = :name, main_person = :main_person, status = :status WHERE id = :id');
+    $stmt->execute([':name'=>$name, ':main_person'=>$main_person, ':status'=>$status, ':id'=>$id]);
+    audit_log($pdo, $this_user_id, 'module_division', $id, 'UPDATE', 'Updated division');
+    $message = 'Division updated.';
+  } else {
+    $stmt = $pdo->prepare('INSERT INTO module_division (agency_id, name, main_person, status) VALUES (:agency_id, :name, :main_person, :status)');
+    $stmt->execute([':agency_id'=>$agency_id, ':name'=>$name, ':main_person'=>$main_person, ':status'=>$status]);
+    $id = $pdo->lastInsertId();
+    audit_log($pdo, $this_user_id, 'module_division', $id, 'CREATE', 'Created division');
+    $message = 'Division added.';
+  }
+}
+
+if($id && $_SERVER['REQUEST_METHOD'] !== 'POST') {
+  $stmt = $pdo->prepare('SELECT name, main_person, status FROM module_division WHERE id = :id');
+  $stmt->execute([':id'=>$id]);
+  $row = $stmt->fetch(PDO::FETCH_ASSOC);
+  if($row){
+    $name = $row['name'];
+    $main_person = $row['main_person'];
+    $status = $row['status'];
+  }
+}
+
+// Fetch status list
+$statusStmt = $pdo->prepare("SELECT li.id, li.label FROM module_lookup_list_items li JOIN module_lookup_lists l ON li.list_id = l.id WHERE l.name = 'DIVISION_STATUS' ORDER BY li.sort_order, li.label");
+$statusStmt->execute();
+$statuses = $statusStmt->fetchAll(PDO::FETCH_ASSOC);
+?>
+<h2 class="mb-4"><?= $id ? 'Edit' : 'Add'; ?> Division for <?= htmlspecialchars($agency['name']); ?></h2>
+<?php if($message){ echo '<div class="alert alert-success">'.htmlspecialchars($message).'</div>'; } ?>
+<form method="post">
+  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+  <div class="mb-3">
+    <label class="form-label">Name</label>
+    <input type="text" name="name" class="form-control" value="<?= htmlspecialchars($name); ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Main Person ID</label>
+    <input type="number" name="main_person" class="form-control" value="<?= htmlspecialchars($main_person); ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Status</label>
+    <select name="status" class="form-select">
+      <option value="">--</option>
+      <?php foreach($statuses as $s): ?>
+        <option value="<?= $s['id']; ?>" <?= $status == $s['id'] ? 'selected' : ''; ?>><?= htmlspecialchars($s['label']); ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <button type="submit" class="btn btn-primary">Save</button>
+  <a href="divisions.php?agency_id=<?= $agency_id; ?>" class="btn btn-secondary">Back</a>
+</form>
+<?php require '../admin_footer.php'; ?>

--- a/admin/agency/divisions.php
+++ b/admin/agency/divisions.php
@@ -1,0 +1,51 @@
+<?php
+require '../admin_header.php';
+
+$agency_id = isset($_GET['agency_id']) ? (int)$_GET['agency_id'] : 0;
+if(!$agency_id) { die('Agency ID required'); }
+
+$agencyStmt = $pdo->prepare('SELECT name, organization_id FROM module_agency WHERE id = :id');
+$agencyStmt->execute([':id'=>$agency_id]);
+$agency = $agencyStmt->fetch(PDO::FETCH_ASSOC);
+if(!$agency) { die('Agency not found'); }
+
+$divStmt = $pdo->prepare('SELECT id, name FROM module_division WHERE agency_id = :agency_id ORDER BY name');
+$divStmt->execute([':agency_id'=>$agency_id]);
+$divisions = $divStmt->fetchAll(PDO::FETCH_ASSOC);
+?>
+<h2 class="mb-4">Divisions for <?= htmlspecialchars($agency['name']); ?></h2>
+<a href="division_edit.php?agency_id=<?= $agency_id; ?>" class="btn btn-sm btn-primary mb-3">Add Division</a>
+<div id="divisions" data-list='{"valueNames":["id","name"],"page":10,"pagination":true}'>
+  <div class="row justify-content-between g-2 mb-3">
+    <div class="col-auto">
+      <input class="form-control form-control-sm search" placeholder="Search" />
+    </div>
+  </div>
+  <div class="table-responsive">
+    <table class="table table-striped table-sm mb-0">
+      <thead>
+        <tr>
+          <th class="sort" data-sort="id">ID</th>
+          <th class="sort" data-sort="name">Name</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody class="list">
+        <?php foreach($divisions as $d): ?>
+          <tr>
+            <td class="id"><?= htmlspecialchars($d['id']); ?></td>
+            <td class="name"><?= htmlspecialchars($d['name']); ?></td>
+            <td>
+              <a class="btn btn-sm btn-secondary" href="division_edit.php?id=<?= $d['id']; ?>&agency_id=<?= $agency_id; ?>">Edit</a>
+            </td>
+          </tr>
+        <?php endforeach; ?>
+      </tbody>
+    </table>
+  </div>
+  <div class="d-flex justify-content-between align-items-center mt-3">
+    <p class="mb-0" data-list-info></p>
+    <ul class="pagination mb-0"></ul>
+  </div>
+</div>
+<?php require '../admin_footer.php'; ?>

--- a/admin/agency/index.php
+++ b/admin/agency/index.php
@@ -1,0 +1,49 @@
+<?php
+require '../admin_header.php';
+
+$token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
+$_SESSION['csrf_token'] = $token;
+$message = '';
+
+// Fetch organizations
+$stmt = $pdo->query('SELECT id, name FROM module_organization ORDER BY name');
+$organizations = $stmt->fetchAll(PDO::FETCH_ASSOC);
+?>
+<h2 class="mb-4">Organizations</h2>
+<?php if($message){ echo '<div class="alert alert-success">'.htmlspecialchars($message).'</div>'; } ?>
+<a href="organization_edit.php" class="btn btn-sm btn-primary mb-3">Add Organization</a>
+<div id="organizations" data-list='{"valueNames":["id","name"],"page":10,"pagination":true}'>
+  <div class="row justify-content-between g-2 mb-3">
+    <div class="col-auto">
+      <input class="form-control form-control-sm search" placeholder="Search" />
+    </div>
+  </div>
+  <div class="table-responsive">
+    <table class="table table-striped table-sm mb-0">
+      <thead>
+        <tr>
+          <th class="sort" data-sort="id">ID</th>
+          <th class="sort" data-sort="name">Name</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody class="list">
+        <?php foreach($organizations as $o): ?>
+          <tr>
+            <td class="id"><?= htmlspecialchars($o['id']); ?></td>
+            <td class="name"><?= htmlspecialchars($o['name']); ?></td>
+            <td>
+              <a class="btn btn-sm btn-secondary" href="organization_edit.php?id=<?= $o['id']; ?>">Edit</a>
+              <a class="btn btn-sm btn-info" href="agencies.php?organization_id=<?= $o['id']; ?>">Agencies</a>
+            </td>
+          </tr>
+        <?php endforeach; ?>
+      </tbody>
+    </table>
+  </div>
+  <div class="d-flex justify-content-between align-items-center mt-3">
+    <p class="mb-0" data-list-info></p>
+    <ul class="pagination mb-0"></ul>
+  </div>
+</div>
+<?php require '../admin_footer.php'; ?>

--- a/admin/agency/organization_edit.php
+++ b/admin/agency/organization_edit.php
@@ -1,0 +1,74 @@
+<?php
+require '../admin_header.php';
+
+$token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
+$_SESSION['csrf_token'] = $token;
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$name = '';
+$main_person = null;
+$status = null;
+$message = '';
+
+if($_SERVER['REQUEST_METHOD'] === 'POST') {
+  if(!hash_equals($token, $_POST['csrf_token'] ?? '')) {
+    die('Invalid CSRF token');
+  }
+  $name = trim($_POST['name'] ?? '');
+  $main_person = !empty($_POST['main_person']) ? (int)$_POST['main_person'] : null;
+  $status = !empty($_POST['status']) ? (int)$_POST['status'] : null;
+  if($id){
+    $stmt = $pdo->prepare('UPDATE module_organization SET name = :name, main_person = :main_person, status = :status WHERE id = :id');
+    $stmt->execute([':name'=>$name, ':main_person'=>$main_person, ':status'=>$status, ':id'=>$id]);
+    audit_log($pdo, $this_user_id, 'module_organization', $id, 'UPDATE', 'Updated organization');
+    $message = 'Organization updated.';
+  } else {
+    $stmt = $pdo->prepare('INSERT INTO module_organization (name, main_person, status) VALUES (:name, :main_person, :status)');
+    $stmt->execute([':name'=>$name, ':main_person'=>$main_person, ':status'=>$status]);
+    $id = $pdo->lastInsertId();
+    audit_log($pdo, $this_user_id, 'module_organization', $id, 'CREATE', 'Created organization');
+    $message = 'Organization added.';
+  }
+}
+
+if($id && $_SERVER['REQUEST_METHOD'] !== 'POST') {
+  $stmt = $pdo->prepare('SELECT name, main_person, status FROM module_organization WHERE id = :id');
+  $stmt->execute([':id'=>$id]);
+  $row = $stmt->fetch(PDO::FETCH_ASSOC);
+  if($row){
+    $name = $row['name'];
+    $main_person = $row['main_person'];
+    $status = $row['status'];
+  }
+}
+
+// Fetch status list
+$statusStmt = $pdo->prepare("SELECT li.id, li.label FROM module_lookup_list_items li JOIN module_lookup_lists l ON li.list_id = l.id WHERE l.name = 'ORGANIZATION_STATUS' ORDER BY li.sort_order, li.label");
+$statusStmt->execute();
+$statuses = $statusStmt->fetchAll(PDO::FETCH_ASSOC);
+?>
+<h2 class="mb-4"><?= $id ? 'Edit' : 'Add'; ?> Organization</h2>
+<?php if($message){ echo '<div class="alert alert-success">'.htmlspecialchars($message).'</div>'; } ?>
+<form method="post">
+  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+  <div class="mb-3">
+    <label class="form-label">Name</label>
+    <input type="text" name="name" class="form-control" value="<?= htmlspecialchars($name); ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Main Person ID</label>
+    <input type="number" name="main_person" class="form-control" value="<?= htmlspecialchars($main_person); ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Status</label>
+    <select name="status" class="form-select">
+      <option value="">--</option>
+      <?php foreach($statuses as $s): ?>
+        <option value="<?= $s['id']; ?>" <?= $status == $s['id'] ? 'selected' : ''; ?>><?= htmlspecialchars($s['label']); ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <button type="submit" class="btn btn-primary">Save</button>
+  <a href="index.php" class="btn btn-secondary">Back</a>
+</form>
+<?php require '../admin_footer.php'; ?>


### PR DESCRIPTION
## Summary
- add admin/agency module with pages to manage organizations, agencies, and divisions
- create SQL schema for module_organization, module_agency, module_division and seed status lookup lists

## Testing
- `php -l admin/agency/index.php`
- `php -l admin/agency/organization_edit.php`
- `php -l admin/agency/agencies.php`
- `php -l admin/agency/agency_edit.php`
- `php -l admin/agency/divisions.php`
- `php -l admin/agency/division_edit.php`


------
https://chatgpt.com/codex/tasks/task_e_6892e2b15a008333898ec0cc8c894cf1