### PR TITLE
Add Users card and nav link to admin dashboard

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -4,6 +4,15 @@
   <div class="col-md-4">
     <div class="card shadow-sm">
       <div class="card-body">
+        <h5 class="card-title"><span class="me-2" data-feather="users"></span>Users</h5>
+        <p class="card-text">Manage system users.</p>
+        <a href="users/index.php" class="btn btn-primary btn-sm">Manage</a>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-4">
+    <div class="card shadow-sm">
+      <div class="card-body">
         <h5 class="card-title">Lookup Lists</h5>
         <p class="card-text">Manage lookup lists and items.</p>
         <a href="lookup-lists/index.php" class="btn btn-primary btn-sm">Manage</a>

--- a/admin/left_navigation.php
+++ b/admin/left_navigation.php
@@ -13,6 +13,11 @@
           </a>
         </li>
         <li class="nav-item">
+          <a class="nav-link" href="<?php echo getURLDir(); ?>admin/users/index.php">
+            <div class="d-flex align-items-center"><span class="nav-link-icon"><span data-feather="users"></span></span><span class="nav-link-text">Users</span></div>
+          </a>
+        </li>
+        <li class="nav-item">
           <a class="nav-link" href="<?php echo getURLDir(); ?>admin/roles/index.php">
             <div class="d-flex align-items-center"><span class="nav-link-icon"><span data-feather="shield"></span></span><span class="nav-link-text">Roles</span></div>
           </a>


### PR DESCRIPTION
## Summary
- add Users card to admin dashboard
- link Users section in admin left navigation

## Testing
- `php -l admin/index.php`
- `php -l admin/left_navigation.php`


------
https://chatgpt.com/codex/tasks/task_e_6893a9970bdc833381481190016805ff