### PR TITLE
Add orgs admin module and RBAC entries

### DIFF
--- a/_SQL/atlis.sql
+++ b/_SQL/atlis.sql
@@ -71,7 +71,11 @@ INSERT INTO `admin_permissions` (`id`, `user_id`, `user_updated`, `date_created`
 (5, NULL, NULL, '2025-08-06 16:07:59', '2025-08-06 16:07:59', NULL, 'person', 'create'),
 (6, NULL, NULL, '2025-08-06 16:07:59', '2025-08-06 16:07:59', NULL, 'person', 'read'),
 (7, NULL, NULL, '2025-08-06 16:07:59', '2025-08-06 16:07:59', NULL, 'person', 'update'),
-(8, NULL, NULL, '2025-08-06 16:07:59', '2025-08-06 16:07:59', NULL, 'person', 'delete');
+(8, NULL, NULL, '2025-08-06 16:07:59', '2025-08-06 16:07:59', NULL, 'person', 'delete'),
+(9, NULL, NULL, '2025-08-06 16:07:59', '2025-08-06 16:07:59', NULL, 'orgs', 'create'),
+(10, NULL, NULL, '2025-08-06 16:07:59', '2025-08-06 16:07:59', NULL, 'orgs', 'read'),
+(11, NULL, NULL, '2025-08-06 16:07:59', '2025-08-06 16:07:59', NULL, 'orgs', 'update'),
+(12, NULL, NULL, '2025-08-06 16:07:59', '2025-08-06 16:07:59', NULL, 'orgs', 'delete');
 
 -- --------------------------------------------------------
 
@@ -96,7 +100,8 @@ CREATE TABLE `admin_roles` (
 
 INSERT INTO `admin_roles` (`id`, `user_id`, `user_updated`, `date_created`, `date_updated`, `memo`, `name`, `description`) VALUES
 (1, NULL, NULL, '2025-08-06 16:07:43', '2025-08-06 16:07:43', NULL, 'Admin', 'System administrator with full permissions'),
-(2, NULL, NULL, '2025-08-06 16:07:59', '2025-08-06 16:07:59', NULL, 'Manage Person', 'Can manage person records');
+(2, NULL, NULL, '2025-08-06 16:07:59', '2025-08-06 16:07:59', NULL, 'Manage Person', 'Can manage person records'),
+(3, NULL, NULL, '2025-08-06 16:07:59', '2025-08-06 16:07:59', NULL, 'Manage Orgs', 'Can manage organizations, agencies and divisions');
 
 -- --------------------------------------------------------
 
@@ -130,7 +135,15 @@ INSERT INTO `admin_role_permissions` (`id`, `user_id`, `user_updated`, `date_cre
 (11, NULL, NULL, '2025-08-06 16:07:59', '2025-08-06 16:07:59', NULL, 1, 5),
 (12, NULL, NULL, '2025-08-06 16:07:59', '2025-08-06 16:07:59', NULL, 1, 8),
 (13, NULL, NULL, '2025-08-06 16:07:59', '2025-08-06 16:07:59', NULL, 1, 6),
-(14, NULL, NULL, '2025-08-06 16:07:59', '2025-08-06 16:07:59', NULL, 1, 7);
+(14, NULL, NULL, '2025-08-06 16:07:59', '2025-08-06 16:07:59', NULL, 1, 7),
+(15, NULL, NULL, '2025-08-06 16:07:59', '2025-08-06 16:07:59', NULL, 3, 9),
+(16, NULL, NULL, '2025-08-06 16:07:59', '2025-08-06 16:07:59', NULL, 3, 10),
+(17, NULL, NULL, '2025-08-06 16:07:59', '2025-08-06 16:07:59', NULL, 3, 11),
+(18, NULL, NULL, '2025-08-06 16:07:59', '2025-08-06 16:07:59', NULL, 3, 12),
+(19, NULL, NULL, '2025-08-06 16:07:59', '2025-08-06 16:07:59', NULL, 1, 9),
+(20, NULL, NULL, '2025-08-06 16:07:59', '2025-08-06 16:07:59', NULL, 1, 10),
+(21, NULL, NULL, '2025-08-06 16:07:59', '2025-08-06 16:07:59', NULL, 1, 11),
+(22, NULL, NULL, '2025-08-06 16:07:59', '2025-08-06 16:07:59', NULL, 1, 12);
 
 -- --------------------------------------------------------
 

--- a/admin/orgs/agency.php
+++ b/admin/orgs/agency.php
@@ -1,0 +1,112 @@
+<?php
+require '../admin_header.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$organization_id = isset($_GET['organization_id']) ? (int)$_GET['organization_id'] : 0;
+$token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
+$_SESSION['csrf_token'] = $token;
+
+if ($id) {
+    require_permission('orgs','update');
+    if (!$organization_id) {
+        $stmt = $pdo->prepare('SELECT organization_id FROM module_agency WHERE id = :id');
+        $stmt->execute([':id'=>$id]);
+        $organization_id = (int)$stmt->fetchColumn();
+    }
+} else {
+    require_permission('orgs','create');
+    if (!$organization_id) { die('Organization ID required'); }
+}
+
+$orgStmt = $pdo->prepare('SELECT name FROM module_organization WHERE id = :id');
+$orgStmt->execute([':id'=>$organization_id]);
+$organization = $orgStmt->fetch(PDO::FETCH_ASSOC);
+if (!$organization) { die('Organization not found'); }
+
+$name = '';
+$main_person = null;
+$status = null;
+$message = '';
+
+if ($id && $_SERVER['REQUEST_METHOD'] !== 'POST') {
+    $stmt = $pdo->prepare('SELECT name, main_person, status FROM module_agency WHERE id = :id');
+    $stmt->execute([':id'=>$id]);
+    if ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+        $name = $row['name'];
+        $main_person = $row['main_person'];
+        $status = $row['status'];
+    } else {
+        die('Agency not found');
+    }
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!hash_equals($token, $_POST['csrf_token'] ?? '')) { die('Invalid CSRF token'); }
+    $name = trim($_POST['name'] ?? '');
+    $main_person = $_POST['main_person'] !== '' ? (int)$_POST['main_person'] : null;
+    $status = $_POST['status'] !== '' ? (int)$_POST['status'] : null;
+    if ($id) {
+        $stmt = $pdo->prepare('UPDATE module_agency SET name=:name, main_person=:main_person, status=:status, user_updated=:uid WHERE id=:id');
+        $stmt->execute([':name'=>$name, ':main_person'=>$main_person, ':status'=>$status, ':uid'=>$this_user_id, ':id'=>$id]);
+        admin_audit_log($pdo,$this_user_id,'module_agency',$id,'UPDATE',null,json_encode(['name'=>$name,'main_person'=>$main_person,'status'=>$status]),'Updated agency');
+        $message = 'Agency updated.';
+    } else {
+        $stmt = $pdo->prepare('INSERT INTO module_agency (user_id,user_updated,organization_id,name,main_person,status) VALUES (:uid,:uid,:org,:name,:main_person,:status)');
+        $stmt->execute([':uid'=>$this_user_id, ':org'=>$organization_id, ':name'=>$name, ':main_person'=>$main_person, ':status'=>$status]);
+        $id = $pdo->lastInsertId();
+        admin_audit_log($pdo,$this_user_id,'module_agency',$id,'CREATE',null,json_encode(['organization_id'=>$organization_id,'name'=>$name,'main_person'=>$main_person,'status'=>$status]),'Created agency');
+        header('Location: agency.php?id='.$id);
+        exit;
+    }
+}
+
+$statusStmt = $pdo->prepare("SELECT li.id, li.label FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'AGENCY_STATUS' ORDER BY li.sort_order, li.label");
+$statusStmt->execute();
+$statuses = $statusStmt->fetchAll(PDO::FETCH_ASSOC);
+
+// Fetch divisions for display
+$agencyDivisions = [];
+if ($id) {
+    $divStmt = $pdo->prepare('SELECT id, name FROM module_division WHERE agency_id = :id ORDER BY name');
+    $divStmt->execute([':id'=>$id]);
+    $agencyDivisions = $divStmt->fetchAll(PDO::FETCH_ASSOC);
+}
+?>
+<h2 class="mb-4"><?= $id ? 'Edit Agency' : 'Add Agency'; ?> for <?= htmlspecialchars($organization['name']); ?></h2>
+<?php if($message){ echo '<div class="alert alert-success">'.htmlspecialchars($message).'</div>'; } ?>
+<form method="post" class="mb-4">
+  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+  <div class="mb-3">
+    <label class="form-label">Name</label>
+    <input type="text" name="name" class="form-control" value="<?= htmlspecialchars($name); ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Main Person ID</label>
+    <input type="number" name="main_person" class="form-control" value="<?= htmlspecialchars($main_person); ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Status</label>
+    <select name="status" class="form-select">
+      <option value="">--</option>
+      <?php foreach($statuses as $s): ?>
+        <option value="<?= $s['id']; ?>" <?= (string)$status === (string)$s['id'] ? 'selected' : ''; ?>><?= htmlspecialchars($s['label']); ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <button class="btn btn-primary" type="submit">Save</button>
+  <a href="index.php" class="btn btn-secondary">Back</a>
+</form>
+<?php if ($id): ?>
+  <h3 class="mb-3">Divisions</h3>
+  <a href="division.php?agency_id=<?= $id; ?>" class="btn btn-sm btn-primary mb-3">Add Division</a>
+  <?php if ($agencyDivisions): ?>
+    <ul class="list-unstyled">
+      <?php foreach ($agencyDivisions as $d): ?>
+        <li><a href="division.php?id=<?= $d['id']; ?>"><?= htmlspecialchars($d['name']); ?></a></li>
+      <?php endforeach; ?>
+    </ul>
+  <?php else: ?>
+    <p class="text-muted">No divisions yet.</p>
+  <?php endif; ?>
+<?php endif; ?>
+<?php require '../admin_footer.php'; ?>

--- a/admin/orgs/division.php
+++ b/admin/orgs/division.php
@@ -1,0 +1,91 @@
+<?php
+require '../admin_header.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$agency_id = isset($_GET['agency_id']) ? (int)$_GET['agency_id'] : 0;
+$token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
+$_SESSION['csrf_token'] = $token;
+
+if ($id) {
+    require_permission('orgs','update');
+    if (!$agency_id) {
+        $stmt = $pdo->prepare('SELECT agency_id FROM module_division WHERE id = :id');
+        $stmt->execute([':id'=>$id]);
+        $agency_id = (int)$stmt->fetchColumn();
+    }
+} else {
+    require_permission('orgs','create');
+    if (!$agency_id) { die('Agency ID required'); }
+}
+
+$agencyStmt = $pdo->prepare('SELECT name FROM module_agency WHERE id = :id');
+$agencyStmt->execute([':id'=>$agency_id]);
+$agency = $agencyStmt->fetch(PDO::FETCH_ASSOC);
+if (!$agency) { die('Agency not found'); }
+
+$name = '';
+$main_person = null;
+$status = null;
+$message = '';
+
+if ($id && $_SERVER['REQUEST_METHOD'] !== 'POST') {
+    $stmt = $pdo->prepare('SELECT name, main_person, status FROM module_division WHERE id = :id');
+    $stmt->execute([':id'=>$id]);
+    if ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+        $name = $row['name'];
+        $main_person = $row['main_person'];
+        $status = $row['status'];
+    } else {
+        die('Division not found');
+    }
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!hash_equals($token, $_POST['csrf_token'] ?? '')) { die('Invalid CSRF token'); }
+    $name = trim($_POST['name'] ?? '');
+    $main_person = $_POST['main_person'] !== '' ? (int)$_POST['main_person'] : null;
+    $status = $_POST['status'] !== '' ? (int)$_POST['status'] : null;
+    if ($id) {
+        $stmt = $pdo->prepare('UPDATE module_division SET name=:name, main_person=:main_person, status=:status, user_updated=:uid WHERE id=:id');
+        $stmt->execute([':name'=>$name, ':main_person'=>$main_person, ':status'=>$status, ':uid'=>$this_user_id, ':id'=>$id]);
+        admin_audit_log($pdo,$this_user_id,'module_division',$id,'UPDATE',null,json_encode(['name'=>$name,'main_person'=>$main_person,'status'=>$status]),'Updated division');
+        $message = 'Division updated.';
+    } else {
+        $stmt = $pdo->prepare('INSERT INTO module_division (user_id,user_updated,agency_id,name,main_person,status) VALUES (:uid,:uid,:agency,:name,:main_person,:status)');
+        $stmt->execute([':uid'=>$this_user_id, ':agency'=>$agency_id, ':name'=>$name, ':main_person'=>$main_person, ':status'=>$status]);
+        $id = $pdo->lastInsertId();
+        admin_audit_log($pdo,$this_user_id,'module_division',$id,'CREATE',null,json_encode(['agency_id'=>$agency_id,'name'=>$name,'main_person'=>$main_person,'status'=>$status]),'Created division');
+        header('Location: division.php?id='.$id);
+        exit;
+    }
+}
+
+$statusStmt = $pdo->prepare("SELECT li.id, li.label FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'DIVISION_STATUS' ORDER BY li.sort_order, li.label");
+$statusStmt->execute();
+$statuses = $statusStmt->fetchAll(PDO::FETCH_ASSOC);
+?>
+<h2 class="mb-4"><?= $id ? 'Edit Division' : 'Add Division'; ?> for <?= htmlspecialchars($agency['name']); ?></h2>
+<?php if($message){ echo '<div class="alert alert-success">'.htmlspecialchars($message).'</div>'; } ?>
+<form method="post">
+  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+  <div class="mb-3">
+    <label class="form-label">Name</label>
+    <input type="text" name="name" class="form-control" value="<?= htmlspecialchars($name); ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Main Person ID</label>
+    <input type="number" name="main_person" class="form-control" value="<?= htmlspecialchars($main_person); ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Status</label>
+    <select name="status" class="form-select">
+      <option value="">--</option>
+      <?php foreach($statuses as $s): ?>
+        <option value="<?= $s['id']; ?>" <?= (string)$status === (string)$s['id'] ? 'selected' : ''; ?>><?= htmlspecialchars($s['label']); ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <button class="btn btn-primary" type="submit">Save</button>
+  <a href="index.php" class="btn btn-secondary">Back</a>
+</form>
+<?php require '../admin_footer.php'; ?>

--- a/admin/orgs/index.php
+++ b/admin/orgs/index.php
@@ -1,0 +1,61 @@
+<?php
+require '../admin_header.php';
+require_permission('orgs','read');
+
+$token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
+$_SESSION['csrf_token'] = $token;
+
+// Fetch organizations
+$orgStmt = $pdo->query('SELECT id, name FROM module_organization ORDER BY name');
+$organizations = $orgStmt->fetchAll(PDO::FETCH_ASSOC);
+
+// Fetch agencies grouped by organization
+$agencyRows = $pdo->query('SELECT id, organization_id, name FROM module_agency ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
+$agencies = [];
+foreach ($agencyRows as $row) {
+    $agencies[$row['organization_id']][] = $row;
+}
+
+// Fetch divisions grouped by agency
+$divisionRows = $pdo->query('SELECT id, agency_id, name FROM module_division ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
+$divisions = [];
+foreach ($divisionRows as $row) {
+    $divisions[$row['agency_id']][] = $row;
+}
+?>
+<h2 class="mb-4">Organizations</h2>
+<a href="organization.php" class="btn btn-sm btn-primary mb-3">Add Organization</a>
+<?php foreach ($organizations as $org): ?>
+  <div class="card mb-3">
+    <div class="card-header d-flex justify-content-between align-items-center">
+      <h5 class="mb-0"><?= htmlspecialchars($org['name']); ?></h5>
+      <div>
+        <a class="btn btn-sm btn-secondary" href="organization.php?id=<?= $org['id']; ?>">View</a>
+      </div>
+    </div>
+    <div class="card-body">
+      <h6>Agencies</h6>
+      <?php if (!empty($agencies[$org['id']])): ?>
+        <ul class="list-unstyled ms-3">
+          <?php foreach ($agencies[$org['id']] as $agency): ?>
+            <li class="mb-2">
+              <strong><a href="agency.php?id=<?= $agency['id']; ?>"><?= htmlspecialchars($agency['name']); ?></a></strong>
+              <?php if (!empty($divisions[$agency['id']])): ?>
+                <ul class="list-unstyled ms-3 mt-1">
+                  <?php foreach ($divisions[$agency['id']] as $division): ?>
+                    <li><a href="division.php?id=<?= $division['id']; ?>"><?= htmlspecialchars($division['name']); ?></a></li>
+                  <?php endforeach; ?>
+                </ul>
+              <?php endif; ?>
+              <a class="btn btn-sm btn-outline-primary mt-1" href="division.php?agency_id=<?= $agency['id']; ?>">Add Division</a>
+            </li>
+          <?php endforeach; ?>
+        </ul>
+      <?php else: ?>
+        <p class="ms-3 text-muted">No agencies yet.</p>
+      <?php endif; ?>
+      <a class="btn btn-sm btn-outline-primary" href="agency.php?organization_id=<?= $org['id']; ?>">Add Agency</a>
+    </div>
+  </div>
+<?php endforeach; ?>
+<?php require '../admin_footer.php'; ?>

--- a/admin/orgs/organization.php
+++ b/admin/orgs/organization.php
@@ -1,0 +1,101 @@
+<?php
+require '../admin_header.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
+$_SESSION['csrf_token'] = $token;
+
+$name = '';
+$main_person = null;
+$status = null;
+$message = '';
+
+if ($id) {
+    require_permission('orgs','update');
+    if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+        $stmt = $pdo->prepare('SELECT name, main_person, status FROM module_organization WHERE id = :id');
+        $stmt->execute([':id'=>$id]);
+        if ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $name = $row['name'];
+            $main_person = $row['main_person'];
+            $status = $row['status'];
+        } else {
+            die('Organization not found');
+        }
+    }
+} else {
+    require_permission('orgs','create');
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!hash_equals($token, $_POST['csrf_token'] ?? '')) {
+        die('Invalid CSRF token');
+    }
+    $name = trim($_POST['name'] ?? '');
+    $main_person = $_POST['main_person'] !== '' ? (int)$_POST['main_person'] : null;
+    $status = $_POST['status'] !== '' ? (int)$_POST['status'] : null;
+    if ($id) {
+        $stmt = $pdo->prepare('UPDATE module_organization SET name=:name, main_person=:main_person, status=:status, user_updated=:uid WHERE id=:id');
+        $stmt->execute([':name'=>$name, ':main_person'=>$main_person, ':status'=>$status, ':uid'=>$this_user_id, ':id'=>$id]);
+        admin_audit_log($pdo,$this_user_id,'module_organization',$id,'UPDATE',null,json_encode(['name'=>$name,'main_person'=>$main_person,'status'=>$status]),'Updated organization');
+        $message = 'Organization updated.';
+    } else {
+        $stmt = $pdo->prepare('INSERT INTO module_organization (user_id,user_updated,name,main_person,status) VALUES (:uid,:uid,:name,:main_person,:status)');
+        $stmt->execute([':uid'=>$this_user_id, ':name'=>$name, ':main_person'=>$main_person, ':status'=>$status]);
+        $id = $pdo->lastInsertId();
+        admin_audit_log($pdo,$this_user_id,'module_organization',$id,'CREATE',null,json_encode(['name'=>$name,'main_person'=>$main_person,'status'=>$status]),'Created organization');
+        header('Location: organization.php?id='.$id);
+        exit;
+    }
+}
+
+$statusStmt = $pdo->prepare("SELECT li.id, li.label FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'ORGANIZATION_STATUS' ORDER BY li.sort_order, li.label");
+$statusStmt->execute();
+$statuses = $statusStmt->fetchAll(PDO::FETCH_ASSOC);
+
+// Fetch agencies for display when editing
+$orgAgencies = [];
+if ($id) {
+    $agStmt = $pdo->prepare('SELECT id, name FROM module_agency WHERE organization_id = :id ORDER BY name');
+    $agStmt->execute([':id'=>$id]);
+    $orgAgencies = $agStmt->fetchAll(PDO::FETCH_ASSOC);
+}
+?>
+<h2 class="mb-4"><?= $id ? 'Edit Organization' : 'Add Organization'; ?></h2>
+<?php if($message){ echo '<div class="alert alert-success">'.htmlspecialchars($message).'</div>'; } ?>
+<form method="post" class="mb-4">
+  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+  <div class="mb-3">
+    <label class="form-label">Name</label>
+    <input type="text" name="name" class="form-control" value="<?= htmlspecialchars($name); ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Main Person ID</label>
+    <input type="number" name="main_person" class="form-control" value="<?= htmlspecialchars($main_person); ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Status</label>
+    <select name="status" class="form-select">
+      <option value="">--</option>
+      <?php foreach($statuses as $s): ?>
+        <option value="<?= $s['id']; ?>" <?= (string)$status === (string)$s['id'] ? 'selected' : ''; ?>><?= htmlspecialchars($s['label']); ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <button class="btn btn-primary" type="submit">Save</button>
+  <a href="index.php" class="btn btn-secondary">Back</a>
+</form>
+<?php if ($id): ?>
+  <h3 class="mb-3">Agencies</h3>
+  <a href="agency.php?organization_id=<?= $id; ?>" class="btn btn-sm btn-primary mb-3">Add Agency</a>
+  <?php if ($orgAgencies): ?>
+    <ul class="list-unstyled">
+      <?php foreach ($orgAgencies as $a): ?>
+        <li><a href="agency.php?id=<?= $a['id']; ?>"><?= htmlspecialchars($a['name']); ?></a></li>
+      <?php endforeach; ?>
+    </ul>
+  <?php else: ?>
+    <p class="text-muted">No agencies yet.</p>
+  <?php endif; ?>
+<?php endif; ?>
+<?php require '../admin_footer.php'; ?>


### PR DESCRIPTION
## Summary
- Add organization module with nested agency and division management
- Implement CRUD detail pages for organizations, agencies, and divisions with RBAC checks
- Seed RBAC permissions and role mappings for orgs module

## Testing
- `php -l admin/orgs/index.php`
- `php -l admin/orgs/organization.php`
- `php -l admin/orgs/agency.php`
- `php -l admin/orgs/division.php`


------
https://chatgpt.com/codex/tasks/task_e_6893d84bea7083339cd619799f698a1a