### PR TITLE
Add RBAC checks for admin user and role management

### DIFF
--- a/_SQL/011_admin_roles.sql
+++ b/_SQL/011_admin_roles.sql
@@ -1,0 +1,13 @@
+-- Seed permissions for managing roles
+INSERT INTO `admin_permissions` (`module`, `action`) VALUES
+  ('roles', 'create'),
+  ('roles', 'read'),
+  ('roles', 'update'),
+  ('roles', 'delete');
+
+-- Grant permissions to the default Admin role
+INSERT INTO `admin_role_permissions` (`role_id`, `permission_id`)
+SELECT r.id, p.id
+FROM admin_roles r
+JOIN admin_permissions p ON p.module = 'roles' AND p.action IN ('create','read','update','delete')
+WHERE r.name = 'Admin';

--- a/admin/roles/edit.php
+++ b/admin/roles/edit.php
@@ -7,12 +7,15 @@ $description = '';
 $btnClass = $id ? 'btn-warning' : 'btn-success';
 
 if ($id) {
+  require_permission('roles','update');
   $stmt = $pdo->prepare('SELECT name, description FROM admin_roles WHERE id = :id');
   $stmt->execute([':id' => $id]);
   if ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
     $name = $row['name'];
     $description = $row['description'];
   }
+} else {
+  require_permission('roles','create');
 }
 
 $token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));

--- a/admin/roles/index.php
+++ b/admin/roles/index.php
@@ -1,5 +1,6 @@
 <?php
 require '../admin_header.php';
+require_permission('roles','read');
 
 $token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
 $_SESSION['csrf_token'] = $token;
@@ -9,6 +10,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete_id'])) {
   if (!hash_equals($token, $_POST['csrf_token'] ?? '')) {
     die('Invalid CSRF token');
   }
+  require_permission('roles','delete');
   $delId = (int)$_POST['delete_id'];
   $stmt = $pdo->prepare('DELETE FROM admin_roles WHERE id = :id');
   $stmt->execute([':id' => $delId]);

--- a/admin/roles/matrix.php
+++ b/admin/roles/matrix.php
@@ -1,5 +1,6 @@
 <?php
 require '../admin_header.php';
+require_permission('roles','read');
 
 $token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
 $_SESSION['csrf_token'] = $token;
@@ -16,6 +17,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   if (!hash_equals($token, $_POST['csrf_token'] ?? '')) {
     die('Invalid CSRF token');
   }
+  require_permission('roles','update');
   $rolePerms = $_POST['perm'] ?? [];
   $roles = $pdo->query('SELECT id FROM admin_roles')->fetchAll(PDO::FETCH_COLUMN);
   foreach ($roles as $roleId) {

--- a/admin/roles/permission_edit.php
+++ b/admin/roles/permission_edit.php
@@ -7,12 +7,15 @@ $action = '';
 $btnClass = $id ? 'btn-warning' : 'btn-success';
 
 if ($id) {
+  require_permission('roles','update');
   $stmt = $pdo->prepare('SELECT module, action FROM admin_permissions WHERE id = :id');
   $stmt->execute([':id' => $id]);
   if ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
     $module = $row['module'];
     $action = $row['action'];
   }
+} else {
+  require_permission('roles','create');
 }
 
 $token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));

--- a/admin/roles/permissions.php
+++ b/admin/roles/permissions.php
@@ -1,5 +1,6 @@
 <?php
 require '../admin_header.php';
+require_permission('roles','read');
 
 $token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
 $_SESSION['csrf_token'] = $token;
@@ -9,6 +10,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete_id'])) {
   if (!hash_equals($token, $_POST['csrf_token'] ?? '')) {
     die('Invalid CSRF token');
   }
+  require_permission('roles','delete');
   $delId = (int)$_POST['delete_id'];
   $stmt = $pdo->prepare('DELETE FROM admin_permissions WHERE id = :id');
   $stmt->execute([':id' => $delId]);

--- a/admin/users/edit.php
+++ b/admin/users/edit.php
@@ -1,9 +1,6 @@
 <?php
 require '../admin_header.php';
 
-$token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
-$_SESSION['csrf_token'] = $token;
-
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 $username = $email = $first_name = $last_name = $type = 'ADMIN';
 $status = 1;
@@ -12,6 +9,7 @@ $message = $error = '';
 $btnClass = $id ? 'btn-warning' : 'btn-success';
 
 if ($id) {
+  require_permission('users','update');
   $stmt = $pdo->prepare('SELECT u.username, u.email, u.type, u.status, p.first_name, p.last_name FROM users u LEFT JOIN person p ON u.id = p.user_id WHERE u.id = :id');
   $stmt->execute([':id' => $id]);
   if ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
@@ -25,7 +23,12 @@ if ($id) {
   $stmt = $pdo->prepare('SELECT role_id FROM admin_user_roles WHERE user_account_id = :id');
   $stmt->execute([':id' => $id]);
   $assigned = $stmt->fetchAll(PDO::FETCH_COLUMN);
+} else {
+  require_permission('users','create');
 }
+
+$token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
+$_SESSION['csrf_token'] = $token;
 
 $roles = $pdo->query('SELECT id, name FROM admin_roles ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
 

--- a/admin/users/index.php
+++ b/admin/users/index.php
@@ -1,5 +1,6 @@
 <?php
 require '../admin_header.php';
+require_permission('users','read');
 
 $token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
 $_SESSION['csrf_token'] = $token;
@@ -17,6 +18,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete_id'])) {
   if (!hash_equals($token, $_POST['csrf_token'] ?? '')) {
     die('Invalid CSRF token');
   }
+  require_permission('users','delete');
   $delId = (int)$_POST['delete_id'];
   $stmt = $pdo->prepare('DELETE FROM admin_user_roles WHERE user_account_id = :id');
   $stmt->execute([':id' => $delId]);


### PR DESCRIPTION
## Summary
- enforce module-level permission checks for admin user and role pages
- seed default permissions for managing roles and grant to Admin

## Testing
- `php -l admin/users/index.php`
- `php -l admin/users/edit.php`
- `php -l admin/roles/index.php`
- `php -l admin/roles/edit.php`
- `php -l admin/roles/permissions.php`
- `php -l admin/roles/permission_edit.php`
- `php -l admin/roles/matrix.php`


------
https://chatgpt.com/codex/tasks/task_e_68940f1f6d0883338c759a9437aa88cc