### PR TITLE
Validate unique user credentials

### DIFF
--- a/admin/users/edit.php
+++ b/admin/users/edit.php
@@ -64,8 +64,27 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
   if ($username === '' || $email === '') {
     $error = 'Username and email are required.';
+  } elseif (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    $error = 'Invalid email address.';
+  } else {
+    $stmt = $pdo->prepare('SELECT id FROM users WHERE username = :username' . ($id ? ' AND id != :id' : ''));
+    $params = [':username' => $username];
+    if ($id) { $params[':id'] = $id; }
+    $stmt->execute($params);
+    if ($stmt->fetchColumn()) {
+      $error = 'Username already exists.';
+    }
+    if (!$error) {
+      $stmt = $pdo->prepare('SELECT id FROM users WHERE email = :email' . ($id ? ' AND id != :id' : ''));
+      $params = [':email' => $email];
+      if ($id) { $params[':id'] = $id; }
+      $stmt->execute($params);
+      if ($stmt->fetchColumn()) {
+        $error = 'Email already exists.';
+      }
+    }
   }
-  if (!$id && $password === '') {
+  if (!$error && !$id && $password === '') {
     $error = 'Password is required for new users.';
   }
 

--- a/admin/users/index.php
+++ b/admin/users/index.php
@@ -33,7 +33,7 @@ $users = $stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <h2 class="mb-4">Users</h2>
 <?php if($message){ echo '<div class="alert alert-success">'.htmlspecialchars($message).'</div>'; } ?>
-<a href="edit.php" class="btn btn-sm btn-success mb-3">Add User</a>
+<a href="new.php" class="btn btn-sm btn-success mb-3">Add User</a>
 <div id="users" data-list='{"valueNames":["id","username","email","name","type","status"],"page":10,"pagination":true}'>
   <div class="row justify-content-between g-2 mb-3">
     <div class="col-auto">

--- a/admin/users/new.php
+++ b/admin/users/new.php
@@ -1,0 +1,2 @@
+<?php
+require 'edit.php';


### PR DESCRIPTION
## Summary
- ensure usernames and emails are unique and well-formed before user creation or update
- add a dedicated new user entry point

## Testing
- `php -l admin/users/edit.php`
- `php -l admin/users/new.php`
- `php -l admin/users/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68940f44e984833393e6e707617f660d