### PR TITLE
Split user creation from edit

### DIFF
--- a/admin/users/index.php
+++ b/admin/users/index.php
@@ -33,7 +33,7 @@ $users = $stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <h2 class="mb-4">Users</h2>
 <?php if($message){ echo '<div class="alert alert-success">'.htmlspecialchars($message).'</div>'; } ?>
-<a href="edit.php" class="btn btn-sm btn-success mb-3">Add User</a>
+<a href="new.php" class="btn btn-sm btn-success mb-3">Add User</a>
 <div id="users" data-list='{"valueNames":["id","username","email","name","type","status"],"page":10,"pagination":true}'>
   <div class="row justify-content-between g-2 mb-3">
     <div class="col-auto">


### PR DESCRIPTION
## Summary
- Add dedicated `admin/users/new.php` for creating users without an ID
- Restrict `admin/users/edit.php` to editing existing users only
- Point "Add User" button to `new.php`

## Testing
- `php -l admin/users/new.php`
- `php -l admin/users/edit.php`
- `php -l admin/users/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68940f417cdc833391c032c7d9d3af3d