### PR TITLE
Seed users admin permissions

### DIFF
--- a/_SQL/008_admin_users.sql
+++ b/_SQL/008_admin_users.sql
@@ -1,0 +1,13 @@
+-- Seed permissions for managing users
+INSERT INTO `admin_permissions` (`module`, `action`) VALUES
+  ('users', 'create'),
+  ('users', 'read'),
+  ('users', 'update'),
+  ('users', 'delete');
+
+-- Grant permissions to the default Admin role
+INSERT INTO `admin_role_permissions` (`role_id`, `permission_id`)
+SELECT r.id, p.id
+FROM admin_roles r
+JOIN admin_permissions p ON p.module = 'users' AND p.action IN ('create','read','update','delete')
+WHERE r.name = 'Admin';

--- a/admin/README.md
+++ b/admin/README.md
@@ -1,0 +1,11 @@
+# Admin Interface
+
+The admin section hosts pages for managing global resources such as roles, lookup lists, and users.
+
+## Permissions
+
+Admin pages check entries in the `admin_permissions` table. User management pages depend on the following permissions seeded in `_SQL/008_admin_users.sql`:
+
+- module `users` with actions `create`, `read`, `update`, and `delete`
+
+These permissions are automatically granted to the default **Admin** role.


### PR DESCRIPTION
## Summary
- seed `admin_permissions` entries for user management
- grant new permissions to default Admin role
- document user management permission dependency in admin interface

## Testing
- `php -l admin/index.php`
- `php -l admin/roles/index.php`


------
https://chatgpt.com/codex/tasks/task_e_6893a9992ce083338401e6cf76b6148a