### PR TITLE
Apply Phoenix theme button styles across admin

### DIFF
--- a/admin/agency/agencies.php
+++ b/admin/agency/agencies.php
@@ -18,7 +18,7 @@ $stmt->execute([':org_id'=>$organization_id]);
 $agencies = $stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <h2 class="mb-4">Agencies for <?= htmlspecialchars($organization['name']); ?></h2>
-<a href="agency_edit.php?organization_id=<?= $organization_id; ?>" class="btn btn-sm btn-primary mb-3">Add Agency</a>
+<a href="agency_edit.php?organization_id=<?= $organization_id; ?>" class="btn btn-sm btn-phoenix-success mb-3">Add Agency</a>
 <div id="agencies" data-list='{"valueNames":["id","name"],"page":10,"pagination":true}'>
   <div class="row justify-content-between g-2 mb-3">
     <div class="col-auto">
@@ -40,8 +40,8 @@ $agencies = $stmt->fetchAll(PDO::FETCH_ASSOC);
             <td class="id"><?= htmlspecialchars($a['id']); ?></td>
             <td class="name"><?= htmlspecialchars($a['name']); ?></td>
             <td>
-              <a class="btn btn-sm btn-secondary" href="agency_edit.php?id=<?= $a['id']; ?>&organization_id=<?= $organization_id; ?>">Edit</a>
-              <a class="btn btn-sm btn-info" href="divisions.php?agency_id=<?= $a['id']; ?>">Divisions</a>
+              <a class="btn btn-sm btn-phoenix-warning" href="agency_edit.php?id=<?= $a['id']; ?>&organization_id=<?= $organization_id; ?>">Edit</a>
+              <a class="btn btn-sm btn-phoenix-info" href="divisions.php?agency_id=<?= $a['id']; ?>">Divisions</a>
             </td>
           </tr>
         <?php endforeach; ?>

--- a/admin/agency/agency_edit.php
+++ b/admin/agency/agency_edit.php
@@ -24,6 +24,7 @@ $name = '';
 $main_person = null;
 $status = null;
 $message = '';
+$btnClass = $id ? 'btn-phoenix-warning' : 'btn-phoenix-success';
 
 if($_SERVER['REQUEST_METHOD'] === 'POST') {
   if(!hash_equals($token, $_POST['csrf_token'] ?? '')) {
@@ -83,7 +84,7 @@ $statuses = $statusStmt->fetchAll(PDO::FETCH_ASSOC);
       <?php endforeach; ?>
     </select>
   </div>
-  <button type="submit" class="btn btn-primary">Save</button>
-  <a href="agencies.php?organization_id=<?= $organization_id; ?>" class="btn btn-secondary">Back</a>
+  <button type="submit" class="btn <?= $btnClass; ?>">Save</button>
+  <a href="agencies.php?organization_id=<?= $organization_id; ?>" class="btn btn-phoenix-secondary">Back</a>
 </form>
 <?php require '../admin_footer.php'; ?>

--- a/admin/agency/division_edit.php
+++ b/admin/agency/division_edit.php
@@ -22,6 +22,7 @@ $name = '';
 $main_person = null;
 $status = null;
 $message = '';
+$btnClass = $id ? 'btn-phoenix-warning' : 'btn-phoenix-success';
 
 if($_SERVER['REQUEST_METHOD'] === 'POST') {
   if(!hash_equals($token, $_POST['csrf_token'] ?? '')) {
@@ -81,7 +82,7 @@ $statuses = $statusStmt->fetchAll(PDO::FETCH_ASSOC);
       <?php endforeach; ?>
     </select>
   </div>
-  <button type="submit" class="btn btn-primary">Save</button>
-  <a href="divisions.php?agency_id=<?= $agency_id; ?>" class="btn btn-secondary">Back</a>
+  <button type="submit" class="btn <?= $btnClass; ?>">Save</button>
+  <a href="divisions.php?agency_id=<?= $agency_id; ?>" class="btn btn-phoenix-secondary">Back</a>
 </form>
 <?php require '../admin_footer.php'; ?>

--- a/admin/agency/divisions.php
+++ b/admin/agency/divisions.php
@@ -14,7 +14,7 @@ $divStmt->execute([':agency_id'=>$agency_id]);
 $divisions = $divStmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <h2 class="mb-4">Divisions for <?= htmlspecialchars($agency['name']); ?></h2>
-<a href="division_edit.php?agency_id=<?= $agency_id; ?>" class="btn btn-sm btn-primary mb-3">Add Division</a>
+<a href="division_edit.php?agency_id=<?= $agency_id; ?>" class="btn btn-sm btn-phoenix-success mb-3">Add Division</a>
 <div id="divisions" data-list='{"valueNames":["id","name"],"page":10,"pagination":true}'>
   <div class="row justify-content-between g-2 mb-3">
     <div class="col-auto">
@@ -36,7 +36,7 @@ $divisions = $divStmt->fetchAll(PDO::FETCH_ASSOC);
             <td class="id"><?= htmlspecialchars($d['id']); ?></td>
             <td class="name"><?= htmlspecialchars($d['name']); ?></td>
             <td>
-              <a class="btn btn-sm btn-secondary" href="division_edit.php?id=<?= $d['id']; ?>&agency_id=<?= $agency_id; ?>">Edit</a>
+              <a class="btn btn-sm btn-phoenix-warning" href="division_edit.php?id=<?= $d['id']; ?>&agency_id=<?= $agency_id; ?>">Edit</a>
             </td>
           </tr>
         <?php endforeach; ?>

--- a/admin/agency/index.php
+++ b/admin/agency/index.php
@@ -11,7 +11,7 @@ $organizations = $stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <h2 class="mb-4">Organizations</h2>
 <?php if($message){ echo '<div class="alert alert-success">'.htmlspecialchars($message).'</div>'; } ?>
-<a href="organization_edit.php" class="btn btn-sm btn-primary mb-3">Add Organization</a>
+<a href="organization_edit.php" class="btn btn-sm btn-phoenix-success mb-3">Add Organization</a>
 <div id="organizations" data-list='{"valueNames":["id","name"],"page":10,"pagination":true}'>
   <div class="row justify-content-between g-2 mb-3">
     <div class="col-auto">
@@ -33,8 +33,8 @@ $organizations = $stmt->fetchAll(PDO::FETCH_ASSOC);
             <td class="id"><?= htmlspecialchars($o['id']); ?></td>
             <td class="name"><?= htmlspecialchars($o['name']); ?></td>
             <td>
-              <a class="btn btn-sm btn-secondary" href="organization_edit.php?id=<?= $o['id']; ?>">Edit</a>
-              <a class="btn btn-sm btn-info" href="agencies.php?organization_id=<?= $o['id']; ?>">Agencies</a>
+              <a class="btn btn-sm btn-phoenix-warning" href="organization_edit.php?id=<?= $o['id']; ?>">Edit</a>
+              <a class="btn btn-sm btn-phoenix-info" href="agencies.php?organization_id=<?= $o['id']; ?>">Agencies</a>
             </td>
           </tr>
         <?php endforeach; ?>

--- a/admin/agency/organization_edit.php
+++ b/admin/agency/organization_edit.php
@@ -9,6 +9,7 @@ $name = '';
 $main_person = null;
 $status = null;
 $message = '';
+$btnClass = $id ? 'btn-phoenix-warning' : 'btn-phoenix-success';
 
 if($_SERVER['REQUEST_METHOD'] === 'POST') {
   if(!hash_equals($token, $_POST['csrf_token'] ?? '')) {
@@ -68,7 +69,7 @@ $statuses = $statusStmt->fetchAll(PDO::FETCH_ASSOC);
       <?php endforeach; ?>
     </select>
   </div>
-  <button type="submit" class="btn btn-primary">Save</button>
-  <a href="index.php" class="btn btn-secondary">Back</a>
+  <button type="submit" class="btn <?= $btnClass; ?>">Save</button>
+  <a href="index.php" class="btn btn-phoenix-secondary">Back</a>
 </form>
 <?php require '../admin_footer.php'; ?>

--- a/admin/index.php
+++ b/admin/index.php
@@ -6,7 +6,7 @@
       <div class="card-body">
         <h5 class="card-title"><span class="me-2" data-feather="users"></span>Users</h5>
         <p class="card-text">Manage system users.</p>
-        <a href="users/index.php" class="btn btn-primary btn-sm">Manage</a>
+        <a href="users/index.php" class="btn btn-phoenix-primary btn-sm">Manage</a>
       </div>
     </div>
   </div>
@@ -15,7 +15,7 @@
       <div class="card-body">
         <h5 class="card-title">Lookup Lists</h5>
         <p class="card-text">Manage lookup lists and items.</p>
-        <a href="lookup-lists/index.php" class="btn btn-primary btn-sm">Manage</a>
+        <a href="lookup-lists/index.php" class="btn btn-phoenix-primary btn-sm">Manage</a>
       </div>
     </div>
   </div>

--- a/admin/left_navigation.php
+++ b/admin/left_navigation.php
@@ -36,6 +36,6 @@
     </div>
   </div>
   <div class="navbar-vertical-footer">
-    <button class="btn navbar-vertical-toggle border-0 fw-semibold w-100 white-space-nowrap d-flex align-items-center"><span class="uil uil-left-arrow-to-left fs-8"></span><span class="uil uil-arrow-from-right fs-8"></span><span class="navbar-vertical-footer-text ms-2">Collapsed View</span></button>
+    <button class="btn btn-phoenix-secondary navbar-vertical-toggle border-0 fw-semibold w-100 white-space-nowrap d-flex align-items-center"><span class="uil uil-left-arrow-to-left fs-8"></span><span class="uil uil-arrow-from-right fs-8"></span><span class="navbar-vertical-footer-text ms-2">Collapsed View</span></button>
   </div>
 </nav>

--- a/admin/lookup-lists/attributes.php
+++ b/admin/lookup-lists/attributes.php
@@ -56,8 +56,8 @@ $attrs=$stmt->fetchAll(PDO::FETCH_ASSOC);
   <input type="hidden" name="id" value="<?= htmlspecialchars($_POST['id'] ?? ''); ?>">
   <div class="col-md-4"><input class="form-control" name="attr_key" placeholder="Key" value="<?= htmlspecialchars($_POST['attr_key'] ?? ''); ?>" required></div>
   <div class="col-md-4"><input class="form-control" name="attr_value" placeholder="Value" value="<?= htmlspecialchars($_POST['attr_value'] ?? ''); ?>"></div>
-  <div class="col-md-2"><button class="btn btn-primary" type="submit">Save</button></div>
-  <div class="col-md-2"><a class="btn btn-secondary" href="items.php?list_id=<?= $item['list_id']; ?>">Back</a></div>
+  <div class="col-md-2"><button class="btn btn-phoenix-success" type="submit" id="saveBtn">Save</button></div>
+  <div class="col-md-2"><a class="btn btn-phoenix-secondary" href="items.php?list_id=<?= $item['list_id']; ?>">Back</a></div>
 </form>
 <div id="attrs" data-list='{"valueNames":["attr_key","attr_value"],"page":10,"pagination":true}'>
   <div class="row justify-content-between g-2 mb-3">
@@ -74,11 +74,11 @@ $attrs=$stmt->fetchAll(PDO::FETCH_ASSOC);
             <td class="attr_key"><?= htmlspecialchars($a['attr_key']); ?></td>
             <td class="attr_value"><?= htmlspecialchars($a['attr_value']); ?></td>
             <td>
-              <button class="btn btn-sm btn-secondary" onclick="fillAttr(<?= $a['id']; ?>,'<?= htmlspecialchars($a['attr_key'],ENT_QUOTES); ?>','<?= htmlspecialchars($a['attr_value'],ENT_QUOTES); ?>');return false;">Edit</button>
+              <button class="btn btn-sm btn-phoenix-warning" onclick="fillAttr(<?= $a['id']; ?>,'<?= htmlspecialchars($a['attr_key'],ENT_QUOTES); ?>','<?= htmlspecialchars($a['attr_value'],ENT_QUOTES); ?>');return false;">Edit</button>
               <form method="post" class="d-inline">
                 <input type="hidden" name="delete_id" value="<?= $a['id']; ?>">
                 <input type="hidden" name="csrf_token" value="<?= $token; ?>">
-                <button class="btn btn-sm btn-danger" onclick="return confirm('Delete attribute?');">Delete</button>
+                <button class="btn btn-sm btn-phoenix-danger" onclick="return confirm('Delete attribute?');">Delete</button>
               </form>
             </td>
           </tr>
@@ -97,6 +97,9 @@ function fillAttr(id,key,value){
   f.id.value=id;
   f.attr_key.value=key;
   f.attr_value.value=value;
+  const btn=document.getElementById('saveBtn');
+  btn.classList.remove('btn-phoenix-success');
+  btn.classList.add('btn-phoenix-warning');
 }
 </script>
 <?php require '../admin_footer.php'; ?>

--- a/admin/lookup-lists/edit.php
+++ b/admin/lookup-lists/edit.php
@@ -6,6 +6,7 @@ $_SESSION['csrf_token'] = $token;
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 $name = $description = $memo = '';
 $message = $error = '';
+$btnClass = $id ? 'btn-phoenix-warning' : 'btn-phoenix-success';
 
 if ($id) {
   $stmt = $pdo->prepare('SELECT * FROM lookup_lists WHERE id = :id');
@@ -60,7 +61,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <label class="form-label">Memo</label>
     <textarea class="form-control" name="memo"><?= htmlspecialchars($memo); ?></textarea>
   </div>
-  <button class="btn btn-primary" type="submit">Save</button>
-  <a href="index.php" class="btn btn-secondary">Back</a>
+  <button class="btn <?= $btnClass; ?>" type="submit">Save</button>
+  <a href="index.php" class="btn btn-phoenix-secondary">Back</a>
 </form>
 <?php require '../admin_footer.php'; ?>

--- a/admin/lookup-lists/index.php
+++ b/admin/lookup-lists/index.php
@@ -21,7 +21,7 @@ $lists = $stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <h2 class="mb-4">Lookup Lists</h2>
 <?php if($message){ echo '<div class="alert alert-success">'.htmlspecialchars($message).'</div>'; } ?>
-<a href="edit.php" class="btn btn-sm btn-primary mb-3">Add Lookup List</a>
+<a href="edit.php" class="btn btn-sm btn-phoenix-success mb-3">Add Lookup List</a>
 <div id="lookup-lists" data-list='{"valueNames":["id","name","description"],"page":10,"pagination":true}'>
   <div class="row justify-content-between g-2 mb-3">
     <div class="col-auto">
@@ -45,12 +45,12 @@ $lists = $stmt->fetchAll(PDO::FETCH_ASSOC);
             <td class="name"><?= htmlspecialchars($l['name']); ?></td>
             <td class="description"><?= htmlspecialchars($l['description']); ?></td>
             <td>
-              <a class="btn btn-sm btn-secondary" href="edit.php?id=<?= $l['id']; ?>">Edit</a>
-              <a class="btn btn-sm btn-info" href="items.php?list_id=<?= $l['id']; ?>">Items</a>
+              <a class="btn btn-sm btn-phoenix-warning" href="edit.php?id=<?= $l['id']; ?>">Edit</a>
+              <a class="btn btn-sm btn-phoenix-info" href="items.php?list_id=<?= $l['id']; ?>">Items</a>
               <form method="post" class="d-inline">
                 <input type="hidden" name="delete_id" value="<?= $l['id']; ?>">
                 <input type="hidden" name="csrf_token" value="<?= $token; ?>">
-                <button class="btn btn-sm btn-danger" onclick="return confirm('Delete this list?');">Delete</button>
+                <button class="btn btn-sm btn-phoenix-danger" onclick="return confirm('Delete this list?');">Delete</button>
               </form>
             </td>
           </tr>

--- a/admin/lookup-lists/items.php
+++ b/admin/lookup-lists/items.php
@@ -58,8 +58,8 @@ $items=$stmt->fetchAll(PDO::FETCH_ASSOC);
   <div class="col-md-3"><input class="form-control" name="label" placeholder="Label" value="<?= htmlspecialchars($_POST['label'] ?? ''); ?>" required></div>
   <div class="col-md-3"><input class="form-control" name="value" placeholder="Value" value="<?= htmlspecialchars($_POST['value'] ?? ''); ?>"></div>
   <div class="col-md-2"><input class="form-control" type="number" name="sort_order" placeholder="Sort" value="<?= htmlspecialchars($_POST['sort_order'] ?? 0); ?>"></div>
-  <div class="col-md-2"><button class="btn btn-primary" type="submit">Save Item</button></div>
-  <div class="col-md-2"><a class="btn btn-secondary" href="index.php">Back</a></div>
+  <div class="col-md-2"><button class="btn btn-phoenix-success" type="submit" id="saveBtn">Save Item</button></div>
+  <div class="col-md-2"><a class="btn btn-phoenix-secondary" href="index.php">Back</a></div>
 </form>
 <div id="items" data-list='{"valueNames":["label","value","sort_order"],"page":10,"pagination":true}'>
   <div class="row justify-content-between g-2 mb-3">
@@ -78,13 +78,13 @@ $items=$stmt->fetchAll(PDO::FETCH_ASSOC);
             <td class="label"><?= htmlspecialchars($it['label']); ?></td>
             <td class="value"><?= htmlspecialchars($it['value']); ?></td>
             <td class="sort_order"><?= htmlspecialchars($it['sort_order']); ?></td>
-            <td><a class="btn btn-sm btn-info" href="attributes.php?item_id=<?= $it['id']; ?>&list_id=<?= $list_id; ?>">Attributes</a></td>
+            <td><a class="btn btn-sm btn-phoenix-info" href="attributes.php?item_id=<?= $it['id']; ?>&list_id=<?= $list_id; ?>">Attributes</a></td>
             <td>
-              <button class="btn btn-sm btn-secondary" onclick="fillForm(<?= $it['id']; ?>,'<?= htmlspecialchars($it['label'],ENT_QUOTES); ?>','<?= htmlspecialchars($it['value'],ENT_QUOTES); ?>',<?= (int)$it['sort_order']; ?>);return false;">Edit</button>
+              <button class="btn btn-sm btn-phoenix-warning" onclick="fillForm(<?= $it['id']; ?>,'<?= htmlspecialchars($it['label'],ENT_QUOTES); ?>','<?= htmlspecialchars($it['value'],ENT_QUOTES); ?>',<?= (int)$it['sort_order']; ?>);return false;">Edit</button>
               <form method="post" class="d-inline">
                 <input type="hidden" name="delete_id" value="<?= $it['id']; ?>">
                 <input type="hidden" name="csrf_token" value="<?= $token; ?>">
-                <button class="btn btn-sm btn-danger" onclick="return confirm('Delete item?');">Delete</button>
+                <button class="btn btn-sm btn-phoenix-danger" onclick="return confirm('Delete item?');">Delete</button>
               </form>
             </td>
           </tr>
@@ -104,6 +104,9 @@ function fillForm(id,label,value,sort){
   f.label.value=label;
   f.value.value=value;
   f.sort_order.value=sort;
+  const btn=document.getElementById('saveBtn');
+  btn.classList.remove('btn-phoenix-success');
+  btn.classList.add('btn-phoenix-warning');
 }
 </script>
 <?php require '../admin_footer.php'; ?>

--- a/admin/navigation.php
+++ b/admin/navigation.php
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-top fixed-top navbar-expand-lg" id="navbarAdmin" data-navbar-top="combo">
   <div class="navbar-logo">
-    <button class="btn navbar-toggler navbar-toggler-humburger-icon hover-bg-transparent" type="button" data-bs-toggle="collapse" data-bs-target="#navbarVerticalCollapse" aria-controls="navbarVerticalCollapse" aria-expanded="false" aria-label="Toggle Navigation"><span class="navbar-toggle-icon"><span class="toggle-line"></span></span></button>
+    <button class="btn btn-phoenix-secondary navbar-toggler navbar-toggler-humburger-icon hover-bg-transparent" type="button" data-bs-toggle="collapse" data-bs-target="#navbarVerticalCollapse" aria-controls="navbarVerticalCollapse" aria-expanded="false" aria-label="Toggle Navigation"><span class="navbar-toggle-icon"><span class="toggle-line"></span></span></button>
     <a class="navbar-brand me-1 me-sm-3" href="<?php echo getURLDir(); ?>admin/">
       <div class="d-flex align-items-center">
         <div class="d-flex align-items-center"><img src="<?php echo getURLDir(); ?>images/wide.png" alt="Atlisware" class="img-fluid" /></div>

--- a/admin/orgs/agency.php
+++ b/admin/orgs/agency.php
@@ -27,6 +27,7 @@ $name = '';
 $main_person = null;
 $status = null;
 $message = '';
+$btnClass = $id ? 'btn-phoenix-warning' : 'btn-phoenix-success';
 
 if ($id && $_SERVER['REQUEST_METHOD'] !== 'POST') {
     $stmt = $pdo->prepare('SELECT name, main_person, status FROM module_agency WHERE id = :id');
@@ -93,12 +94,12 @@ if ($id) {
       <?php endforeach; ?>
     </select>
   </div>
-  <button class="btn btn-primary" type="submit">Save</button>
-  <a href="index.php" class="btn btn-secondary">Back</a>
+  <button class="btn <?= $btnClass; ?>" type="submit">Save</button>
+  <a href="index.php" class="btn btn-phoenix-secondary">Back</a>
 </form>
 <?php if ($id): ?>
   <h3 class="mb-3">Divisions</h3>
-  <a href="division.php?agency_id=<?= $id; ?>" class="btn btn-sm btn-primary mb-3">Add Division</a>
+  <a href="division.php?agency_id=<?= $id; ?>" class="btn btn-sm btn-phoenix-success mb-3">Add Division</a>
   <?php if ($agencyDivisions): ?>
     <ul class="list-unstyled">
       <?php foreach ($agencyDivisions as $d): ?>

--- a/admin/orgs/division.php
+++ b/admin/orgs/division.php
@@ -27,6 +27,7 @@ $name = '';
 $main_person = null;
 $status = null;
 $message = '';
+$btnClass = $id ? 'btn-phoenix-warning' : 'btn-phoenix-success';
 
 if ($id && $_SERVER['REQUEST_METHOD'] !== 'POST') {
     $stmt = $pdo->prepare('SELECT name, main_person, status FROM module_division WHERE id = :id');
@@ -85,7 +86,7 @@ $statuses = $statusStmt->fetchAll(PDO::FETCH_ASSOC);
       <?php endforeach; ?>
     </select>
   </div>
-  <button class="btn btn-primary" type="submit">Save</button>
-  <a href="index.php" class="btn btn-secondary">Back</a>
+  <button class="btn <?= $btnClass; ?>" type="submit">Save</button>
+  <a href="index.php" class="btn btn-phoenix-secondary">Back</a>
 </form>
 <?php require '../admin_footer.php'; ?>

--- a/admin/orgs/index.php
+++ b/admin/orgs/index.php
@@ -24,13 +24,13 @@ foreach ($divisionRows as $row) {
 }
 ?>
 <h2 class="mb-4">Organizations</h2>
-<a href="organization.php" class="btn btn-sm btn-primary mb-3">Add Organization</a>
+<a href="organization.php" class="btn btn-sm btn-phoenix-success mb-3">Add Organization</a>
 <?php foreach ($organizations as $org): ?>
   <div class="card mb-3">
     <div class="card-header d-flex justify-content-between align-items-center">
       <h5 class="mb-0"><?= htmlspecialchars($org['name']); ?></h5>
       <div>
-        <a class="btn btn-sm btn-secondary" href="organization.php?id=<?= $org['id']; ?>">View</a>
+        <a class="btn btn-sm btn-phoenix-secondary" href="organization.php?id=<?= $org['id']; ?>">View</a>
       </div>
     </div>
     <div class="card-body">
@@ -47,14 +47,14 @@ foreach ($divisionRows as $row) {
                   <?php endforeach; ?>
                 </ul>
               <?php endif; ?>
-              <a class="btn btn-sm btn-outline-primary mt-1" href="division.php?agency_id=<?= $agency['id']; ?>">Add Division</a>
+              <a class="btn btn-sm btn-phoenix-success mt-1" href="division.php?agency_id=<?= $agency['id']; ?>">Add Division</a>
             </li>
           <?php endforeach; ?>
         </ul>
       <?php else: ?>
         <p class="ms-3 text-muted">No agencies yet.</p>
       <?php endif; ?>
-      <a class="btn btn-sm btn-outline-primary" href="agency.php?organization_id=<?= $org['id']; ?>">Add Agency</a>
+      <a class="btn btn-sm btn-phoenix-success" href="agency.php?organization_id=<?= $org['id']; ?>">Add Agency</a>
     </div>
   </div>
 <?php endforeach; ?>

--- a/admin/orgs/organization.php
+++ b/admin/orgs/organization.php
@@ -9,6 +9,7 @@ $name = '';
 $main_person = null;
 $status = null;
 $message = '';
+$btnClass = $id ? 'btn-phoenix-warning' : 'btn-phoenix-success';
 
 if ($id) {
     require_permission('orgs','update');
@@ -82,12 +83,12 @@ if ($id) {
       <?php endforeach; ?>
     </select>
   </div>
-  <button class="btn btn-primary" type="submit">Save</button>
-  <a href="index.php" class="btn btn-secondary">Back</a>
+  <button class="btn <?= $btnClass; ?>" type="submit">Save</button>
+  <a href="index.php" class="btn btn-phoenix-secondary">Back</a>
 </form>
 <?php if ($id): ?>
   <h3 class="mb-3">Agencies</h3>
-  <a href="agency.php?organization_id=<?= $id; ?>" class="btn btn-sm btn-primary mb-3">Add Agency</a>
+  <a href="agency.php?organization_id=<?= $id; ?>" class="btn btn-sm btn-phoenix-success mb-3">Add Agency</a>
   <?php if ($orgAgencies): ?>
     <ul class="list-unstyled">
       <?php foreach ($orgAgencies as $a): ?>

--- a/admin/person/edit.php
+++ b/admin/person/edit.php
@@ -5,6 +5,7 @@ $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 $first_name = $last_name = '';
 $user_id = null;
 $existing = null;
+$btnClass = $id ? 'btn-phoenix-warning' : 'btn-phoenix-success';
 
 if ($id) {
   require_permission('person','update');
@@ -74,7 +75,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <label class="form-label">Last Name</label>
     <input type="text" name="last_name" class="form-control" value="<?= htmlspecialchars($last_name); ?>" required>
   </div>
-  <button class="btn btn-primary" type="submit">Save</button>
-  <a href="index.php" class="btn btn-secondary">Cancel</a>
+  <button class="btn <?= $btnClass; ?>" type="submit">Save</button>
+  <a href="index.php" class="btn btn-phoenix-secondary">Cancel</a>
 </form>
 <?php require '../admin_footer.php'; ?>

--- a/admin/person/index.php
+++ b/admin/person/index.php
@@ -23,7 +23,7 @@ $persons = $stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <h2 class="mb-4">Persons</h2>
 <?php if($message){ echo '<div class="alert alert-success">'.htmlspecialchars($message).'</div>'; } ?>
-<a href="edit.php" class="btn btn-sm btn-primary mb-3">Add Person</a>
+<a href="edit.php" class="btn btn-sm btn-phoenix-success mb-3">Add Person</a>
 <div id="persons" data-list='{"valueNames":["name","user"],"page":12,"pagination":true}'>
   <div class="row justify-content-between g-2 mb-3">
     <div class="col-auto">
@@ -42,11 +42,11 @@ $persons = $stmt->fetchAll(PDO::FETCH_ASSOC);
               <?php endif; ?>
             </div>
             <div>
-              <a class="btn btn-sm btn-secondary" href="edit.php?id=<?= $p['id']; ?>">Edit</a>
+              <a class="btn btn-sm btn-phoenix-warning" href="edit.php?id=<?= $p['id']; ?>">Edit</a>
               <form method="post" class="d-inline">
                 <input type="hidden" name="delete_id" value="<?= $p['id']; ?>">
                 <input type="hidden" name="csrf_token" value="<?= $token; ?>">
-                <button class="btn btn-sm btn-danger" onclick="return confirm('Delete this person?');">Delete</button>
+                <button class="btn btn-sm btn-phoenix-danger" onclick="return confirm('Delete this person?');">Delete</button>
               </form>
             </div>
           </div>

--- a/admin/roles/edit.php
+++ b/admin/roles/edit.php
@@ -4,6 +4,7 @@ require '../admin_header.php';
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 $name = '';
 $description = '';
+$btnClass = $id ? 'btn-phoenix-warning' : 'btn-phoenix-success';
 
 if ($id) {
   $stmt = $pdo->prepare('SELECT name, description FROM admin_roles WHERE id = :id');
@@ -49,7 +50,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <label class="form-label">Description</label>
     <textarea name="description" class="form-control" rows="3"><?= htmlspecialchars($description); ?></textarea>
   </div>
-  <button class="btn btn-primary" type="submit">Save</button>
-  <a href="index.php" class="btn btn-secondary">Cancel</a>
+  <button class="btn <?= $btnClass; ?>" type="submit">Save</button>
+  <a href="index.php" class="btn btn-phoenix-secondary">Cancel</a>
 </form>
 <?php require '../admin_footer.php'; ?>

--- a/admin/roles/index.php
+++ b/admin/roles/index.php
@@ -22,9 +22,9 @@ $roles = $stmt->fetchAll(PDO::FETCH_ASSOC);
 <h2 class="mb-4">Roles</h2>
 <?php if($message){ echo '<div class="alert alert-success">'.htmlspecialchars($message).'</div>'; } ?>
 <div class="mb-3">
-  <a href="edit.php" class="btn btn-sm btn-primary">Add Role</a>
-  <a href="permissions.php" class="btn btn-sm btn-info">Permissions</a>
-  <a href="matrix.php" class="btn btn-sm btn-secondary">Role Permissions</a>
+  <a href="edit.php" class="btn btn-sm btn-phoenix-success">Add Role</a>
+  <a href="permissions.php" class="btn btn-sm btn-phoenix-info">Permissions</a>
+  <a href="matrix.php" class="btn btn-sm btn-phoenix-secondary">Role Permissions</a>
 </div>
 <div id="roles" data-list='{"valueNames":["id","name","description"],"page":10,"pagination":true}'>
   <div class="row justify-content-between g-2 mb-3">
@@ -49,11 +49,11 @@ $roles = $stmt->fetchAll(PDO::FETCH_ASSOC);
             <td class="name"><?= htmlspecialchars($r['name']); ?></td>
             <td class="description"><?= htmlspecialchars($r['description']); ?></td>
             <td>
-              <a class="btn btn-sm btn-secondary" href="edit.php?id=<?= $r['id']; ?>">Edit</a>
+              <a class="btn btn-sm btn-phoenix-warning" href="edit.php?id=<?= $r['id']; ?>">Edit</a>
               <form method="post" class="d-inline">
                 <input type="hidden" name="delete_id" value="<?= $r['id']; ?>">
                 <input type="hidden" name="csrf_token" value="<?= $token; ?>">
-                <button class="btn btn-sm btn-danger" onclick="return confirm('Delete this role?');">Delete</button>
+                <button class="btn btn-sm btn-phoenix-danger" onclick="return confirm('Delete this role?');">Delete</button>
               </form>
             </td>
           </tr>

--- a/admin/roles/matrix.php
+++ b/admin/roles/matrix.php
@@ -78,6 +78,6 @@ foreach ($currentMap as $rid => $pids) {
       </tbody>
     </table>
   </div>
-  <button class="btn btn-primary" type="submit">Save</button>
+  <button class="btn btn-phoenix-warning" type="submit">Save</button>
 </form>
 <?php require '../admin_footer.php'; ?>

--- a/admin/roles/permission_edit.php
+++ b/admin/roles/permission_edit.php
@@ -4,6 +4,7 @@ require '../admin_header.php';
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 $module = '';
 $action = '';
+$btnClass = $id ? 'btn-phoenix-warning' : 'btn-phoenix-success';
 
 if ($id) {
   $stmt = $pdo->prepare('SELECT module, action FROM admin_permissions WHERE id = :id');
@@ -49,7 +50,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <label class="form-label">Action</label>
     <input type="text" name="action" class="form-control" value="<?= htmlspecialchars($action); ?>" required>
   </div>
-  <button class="btn btn-primary" type="submit">Save</button>
-  <a href="permissions.php" class="btn btn-secondary">Cancel</a>
+  <button class="btn <?= $btnClass; ?>" type="submit">Save</button>
+  <a href="permissions.php" class="btn btn-phoenix-secondary">Cancel</a>
 </form>
 <?php require '../admin_footer.php'; ?>

--- a/admin/roles/permissions.php
+++ b/admin/roles/permissions.php
@@ -21,7 +21,7 @@ $perms = $stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <h2 class="mb-4">Permissions</h2>
 <?php if($message){ echo '<div class="alert alert-success">'.htmlspecialchars($message).'</div>'; } ?>
-<a href="permission_edit.php" class="btn btn-sm btn-primary mb-3">Add Permission</a>
+<a href="permission_edit.php" class="btn btn-sm btn-phoenix-success mb-3">Add Permission</a>
 <div id="permissions" data-list='{"valueNames":["id","module","action"],"page":10,"pagination":true}'>
   <div class="row justify-content-between g-2 mb-3">
     <div class="col-auto">
@@ -45,11 +45,11 @@ $perms = $stmt->fetchAll(PDO::FETCH_ASSOC);
             <td class="module"><?= htmlspecialchars($p['module']); ?></td>
             <td class="action"><?= htmlspecialchars($p['action']); ?></td>
             <td>
-              <a class="btn btn-sm btn-secondary" href="permission_edit.php?id=<?= $p['id']; ?>">Edit</a>
+              <a class="btn btn-sm btn-phoenix-warning" href="permission_edit.php?id=<?= $p['id']; ?>">Edit</a>
               <form method="post" class="d-inline">
                 <input type="hidden" name="delete_id" value="<?= $p['id']; ?>">
                 <input type="hidden" name="csrf_token" value="<?= $token; ?>">
-                <button class="btn btn-sm btn-danger" onclick="return confirm('Delete this permission?');">Delete</button>
+                <button class="btn btn-sm btn-phoenix-danger" onclick="return confirm('Delete this permission?');">Delete</button>
               </form>
             </td>
           </tr>

--- a/admin/users/edit.php
+++ b/admin/users/edit.php
@@ -9,6 +9,7 @@ $username = $email = $first_name = $last_name = $type = 'ADMIN';
 $status = 1;
 $assigned = [];
 $message = $error = '';
+$btnClass = $id ? 'btn-phoenix-warning' : 'btn-phoenix-success';
 
 if ($id) {
   $stmt = $pdo->prepare('SELECT u.username, u.email, u.type, u.status, p.first_name, p.last_name FROM users u LEFT JOIN person p ON u.id = p.user_id WHERE u.id = :id');
@@ -167,7 +168,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
       </div>
     <?php endforeach; ?>
   </div>
-  <button class="btn btn-primary" type="submit">Save</button>
-  <a href="index.php" class="btn btn-secondary">Back</a>
+  <button class="btn <?= $btnClass; ?>" type="submit">Save</button>
+  <a href="index.php" class="btn btn-phoenix-secondary">Back</a>
 </form>
 <?php require '../admin_footer.php'; ?>

--- a/admin/users/index.php
+++ b/admin/users/index.php
@@ -33,7 +33,7 @@ $users = $stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <h2 class="mb-4">Users</h2>
 <?php if($message){ echo '<div class="alert alert-success">'.htmlspecialchars($message).'</div>'; } ?>
-<a href="edit.php" class="btn btn-sm btn-primary mb-3">Add User</a>
+<a href="edit.php" class="btn btn-sm btn-phoenix-success mb-3">Add User</a>
 <div id="users" data-list='{"valueNames":["id","username","email","name","type","status"],"page":10,"pagination":true}'>
   <div class="row justify-content-between g-2 mb-3">
     <div class="col-auto">
@@ -75,11 +75,11 @@ $users = $stmt->fetchAll(PDO::FETCH_ASSOC);
               </span>
             </td>
             <td>
-              <a class="btn btn-sm btn-secondary" href="edit.php?id=<?= $u['id']; ?>">Edit</a>
+              <a class="btn btn-sm btn-phoenix-warning" href="edit.php?id=<?= $u['id']; ?>">Edit</a>
               <form method="post" class="d-inline">
                 <input type="hidden" name="delete_id" value="<?= $u['id']; ?>">
                 <input type="hidden" name="csrf_token" value="<?= $token; ?>">
-                <button class="btn btn-sm btn-danger" onclick="return confirm('Delete this user?');">Delete</button>
+                <button class="btn btn-sm btn-phoenix-danger" onclick="return confirm('Delete this user?');">Delete</button>
               </form>
             </td>
           </tr>


### PR DESCRIPTION
## Summary
- Align admin buttons with Phoenix theme, using success for create/add, warning for update/edit and danger for delete
- Support dynamic button states and navigation controls with Phoenix button styling

## Testing
- `php -l admin/person/index.php admin/person/edit.php admin/agency/index.php admin/index.php admin/lookup-lists/index.php admin/lookup-lists/edit.php admin/lookup-lists/items.php admin/lookup-lists/attributes.php admin/orgs/index.php admin/orgs/organization.php admin/orgs/division.php admin/roles/index.php admin/agency/agencies.php admin/left_navigation.php admin/roles/permissions.php admin/agency/division_edit.php admin/roles/matrix.php admin/agency/organization_edit.php admin/agency/agency_edit.php admin/agency/divisions.php admin/roles/permission_edit.php admin/orgs/agency.php admin/navigation.php admin/users/index.php admin/users/edit.php admin/roles/edit.php`

------
https://chatgpt.com/codex/tasks/task_e_68940a5a59dc8333b3ce78832aae816e