### PR TITLE
Allow restricting admin permissions

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -2,6 +2,10 @@
 // load functions
 require 'functions.php';
 
+// Admin user IDs that should have permissions enforced
+// Add IDs here to restrict specific admin accounts
+$restricted_admin_ids = [];
+
 // DB Credentials
 define('DB_HOST', 'localhost');
 define('DB_USER', 'root');

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -49,8 +49,8 @@ function admin_audit_log($pdo, $userId, $table, $recordId, $action, $oldValue, $
 
 // Checks if current user has a permission
 function user_has_permission($module, $action){
-  global $pdo, $this_user_id, $this_user_type;
-  if($this_user_type === 'ADMIN'){
+  global $pdo, $this_user_id, $this_user_type, $restricted_admin_ids;
+  if($this_user_type === 'ADMIN' && !in_array($this_user_id, $restricted_admin_ids)){
     return true;
   }
   $sql = "SELECT 1 FROM admin_user_roles ur "


### PR DESCRIPTION
## Summary
- Allow specifying admin IDs whose permissions should be enforced
- Gate permissions for listed admins by checking joined role tables

## Testing
- `php -l includes/functions.php`
- `php -l includes/config.php`


------
https://chatgpt.com/codex/tasks/task_e_68940f1e5ccc83338e3a5d655f858085