### PR TITLE
feat: add person admin module

### DIFF
--- a/_SQL/002_person.sql
+++ b/_SQL/002_person.sql
@@ -1,6 +1,6 @@
 CREATE TABLE `person` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `user_id` int(11) NOT NULL,
+  `user_id` int(11) DEFAULT NULL,
   `first_name` varchar(100) DEFAULT NULL,
   `last_name` varchar(100) DEFAULT NULL,
   `user_updated` int(11) DEFAULT NULL,
@@ -8,7 +8,7 @@ CREATE TABLE `person` (
   `date_updated` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `memo` text DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `fk_person_user_id` (`user_id`),
+  UNIQUE KEY `fk_person_user_id` (`user_id`),
   KEY `fk_person_user_updated` (`user_updated`),
   CONSTRAINT `fk_person_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
   CONSTRAINT `fk_person_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`)

--- a/_SQL/009_admin_person.sql
+++ b/_SQL/009_admin_person.sql
@@ -1,0 +1,23 @@
+-- Seed permissions and role for managing persons
+INSERT INTO `admin_permissions` (`module`, `action`) VALUES
+  ('person', 'create'),
+  ('person', 'read'),
+  ('person', 'update'),
+  ('person', 'delete');
+
+-- Create Manage Person role
+INSERT INTO `admin_roles` (`name`, `description`) VALUES ('Manage Person', 'Can manage person records');
+
+-- Grant permissions to Manage Person role (excluding delete)
+INSERT INTO `admin_role_permissions` (`role_id`, `permission_id`)
+SELECT r.id, p.id
+FROM admin_roles r
+JOIN admin_permissions p ON p.module = 'person' AND p.action IN ('create','read','update')
+WHERE r.name = 'Manage Person';
+
+-- Grant permissions to Admin role
+INSERT INTO `admin_role_permissions` (`role_id`, `permission_id`)
+SELECT r.id, p.id
+FROM admin_roles r
+JOIN admin_permissions p ON p.module = 'person' AND p.action IN ('create','read','update','delete')
+WHERE r.name = 'Admin';

--- a/_SQL/atlis.sql
+++ b/_SQL/atlis.sql
@@ -49,7 +49,7 @@ CREATE TABLE `audit_log` (
 
 CREATE TABLE `person` (
   `id` int(11) NOT NULL,
-  `user_id` int(11) NOT NULL,
+  `user_id` int(11) DEFAULT NULL,
   `first_name` varchar(100) DEFAULT NULL,
   `last_name` varchar(100) DEFAULT NULL,
   `user_updated` int(11) DEFAULT NULL,
@@ -210,7 +210,7 @@ ALTER TABLE `audit_log`
 --
 ALTER TABLE `person`
   ADD PRIMARY KEY (`id`),
-  ADD KEY `fk_person_user_id` (`user_id`),
+  ADD UNIQUE KEY `fk_person_user_id` (`user_id`),
   ADD KEY `fk_person_user_updated` (`user_updated`);
 
 --

--- a/admin/left_navigation.php
+++ b/admin/left_navigation.php
@@ -13,13 +13,13 @@
           </a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="<?php echo getURLDir(); ?>admin/lookup-lists/index.php">
-            <div class="d-flex align-items-center"><span class="nav-link-icon"><span data-feather="list"></span></span><span class="nav-link-text">Lookup Lists</span></div>
+          <a class="nav-link" href="<?php echo getURLDir(); ?>admin/person/index.php">
+            <div class="d-flex align-items-center"><span class="nav-link-icon"><span data-feather="user"></span></span><span class="nav-link-text">Persons</span></div>
           </a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="<?php echo getURLDir(); ?>admin/users/index.php">
-            <div class="d-flex align-items-center"><span class="nav-link-icon"><span data-feather="users"></span></span><span class="nav-link-text">Users</span></div>
+          <a class="nav-link" href="<?php echo getURLDir(); ?>admin/lookup-lists/index.php">
+            <div class="d-flex align-items-center"><span class="nav-link-icon"><span data-feather="list"></span></span><span class="nav-link-text">Lookup Lists</span></div>
           </a>
         </li>
         <li class="nav-item">

--- a/admin/person/edit.php
+++ b/admin/person/edit.php
@@ -1,0 +1,80 @@
+<?php
+require '../admin_header.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$first_name = $last_name = '';
+$user_id = null;
+$existing = null;
+
+if ($id) {
+  require_permission('person','update');
+  $stmt = $pdo->prepare('SELECT user_id, first_name, last_name FROM person WHERE id = :id');
+  $stmt->execute([':id' => $id]);
+  if ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+    $existing = $row;
+    $user_id = $row['user_id'];
+    $first_name = $row['first_name'];
+    $last_name = $row['last_name'];
+  }
+} else {
+  require_permission('person','create');
+}
+
+$token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
+$_SESSION['csrf_token'] = $token;
+
+if ($user_id) {
+  $userStmt = $pdo->prepare('SELECT id, username FROM users WHERE id = :id');
+  $userStmt->execute([':id' => $user_id]);
+  $userOptions = $userStmt->fetchAll(PDO::FETCH_KEY_PAIR);
+} else {
+  $userStmt = $pdo->query('SELECT u.id, u.username FROM users u LEFT JOIN person p ON u.id = p.user_id WHERE p.user_id IS NULL ORDER BY u.username');
+  $userOptions = $userStmt->fetchAll(PDO::FETCH_KEY_PAIR);
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  if (!hash_equals($token, $_POST['csrf_token'] ?? '')) {
+    die('Invalid CSRF token');
+  }
+  $first_name = trim($_POST['first_name'] ?? '');
+  $last_name = trim($_POST['last_name'] ?? '');
+  $posted_user_id = $_POST['user_id'] !== '' ? (int)$_POST['user_id'] : null;
+  if ($id) {
+    $stmt = $pdo->prepare('UPDATE person SET first_name=:first_name, last_name=:last_name, user_updated=:uid WHERE id=:id');
+    $stmt->execute([':first_name'=>$first_name, ':last_name'=>$last_name, ':uid'=>$this_user_id, ':id'=>$id]);
+    admin_audit_log($pdo, $this_user_id, 'person', $id, 'UPDATE', json_encode($existing), json_encode(['user_id'=>$user_id,'first_name'=>$first_name,'last_name'=>$last_name]), 'Updated person');
+  } else {
+    $stmt = $pdo->prepare('INSERT INTO person (user_id, first_name, last_name, user_updated) VALUES (:user_id, :first_name, :last_name, :uid)');
+    $stmt->execute([':user_id'=>$posted_user_id, ':first_name'=>$first_name, ':last_name'=>$last_name, ':uid'=>$this_user_id]);
+    $id = $pdo->lastInsertId();
+    admin_audit_log($pdo, $this_user_id, 'person', $id, 'CREATE', null, json_encode(['user_id'=>$posted_user_id,'first_name'=>$first_name,'last_name'=>$last_name]), 'Created person');
+  }
+  header('Location: index.php');
+  exit;
+}
+?>
+<h2 class="mb-4"><?= $id ? 'Edit' : 'Add'; ?> Person</h2>
+<form method="post">
+  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+  <div class="mb-3">
+    <label class="form-label">User Account</label>
+    <select name="user_id" class="form-select" <?= $user_id ? 'disabled' : ''; ?>>
+      <option value="">-- None --</option>
+      <?php foreach($userOptions as $uid => $uname): ?>
+        <option value="<?= $uid; ?>" <?= (int)$uid === (int)$user_id ? 'selected' : ''; ?>><?= htmlspecialchars($uname); ?></option>
+      <?php endforeach; ?>
+    </select>
+    <?php if($user_id): ?><input type="hidden" name="user_id" value="<?= $user_id; ?>"><?php endif; ?>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">First Name</label>
+    <input type="text" name="first_name" class="form-control" value="<?= htmlspecialchars($first_name); ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Last Name</label>
+    <input type="text" name="last_name" class="form-control" value="<?= htmlspecialchars($last_name); ?>" required>
+  </div>
+  <button class="btn btn-primary" type="submit">Save</button>
+  <a href="index.php" class="btn btn-secondary">Cancel</a>
+</form>
+<?php require '../admin_footer.php'; ?>

--- a/admin/person/index.php
+++ b/admin/person/index.php
@@ -1,0 +1,62 @@
+<?php
+require '../admin_header.php';
+require_permission('person','read');
+
+$token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
+$_SESSION['csrf_token'] = $token;
+$message = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete_id'])) {
+  if (!hash_equals($token, $_POST['csrf_token'] ?? '')) {
+    die('Invalid CSRF token');
+  }
+  require_permission('person','delete');
+  $delId = (int)$_POST['delete_id'];
+  $stmt = $pdo->prepare('DELETE FROM person WHERE id = :id');
+  $stmt->execute([':id' => $delId]);
+  admin_audit_log($pdo, $this_user_id, 'person', $delId, 'DELETE', null, null, 'Deleted person');
+  $message = 'Person deleted.';
+}
+
+$stmt = $pdo->query('SELECT p.id, p.first_name, p.last_name, u.email FROM person p LEFT JOIN users u ON p.user_id = u.id ORDER BY p.last_name, p.first_name');
+$persons = $stmt->fetchAll(PDO::FETCH_ASSOC);
+?>
+<h2 class="mb-4">Persons</h2>
+<?php if($message){ echo '<div class="alert alert-success">'.htmlspecialchars($message).'</div>'; } ?>
+<a href="edit.php" class="btn btn-sm btn-primary mb-3">Add Person</a>
+<div id="persons" data-list='{"valueNames":["name","user"],"page":12,"pagination":true}'>
+  <div class="row justify-content-between g-2 mb-3">
+    <div class="col-auto">
+      <input class="form-control form-control-sm search" placeholder="Search" />
+    </div>
+  </div>
+  <div class="row g-3 list">
+    <?php foreach($persons as $p): ?>
+      <div class="col-sm-6 col-md-4 col-lg-3">
+        <div class="card h-100 shadow-sm">
+          <div class="card-body d-flex flex-column justify-content-between">
+            <div>
+              <h5 class="name mb-1"><?= htmlspecialchars(trim(($p['first_name'] ?? '').' '.($p['last_name'] ?? ''))); ?></h5>
+              <?php if($p['email']): ?>
+                <p class="user text-muted small mb-2"><?= htmlspecialchars($p['email']); ?></p>
+              <?php endif; ?>
+            </div>
+            <div>
+              <a class="btn btn-sm btn-secondary" href="edit.php?id=<?= $p['id']; ?>">Edit</a>
+              <form method="post" class="d-inline">
+                <input type="hidden" name="delete_id" value="<?= $p['id']; ?>">
+                <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+                <button class="btn btn-sm btn-danger" onclick="return confirm('Delete this person?');">Delete</button>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    <?php endforeach; ?>
+  </div>
+  <div class="d-flex justify-content-between align-items-center mt-3">
+    <p class="mb-0" data-list-info></p>
+    <ul class="pagination mb-0"></ul>
+  </div>
+</div>
+<?php require '../admin_footer.php'; ?>


### PR DESCRIPTION
## Summary
- allow multiple person records and enforce 1-to-1 user link
- seed Manage Person role and permissions
- add admin interface for managing persons

## Testing
- `php -l admin/person/index.php`
- `php -l admin/person/edit.php`
- `php -l admin/left_navigation.php`


------
https://chatgpt.com/codex/tasks/task_e_6893a9e96e888333b7f5d3fea1fc5dad