### PR TITLE
Add initial role-based access control system

### DIFF
--- a/_SQL/007_admin_rbac.sql
+++ b/_SQL/007_admin_rbac.sql
@@ -1,0 +1,98 @@
+-- Tables for RBAC
+CREATE TABLE `admin_roles` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT CURRENT_TIMESTAMP,
+  `date_updated` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `memo` text DEFAULT NULL,
+  `name` varchar(255) NOT NULL,
+  `description` text DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `fk_admin_roles_user_id` (`user_id`),
+  KEY `fk_admin_roles_user_updated` (`user_updated`),
+  CONSTRAINT `fk_admin_roles_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+  CONSTRAINT `fk_admin_roles_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `admin_permissions` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT CURRENT_TIMESTAMP,
+  `date_updated` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `memo` text DEFAULT NULL,
+  `module` varchar(255) NOT NULL,
+  `action` varchar(255) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_admin_permissions_module_action` (`module`,`action`),
+  KEY `fk_admin_permissions_user_id` (`user_id`),
+  KEY `fk_admin_permissions_user_updated` (`user_updated`),
+  CONSTRAINT `fk_admin_permissions_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+  CONSTRAINT `fk_admin_permissions_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `admin_role_permissions` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT CURRENT_TIMESTAMP,
+  `date_updated` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `memo` text DEFAULT NULL,
+  `role_id` int(11) NOT NULL,
+  `permission_id` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_admin_role_permissions_role_permission` (`role_id`,`permission_id`),
+  KEY `fk_admin_role_permissions_user_id` (`user_id`),
+  KEY `fk_admin_role_permissions_user_updated` (`user_updated`),
+  KEY `fk_admin_role_permissions_role_id` (`role_id`),
+  KEY `fk_admin_role_permissions_permission_id` (`permission_id`),
+  CONSTRAINT `fk_admin_role_permissions_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+  CONSTRAINT `fk_admin_role_permissions_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`),
+  CONSTRAINT `fk_admin_role_permissions_role_id` FOREIGN KEY (`role_id`) REFERENCES `admin_roles` (`id`),
+  CONSTRAINT `fk_admin_role_permissions_permission_id` FOREIGN KEY (`permission_id`) REFERENCES `admin_permissions` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `admin_user_roles` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT CURRENT_TIMESTAMP,
+  `date_updated` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `memo` text DEFAULT NULL,
+  `user_account_id` int(11) NOT NULL,
+  `role_id` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_admin_user_roles_user_role` (`user_account_id`,`role_id`),
+  KEY `fk_admin_user_roles_user_id` (`user_id`),
+  KEY `fk_admin_user_roles_user_updated` (`user_updated`),
+  KEY `fk_admin_user_roles_user_account_id` (`user_account_id`),
+  KEY `fk_admin_user_roles_role_id` (`role_id`),
+  CONSTRAINT `fk_admin_user_roles_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+  CONSTRAINT `fk_admin_user_roles_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`),
+  CONSTRAINT `fk_admin_user_roles_user_account_id` FOREIGN KEY (`user_account_id`) REFERENCES `users` (`id`),
+  CONSTRAINT `fk_admin_user_roles_role_id` FOREIGN KEY (`role_id`) REFERENCES `admin_roles` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `admin_audit_log` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT CURRENT_TIMESTAMP,
+  `date_updated` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `memo` text DEFAULT NULL,
+  `table_name` varchar(150) NOT NULL,
+  `record_id` int(11) NOT NULL,
+  `action` varchar(50) NOT NULL,
+  `details` text DEFAULT NULL,
+  `old_value` text DEFAULT NULL,
+  `new_value` text DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `fk_admin_audit_log_user_id` (`user_id`),
+  KEY `fk_admin_audit_log_user_updated` (`user_updated`),
+  CONSTRAINT `fk_admin_audit_log_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+  CONSTRAINT `fk_admin_audit_log_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- Seed default Admin role
+INSERT INTO `admin_roles` (`name`, `description`) VALUES ('Admin', 'System administrator with full permissions');

--- a/admin/left_navigation.php
+++ b/admin/left_navigation.php
@@ -12,6 +12,11 @@
             <div class="d-flex align-items-center"><span class="nav-link-icon"><span data-feather="list"></span></span><span class="nav-link-text">Lookup Lists</span></div>
           </a>
         </li>
+        <li class="nav-item">
+          <a class="nav-link" href="<?php echo getURLDir(); ?>admin/roles/index.php">
+            <div class="d-flex align-items-center"><span class="nav-link-icon"><span data-feather="shield"></span></span><span class="nav-link-text">Roles</span></div>
+          </a>
+        </li>
       </ul>
     </div>
   </div>

--- a/admin/navigation.php
+++ b/admin/navigation.php
@@ -10,6 +10,7 @@
   <div class="collapse navbar-collapse order-1 order-lg-0" id="navbarTopCollapse">
     <ul class="navbar-nav navbar-nav-top">
       <li class="nav-item"><a class="nav-link" href="<?php echo getURLDir(); ?>admin/lookup-lists/index.php"><span class="uil fs-8 me-2 fas fa-list"></span>Lookup Lists</a></li>
+      <li class="nav-item"><a class="nav-link" href="<?php echo getURLDir(); ?>admin/roles/index.php"><span class="uil fs-8 me-2 fas fa-user-shield"></span>Roles</a></li>
     </ul>
   </div>
   <ul class="navbar-nav navbar-nav-icons flex-row">

--- a/admin/roles/edit.php
+++ b/admin/roles/edit.php
@@ -1,0 +1,55 @@
+<?php
+require '../admin_header.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$name = '';
+$description = '';
+
+if ($id) {
+  $stmt = $pdo->prepare('SELECT name, description FROM admin_roles WHERE id = :id');
+  $stmt->execute([':id' => $id]);
+  if ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+    $name = $row['name'];
+    $description = $row['description'];
+  }
+}
+
+$token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
+$_SESSION['csrf_token'] = $token;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  if (!hash_equals($token, $_POST['csrf_token'] ?? '')) {
+    die('Invalid CSRF token');
+  }
+  $name = trim($_POST['name'] ?? '');
+  $description = trim($_POST['description'] ?? '');
+  if ($id) {
+    $old = json_encode(['name' => $row['name'], 'description' => $row['description']]);
+    $stmt = $pdo->prepare('UPDATE admin_roles SET name = :name, description = :description, user_updated = :uid WHERE id = :id');
+    $stmt->execute([':name' => $name, ':description' => $description, ':uid' => $this_user_id, ':id' => $id]);
+    admin_audit_log($pdo, $this_user_id, 'admin_roles', $id, 'UPDATE', $old, json_encode(['name'=>$name,'description'=>$description]), 'Updated role');
+  } else {
+    $stmt = $pdo->prepare('INSERT INTO admin_roles (name, description, user_id, user_updated) VALUES (:name, :description, :uid, :uid)');
+    $stmt->execute([':name' => $name, ':description' => $description, ':uid' => $this_user_id]);
+    $id = $pdo->lastInsertId();
+    admin_audit_log($pdo, $this_user_id, 'admin_roles', $id, 'CREATE', null, json_encode(['name'=>$name,'description'=>$description]), 'Created role');
+  }
+  header('Location: index.php');
+  exit;
+}
+?>
+<h2 class="mb-4"><?= $id ? 'Edit Role' : 'Add Role'; ?></h2>
+<form method="post">
+  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+  <div class="mb-3">
+    <label class="form-label">Name</label>
+    <input type="text" name="name" class="form-control" value="<?= htmlspecialchars($name); ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Description</label>
+    <textarea name="description" class="form-control" rows="3"><?= htmlspecialchars($description); ?></textarea>
+  </div>
+  <button class="btn btn-primary" type="submit">Save</button>
+  <a href="index.php" class="btn btn-secondary">Cancel</a>
+</form>
+<?php require '../admin_footer.php'; ?>

--- a/admin/roles/index.php
+++ b/admin/roles/index.php
@@ -1,0 +1,69 @@
+<?php
+require '../admin_header.php';
+
+$token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
+$_SESSION['csrf_token'] = $token;
+$message = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete_id'])) {
+  if (!hash_equals($token, $_POST['csrf_token'] ?? '')) {
+    die('Invalid CSRF token');
+  }
+  $delId = (int)$_POST['delete_id'];
+  $stmt = $pdo->prepare('DELETE FROM admin_roles WHERE id = :id');
+  $stmt->execute([':id' => $delId]);
+  admin_audit_log($pdo, $this_user_id, 'admin_roles', $delId, 'DELETE', null, null, 'Deleted role');
+  $message = 'Role deleted.';
+}
+
+$stmt = $pdo->query('SELECT id, name, description FROM admin_roles ORDER BY name');
+$roles = $stmt->fetchAll(PDO::FETCH_ASSOC);
+?>
+<h2 class="mb-4">Roles</h2>
+<?php if($message){ echo '<div class="alert alert-success">'.htmlspecialchars($message).'</div>'; } ?>
+<div class="mb-3">
+  <a href="edit.php" class="btn btn-sm btn-primary">Add Role</a>
+  <a href="permissions.php" class="btn btn-sm btn-info">Permissions</a>
+  <a href="matrix.php" class="btn btn-sm btn-secondary">Role Permissions</a>
+</div>
+<div id="roles" data-list='{"valueNames":["id","name","description"],"page":10,"pagination":true}'>
+  <div class="row justify-content-between g-2 mb-3">
+    <div class="col-auto">
+      <input class="form-control form-control-sm search" placeholder="Search" />
+    </div>
+  </div>
+  <div class="table-responsive">
+    <table class="table table-striped table-sm mb-0">
+      <thead>
+        <tr>
+          <th class="sort" data-sort="id">ID</th>
+          <th class="sort" data-sort="name">Name</th>
+          <th class="sort" data-sort="description">Description</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody class="list">
+        <?php foreach($roles as $r): ?>
+          <tr>
+            <td class="id"><?= htmlspecialchars($r['id']); ?></td>
+            <td class="name"><?= htmlspecialchars($r['name']); ?></td>
+            <td class="description"><?= htmlspecialchars($r['description']); ?></td>
+            <td>
+              <a class="btn btn-sm btn-secondary" href="edit.php?id=<?= $r['id']; ?>">Edit</a>
+              <form method="post" class="d-inline">
+                <input type="hidden" name="delete_id" value="<?= $r['id']; ?>">
+                <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+                <button class="btn btn-sm btn-danger" onclick="return confirm('Delete this role?');">Delete</button>
+              </form>
+            </td>
+          </tr>
+        <?php endforeach; ?>
+      </tbody>
+    </table>
+  </div>
+  <div class="d-flex justify-content-between align-items-center mt-3">
+    <p class="mb-0" data-list-info></p>
+    <ul class="pagination mb-0"></ul>
+  </div>
+</div>
+<?php require '../admin_footer.php'; ?>

--- a/admin/roles/matrix.php
+++ b/admin/roles/matrix.php
@@ -1,0 +1,83 @@
+<?php
+require '../admin_header.php';
+
+$token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
+$_SESSION['csrf_token'] = $token;
+$message = '';
+
+// Current assignments for audit and display
+$currentAssignments = $pdo->query('SELECT role_id, permission_id FROM admin_role_permissions')->fetchAll(PDO::FETCH_ASSOC);
+$currentMap = [];
+foreach ($currentAssignments as $a) {
+  $currentMap[$a['role_id']][] = $a['permission_id'];
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  if (!hash_equals($token, $_POST['csrf_token'] ?? '')) {
+    die('Invalid CSRF token');
+  }
+  $rolePerms = $_POST['perm'] ?? [];
+  $roles = $pdo->query('SELECT id FROM admin_roles')->fetchAll(PDO::FETCH_COLUMN);
+  foreach ($roles as $roleId) {
+    $old = json_encode($currentMap[$roleId] ?? []);
+    $stmt = $pdo->prepare('DELETE FROM admin_role_permissions WHERE role_id = :role_id');
+    $stmt->execute([':role_id' => $roleId]);
+    $newPerms = [];
+    if (!empty($rolePerms[$roleId]) && is_array($rolePerms[$roleId])) {
+      foreach ($rolePerms[$roleId] as $pid) {
+        $stmt2 = $pdo->prepare('INSERT INTO admin_role_permissions (role_id, permission_id, user_id, user_updated) VALUES (:rid, :pid, :uid, :uid)');
+        $stmt2->execute([':rid' => $roleId, ':pid' => $pid, ':uid' => $this_user_id]);
+        $newPerms[] = (int)$pid;
+      }
+    }
+    admin_audit_log($pdo, $this_user_id, 'admin_role_permissions', $roleId, 'SYNC', $old, json_encode($newPerms), 'Updated role permissions');
+  }
+  $message = 'Permissions updated.';
+  // refresh current map for display
+  $currentAssignments = $pdo->query('SELECT role_id, permission_id FROM admin_role_permissions')->fetchAll(PDO::FETCH_ASSOC);
+  $currentMap = [];
+  foreach ($currentAssignments as $a) {
+    $currentMap[$a['role_id']][] = $a['permission_id'];
+  }
+}
+
+$roles = $pdo->query('SELECT id, name FROM admin_roles ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
+$permissions = $pdo->query('SELECT id, module, action FROM admin_permissions ORDER BY module, action')->fetchAll(PDO::FETCH_ASSOC);
+$assignedMap = [];
+foreach ($currentMap as $rid => $pids) {
+  foreach ($pids as $pid) {
+    $assignedMap[$rid][$pid] = true;
+  }
+}
+?>
+<h2 class="mb-4">Role Permissions</h2>
+<?php if($message){ echo '<div class="alert alert-success">'.htmlspecialchars($message).'</div>'; } ?>
+<form method="post">
+  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+  <div class="table-responsive">
+    <table class="table table-striped table-sm">
+      <thead>
+        <tr>
+          <th>Permission</th>
+          <?php foreach($roles as $r): ?>
+            <th><?= htmlspecialchars($r['name']); ?></th>
+          <?php endforeach; ?>
+        </tr>
+      </thead>
+      <tbody>
+        <?php foreach($permissions as $p): ?>
+          <tr>
+            <td><?= htmlspecialchars($p['module'].' - '.$p['action']); ?></td>
+            <?php foreach($roles as $r): ?>
+              <td class="text-center">
+                <input type="checkbox" name="perm[<?= $r['id']; ?>][]" value="<?= $p['id']; ?>" <?= isset($assignedMap[$r['id']][$p['id']]) ? 'checked' : ''; ?>>
+              </td>
+            <?php endforeach; ?>
+          </tr>
+        <?php endforeach; ?>
+      </tbody>
+    </table>
+  </div>
+  <button class="btn btn-primary" type="submit">Save</button>
+</form>
+<?php require '../admin_footer.php'; ?>

--- a/admin/roles/permission_edit.php
+++ b/admin/roles/permission_edit.php
@@ -1,0 +1,55 @@
+<?php
+require '../admin_header.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$module = '';
+$action = '';
+
+if ($id) {
+  $stmt = $pdo->prepare('SELECT module, action FROM admin_permissions WHERE id = :id');
+  $stmt->execute([':id' => $id]);
+  if ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+    $module = $row['module'];
+    $action = $row['action'];
+  }
+}
+
+$token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
+$_SESSION['csrf_token'] = $token;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  if (!hash_equals($token, $_POST['csrf_token'] ?? '')) {
+    die('Invalid CSRF token');
+  }
+  $module = trim($_POST['module'] ?? '');
+  $action = trim($_POST['action'] ?? '');
+  if ($id) {
+    $old = json_encode(['module' => $row['module'], 'action' => $row['action']]);
+    $stmt = $pdo->prepare('UPDATE admin_permissions SET module = :module, action = :action, user_updated = :uid WHERE id = :id');
+    $stmt->execute([':module' => $module, ':action' => $action, ':uid' => $this_user_id, ':id' => $id]);
+    admin_audit_log($pdo, $this_user_id, 'admin_permissions', $id, 'UPDATE', $old, json_encode(['module'=>$module,'action'=>$action]), 'Updated permission');
+  } else {
+    $stmt = $pdo->prepare('INSERT INTO admin_permissions (module, action, user_id, user_updated) VALUES (:module, :action, :uid, :uid)');
+    $stmt->execute([':module' => $module, ':action' => $action, ':uid' => $this_user_id]);
+    $id = $pdo->lastInsertId();
+    admin_audit_log($pdo, $this_user_id, 'admin_permissions', $id, 'CREATE', null, json_encode(['module'=>$module,'action'=>$action]), 'Created permission');
+  }
+  header('Location: permissions.php');
+  exit;
+}
+?>
+<h2 class="mb-4"><?= $id ? 'Edit Permission' : 'Add Permission'; ?></h2>
+<form method="post">
+  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+  <div class="mb-3">
+    <label class="form-label">Module</label>
+    <input type="text" name="module" class="form-control" value="<?= htmlspecialchars($module); ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Action</label>
+    <input type="text" name="action" class="form-control" value="<?= htmlspecialchars($action); ?>" required>
+  </div>
+  <button class="btn btn-primary" type="submit">Save</button>
+  <a href="permissions.php" class="btn btn-secondary">Cancel</a>
+</form>
+<?php require '../admin_footer.php'; ?>

--- a/admin/roles/permissions.php
+++ b/admin/roles/permissions.php
@@ -1,0 +1,65 @@
+<?php
+require '../admin_header.php';
+
+$token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
+$_SESSION['csrf_token'] = $token;
+$message = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete_id'])) {
+  if (!hash_equals($token, $_POST['csrf_token'] ?? '')) {
+    die('Invalid CSRF token');
+  }
+  $delId = (int)$_POST['delete_id'];
+  $stmt = $pdo->prepare('DELETE FROM admin_permissions WHERE id = :id');
+  $stmt->execute([':id' => $delId]);
+  admin_audit_log($pdo, $this_user_id, 'admin_permissions', $delId, 'DELETE', null, null, 'Deleted permission');
+  $message = 'Permission deleted.';
+}
+
+$stmt = $pdo->query('SELECT id, module, action FROM admin_permissions ORDER BY module, action');
+$perms = $stmt->fetchAll(PDO::FETCH_ASSOC);
+?>
+<h2 class="mb-4">Permissions</h2>
+<?php if($message){ echo '<div class="alert alert-success">'.htmlspecialchars($message).'</div>'; } ?>
+<a href="permission_edit.php" class="btn btn-sm btn-primary mb-3">Add Permission</a>
+<div id="permissions" data-list='{"valueNames":["id","module","action"],"page":10,"pagination":true}'>
+  <div class="row justify-content-between g-2 mb-3">
+    <div class="col-auto">
+      <input class="form-control form-control-sm search" placeholder="Search" />
+    </div>
+  </div>
+  <div class="table-responsive">
+    <table class="table table-striped table-sm mb-0">
+      <thead>
+        <tr>
+          <th class="sort" data-sort="id">ID</th>
+          <th class="sort" data-sort="module">Module</th>
+          <th class="sort" data-sort="action">Action</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody class="list">
+        <?php foreach($perms as $p): ?>
+          <tr>
+            <td class="id"><?= htmlspecialchars($p['id']); ?></td>
+            <td class="module"><?= htmlspecialchars($p['module']); ?></td>
+            <td class="action"><?= htmlspecialchars($p['action']); ?></td>
+            <td>
+              <a class="btn btn-sm btn-secondary" href="permission_edit.php?id=<?= $p['id']; ?>">Edit</a>
+              <form method="post" class="d-inline">
+                <input type="hidden" name="delete_id" value="<?= $p['id']; ?>">
+                <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+                <button class="btn btn-sm btn-danger" onclick="return confirm('Delete this permission?');">Delete</button>
+              </form>
+            </td>
+          </tr>
+        <?php endforeach; ?>
+      </tbody>
+    </table>
+  </div>
+  <div class="d-flex justify-content-between align-items-center mt-3">
+    <p class="mb-0" data-list-info></p>
+    <ul class="pagination mb-0"></ul>
+  </div>
+</div>
+<?php require '../admin_footer.php'; ?>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -30,6 +30,47 @@ function audit_log($pdo, $userId, $table, $recordId, $action, $details){
   ]);
 }
 
+// Records admin-side CRUD actions into the admin_audit_log table
+function admin_audit_log($pdo, $userId, $table, $recordId, $action, $oldValue, $newValue, $details=''){
+  $sql = "INSERT INTO admin_audit_log (user_id, user_updated, table_name, record_id, action, details, old_value, new_value)"
+       . " VALUES (:user_id, :user_updated, :table_name, :record_id, :action, :details, :old_value, :new_value)";
+  $stmt = $pdo->prepare($sql);
+  $stmt->execute([
+    ':user_id' => $userId,
+    ':user_updated' => $userId,
+    ':table_name' => $table,
+    ':record_id' => $recordId,
+    ':action' => $action,
+    ':details' => $details,
+    ':old_value' => $oldValue,
+    ':new_value' => $newValue,
+  ]);
+}
+
+// Checks if current user has a permission
+function user_has_permission($module, $action){
+  global $pdo, $this_user_id, $this_user_type;
+  if($this_user_type === 'ADMIN'){
+    return true;
+  }
+  $sql = "SELECT 1 FROM admin_user_roles ur "
+       . "JOIN admin_role_permissions rp ON ur.role_id = rp.role_id "
+       . "JOIN admin_permissions p ON rp.permission_id = p.id "
+       . "WHERE ur.user_account_id = :uid AND p.module = :module AND p.action = :action";
+  $stmt = $pdo->prepare($sql);
+  $stmt->execute([':uid' => $this_user_id, ':module' => $module, ':action' => $action]);
+  return (bool)$stmt->fetchColumn();
+}
+
+// Enforces permission check
+function require_permission($module, $action){
+  if(!user_has_permission($module, $action)){
+    header('HTTP/1.1 403 Forbidden');
+    echo '403 Forbidden';
+    exit;
+  }
+}
+
 // Ensures the current session belongs to an admin user
 function require_admin(){
   global $is_admin;


### PR DESCRIPTION
## Summary
- add RBAC database tables and seed Admin role
- implement permission helper functions and admin audit logging
- build admin UI for roles, permissions, and assignments

## Testing
- `php -l includes/functions.php`
- `php -l admin/navigation.php`
- `php -l admin/left_navigation.php`
- `php -l admin/roles/index.php`
- `php -l admin/roles/edit.php`
- `php -l admin/roles/permissions.php`
- `php -l admin/roles/permission_edit.php`
- `php -l admin/roles/matrix.php`


------
https://chatgpt.com/codex/tasks/task_e_6892debd2d548333b7429d0f7ad7ec2f