### PR TITLE
Add AJAX modals for lookup lists

### DIFF
--- a/admin/api/lookup-lists.php
+++ b/admin/api/lookup-lists.php
@@ -1,0 +1,147 @@
+<?php
+require_once __DIR__ . '/../includes/admin_guard.php';
+header('Content-Type: application/json');
+
+$token = $_SESSION['csrf_token'] ?? '';
+$entity = $_REQUEST['entity'] ?? '';
+$action = $_REQUEST['action'] ?? '';
+
+try {
+  switch ($entity) {
+    case 'list':
+      handleList($action);
+      break;
+    case 'item':
+      handleItem($action);
+      break;
+    case 'attribute':
+      handleAttr($action);
+      break;
+    default:
+      echo json_encode(['success'=>false,'error'=>'Invalid entity']);
+  }
+} catch (Exception $e) {
+  echo json_encode(['success'=>false,'error'=>'Server error']);
+}
+
+function verifyToken() {
+  global $token;
+  if (!hash_equals($token, $_POST['csrf_token'] ?? '')) {
+    echo json_encode(['success'=>false,'error'=>'Invalid CSRF token']);
+    exit;
+  }
+}
+
+function handleList($action){
+  global $pdo, $this_user_id;
+  if(in_array($action, ['create','update','delete'])){ verifyToken(); }
+  if($action==='create'){
+    $name=trim($_POST['name']??'');
+    if($name===''){ echo json_encode(['success'=>false,'error'=>'Name is required']); return; }
+    $description=trim($_POST['description']??'');
+    $memo=trim($_POST['memo']??'');
+    $stmt=$pdo->prepare('INSERT INTO lookup_lists (user_id,user_updated,name,description,memo) VALUES (:uid,:uid,:name,:description,:memo)');
+    $stmt->execute([':uid'=>$this_user_id,':name'=>$name,':description'=>$description,':memo'=>$memo]);
+    $id=$pdo->lastInsertId();
+    audit_log($pdo,$this_user_id,'lookup_lists',$id,'CREATE','Created lookup list');
+    echo json_encode(['success'=>true,'message'=>'Lookup list created','list'=>['id'=>$id,'name'=>$name,'description'=>$description]]);
+  }elseif($action==='update'){
+    $id=(int)($_POST['id']??0);
+    $name=trim($_POST['name']??'');
+    if($id<=0||$name===''){ echo json_encode(['success'=>false,'error'=>'Invalid data']); return; }
+    $description=trim($_POST['description']??'');
+    $memo=trim($_POST['memo']??'');
+    $stmt=$pdo->prepare('UPDATE lookup_lists SET name=:name,description=:description,memo=:memo,user_updated=:uid WHERE id=:id');
+    $stmt->execute([':name'=>$name,':description'=>$description,':memo'=>$memo,':uid'=>$this_user_id,':id'=>$id]);
+    audit_log($pdo,$this_user_id,'lookup_lists',$id,'UPDATE','Updated lookup list');
+    echo json_encode(['success'=>true,'message'=>'Lookup list updated','list'=>['id'=>$id,'name'=>$name,'description'=>$description]]);
+  }elseif($action==='delete'){
+    $id=(int)($_POST['id']??0);
+    if($id<=0){ echo json_encode(['success'=>false,'error'=>'Invalid ID']); return; }
+    $pdo->prepare('DELETE FROM lookup_lists WHERE id=:id')->execute([':id'=>$id]);
+    audit_log($pdo,$this_user_id,'lookup_lists',$id,'DELETE','Deleted lookup list');
+    echo json_encode(['success'=>true,'message'=>'Lookup list deleted']);
+  }else{
+    echo json_encode(['success'=>false,'error'=>'Invalid action']);
+  }
+}
+
+function handleItem($action){
+  global $pdo,$this_user_id;
+  if(in_array($action,['create','update','delete'])){ verifyToken(); }
+  if($action==='list'){
+    $list_id=(int)($_GET['list_id']??0);
+    $stmt=$pdo->prepare('SELECT id,label,value,sort_order FROM lookup_list_items WHERE list_id=:list_id ORDER BY sort_order,label');
+    $stmt->execute([':list_id'=>$list_id]);
+    $items=$stmt->fetchAll(PDO::FETCH_ASSOC);
+    echo json_encode(['success'=>true,'items'=>$items]);
+  }elseif($action==='create'){
+    $list_id=(int)($_POST['list_id']??0);
+    $label=trim($_POST['label']??'');
+    $value=trim($_POST['value']??'');
+    $sort=(int)($_POST['sort_order']??0);
+    if($list_id<=0||$label===''){ echo json_encode(['success'=>false,'error'=>'Invalid data']); return; }
+    $stmt=$pdo->prepare('INSERT INTO lookup_list_items (user_id,user_updated,list_id,label,value,sort_order) VALUES (:uid,:uid,:list_id,:label,:value,:sort)');
+    $stmt->execute([':uid'=>$this_user_id,':list_id'=>$list_id,':label'=>$label,':value'=>$value,':sort'=>$sort]);
+    $id=$pdo->lastInsertId();
+    audit_log($pdo,$this_user_id,'lookup_list_items',$id,'CREATE','Created lookup list item');
+    echo json_encode(['success'=>true,'message'=>'Item created','item'=>['id'=>$id,'label'=>$label,'value'=>$value,'sort_order'=>$sort]]);
+  }elseif($action==='update'){
+    $id=(int)($_POST['id']??0);
+    $label=trim($_POST['label']??'');
+    $value=trim($_POST['value']??'');
+    $sort=(int)($_POST['sort_order']??0);
+    if($id<=0||$label===''){ echo json_encode(['success'=>false,'error'=>'Invalid data']); return; }
+    $stmt=$pdo->prepare('UPDATE lookup_list_items SET label=:label,value=:value,sort_order=:sort,user_updated=:uid WHERE id=:id');
+    $stmt->execute([':label'=>$label,':value'=>$value,':sort'=>$sort,':uid'=>$this_user_id,':id'=>$id]);
+    audit_log($pdo,$this_user_id,'lookup_list_items',$id,'UPDATE','Updated lookup list item');
+    echo json_encode(['success'=>true,'message'=>'Item updated','item'=>['id'=>$id,'label'=>$label,'value'=>$value,'sort_order'=>$sort]]);
+  }elseif($action==='delete'){
+    $id=(int)($_POST['id']??0);
+    if($id<=0){ echo json_encode(['success'=>false,'error'=>'Invalid ID']); return; }
+    $pdo->prepare('DELETE FROM lookup_list_items WHERE id=:id')->execute([':id'=>$id]);
+    audit_log($pdo,$this_user_id,'lookup_list_items',$id,'DELETE','Deleted lookup list item');
+    echo json_encode(['success'=>true,'message'=>'Item deleted']);
+  }else{
+    echo json_encode(['success'=>false,'error'=>'Invalid action']);
+  }
+}
+
+function handleAttr($action){
+  global $pdo,$this_user_id;
+  if(in_array($action,['create','update','delete'])){ verifyToken(); }
+  if($action==='list'){
+    $item_id=(int)($_GET['item_id']??0);
+    $stmt=$pdo->prepare('SELECT id,attr_key,attr_value FROM lookup_list_item_attributes WHERE item_id=:item_id');
+    $stmt->execute([':item_id'=>$item_id]);
+    $attrs=$stmt->fetchAll(PDO::FETCH_ASSOC);
+    echo json_encode(['success'=>true,'attrs'=>$attrs]);
+  }elseif($action==='create'){
+    $item_id=(int)($_POST['item_id']??0);
+    $key=trim($_POST['attr_key']??'');
+    $value=trim($_POST['attr_value']??'');
+    if($item_id<=0||$key===''){ echo json_encode(['success'=>false,'error'=>'Invalid data']); return; }
+    $stmt=$pdo->prepare('INSERT INTO lookup_list_item_attributes (user_id,user_updated,item_id,attr_key,attr_value) VALUES (:uid,:uid,:item_id,:k,:v)');
+    $stmt->execute([':uid'=>$this_user_id,':item_id'=>$item_id,':k'=>$key,':v'=>$value]);
+    $id=$pdo->lastInsertId();
+    audit_log($pdo,$this_user_id,'lookup_list_item_attributes',$id,'CREATE','Created item attribute');
+    echo json_encode(['success'=>true,'message'=>'Attribute created','attr'=>['id'=>$id,'attr_key'=>$key,'attr_value'=>$value]]);
+  }elseif($action==='update'){
+    $id=(int)($_POST['id']??0);
+    $key=trim($_POST['attr_key']??'');
+    $value=trim($_POST['attr_value']??'');
+    if($id<=0||$key===''){ echo json_encode(['success'=>false,'error'=>'Invalid data']); return; }
+    $stmt=$pdo->prepare('UPDATE lookup_list_item_attributes SET attr_key=:k, attr_value=:v, user_updated=:uid WHERE id=:id');
+    $stmt->execute([':k'=>$key,':v'=>$value,':uid'=>$this_user_id,':id'=>$id]);
+    audit_log($pdo,$this_user_id,'lookup_list_item_attributes',$id,'UPDATE','Updated item attribute');
+    echo json_encode(['success'=>true,'message'=>'Attribute updated','attr'=>['id'=>$id,'attr_key'=>$key,'attr_value'=>$value]]);
+  }elseif($action==='delete'){
+    $id=(int)($_POST['id']??0);
+    if($id<=0){ echo json_encode(['success'=>false,'error'=>'Invalid ID']); return; }
+    $pdo->prepare('DELETE FROM lookup_list_item_attributes WHERE id=:id')->execute([':id'=>$id]);
+    audit_log($pdo,$this_user_id,'lookup_list_item_attributes',$id,'DELETE','Deleted item attribute');
+    echo json_encode(['success'=>true,'message'=>'Attribute deleted']);
+  }else{
+    echo json_encode(['success'=>false,'error'=>'Invalid action']);
+  }
+}

--- a/admin/lookup-lists/index.php
+++ b/admin/lookup-lists/index.php
@@ -3,25 +3,11 @@ require '../admin_header.php';
 
 $token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
 $_SESSION['csrf_token'] = $token;
-$message = '';
-
-if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete_id'])) {
-  if (!hash_equals($token, $_POST['csrf_token'] ?? '')) {
-    die('Invalid CSRF token');
-  }
-  $delId = (int)$_POST['delete_id'];
-  $stmt = $pdo->prepare('DELETE FROM lookup_lists WHERE id = :id');
-  $stmt->execute([':id' => $delId]);
-  audit_log($pdo, $this_user_id, 'lookup_lists', $delId, 'DELETE', 'Deleted lookup list');
-  $message = 'Lookup list deleted.';
-}
-
-$stmt = $pdo->query('SELECT id, name, description FROM lookup_lists ORDER BY name');
+$stmt = $pdo->query('SELECT id, name, description, memo FROM lookup_lists ORDER BY name');
 $lists = $stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <h2 class="mb-4">Lookup Lists</h2>
-<?php if($message){ echo '<div class="alert alert-success">'.htmlspecialchars($message).'</div>'; } ?>
-<a href="edit.php" class="btn btn-sm btn-success mb-3">Add Lookup List</a>
+<button id="addListBtn" class="btn btn-sm btn-success mb-3">Add Lookup List</button>
 <div id="lookup-lists" data-list='{"valueNames":["id","name","description"],"page":10,"pagination":true}'>
   <div class="row justify-content-between g-2 mb-3">
     <div class="col-auto">
@@ -40,18 +26,14 @@ $lists = $stmt->fetchAll(PDO::FETCH_ASSOC);
       </thead>
       <tbody class="list">
         <?php foreach($lists as $l): ?>
-          <tr>
+          <tr data-id="<?= htmlspecialchars($l['id']); ?>">
             <td class="id"><?= htmlspecialchars($l['id']); ?></td>
             <td class="name"><?= htmlspecialchars($l['name']); ?></td>
             <td class="description"><?= htmlspecialchars($l['description']); ?></td>
             <td>
-              <a class="btn btn-sm btn-warning" href="edit.php?id=<?= $l['id']; ?>">Edit</a>
-              <a class="btn btn-sm btn-info" href="items.php?list_id=<?= $l['id']; ?>">Items</a>
-              <form method="post" class="d-inline">
-                <input type="hidden" name="delete_id" value="<?= $l['id']; ?>">
-                <input type="hidden" name="csrf_token" value="<?= $token; ?>">
-                <button class="btn btn-sm btn-danger" onclick="return confirm('Delete this list?');">Delete</button>
-              </form>
+              <button class="btn btn-sm btn-warning edit-list" data-id="<?= $l['id']; ?>" data-name="<?= htmlspecialchars($l['name'], ENT_QUOTES); ?>" data-description="<?= htmlspecialchars($l['description'], ENT_QUOTES); ?>" data-memo="<?= htmlspecialchars($l['memo'], ENT_QUOTES); ?>">Edit</button>
+              <button class="btn btn-sm btn-info items-list" data-id="<?= $l['id']; ?>" data-name="<?= htmlspecialchars($l['name'], ENT_QUOTES); ?>">Items</button>
+              <button class="btn btn-sm btn-danger delete-list" data-id="<?= $l['id']; ?>">Delete</button>
             </td>
           </tr>
         <?php endforeach; ?>
@@ -63,4 +45,311 @@ $lists = $stmt->fetchAll(PDO::FETCH_ASSOC);
     <ul class="pagination mb-0"></ul>
   </div>
 </div>
+<div class="modal fade" id="listModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <form class="modal-content" id="listForm">
+      <div class="modal-header">
+        <h5 class="modal-title" id="listModalLabel">Add Lookup List</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div id="listAlert"></div>
+        <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+        <input type="hidden" name="id" id="list-id">
+        <div class="mb-3">
+          <label class="form-label">Name</label>
+          <input type="text" class="form-control" name="name" id="list-name" required>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Description</label>
+          <textarea class="form-control" name="description" id="list-description"></textarea>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Memo</label>
+          <textarea class="form-control" name="memo" id="list-memo"></textarea>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+        <button type="submit" class="btn btn-primary" id="listSaveBtn">
+          <span class="spinner-border spinner-border-sm d-none" id="listLoading"></span>
+          Save
+        </button>
+      </div>
+    </form>
+  </div>
+</div>
+<div class="modal fade" id="itemModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="itemModalLabel">Items</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div id="itemAlert"></div>
+        <form id="itemForm" class="row g-2 mb-3">
+          <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+          <input type="hidden" name="list_id" id="item-list-id">
+          <input type="hidden" name="id" id="item-id">
+          <div class="col-md-4"><input class="form-control" name="label" id="item-label" placeholder="Label" required></div>
+          <div class="col-md-4"><input class="form-control" name="value" id="item-value" placeholder="Value"></div>
+          <div class="col-md-2"><input class="form-control" type="number" name="sort_order" id="item-sort" placeholder="Sort"></div>
+          <div class="col-md-2">
+            <button class="btn btn-primary w-100" type="submit" id="itemSaveBtn">
+              <span class="spinner-border spinner-border-sm d-none" id="itemLoading"></span>
+              Save
+            </button>
+          </div>
+        </form>
+        <table class="table table-striped table-sm" id="itemsTable">
+          <thead><tr><th>Label</th><th>Value</th><th>Sort</th><th>Attributes</th><th>Actions</th></tr></thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="modal fade" id="attrModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="attrModalLabel">Attributes</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div id="attrAlert"></div>
+        <form id="attrForm" class="row g-2 mb-3">
+          <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+          <input type="hidden" name="item_id" id="attr-item-id">
+          <input type="hidden" name="id" id="attr-id">
+          <div class="col-md-4"><input class="form-control" name="attr_key" id="attr-key" placeholder="Key" required></div>
+          <div class="col-md-4"><input class="form-control" name="attr_value" id="attr-value" placeholder="Value"></div>
+          <div class="col-md-4">
+            <button class="btn btn-primary w-100" type="submit" id="attrSaveBtn">
+              <span class="spinner-border spinner-border-sm d-none" id="attrLoading"></span>
+              Save
+            </button>
+          </div>
+        </form>
+        <table class="table table-striped table-sm" id="attrsTable">
+          <thead><tr><th>Key</th><th>Value</th><th>Actions</th></tr></thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script>
+$(function(){
+  var csrfToken = '<?= $token; ?>';
+  var listModal = new bootstrap.Modal(document.getElementById('listModal'));
+  var itemModal = new bootstrap.Modal(document.getElementById('itemModal'));
+  var attrModal = new bootstrap.Modal(document.getElementById('attrModal'));
+
+  $('#addListBtn').on('click', function(){
+    $('#listForm')[0].reset();
+    $('#list-id').val('');
+    $('#listModalLabel').text('Add Lookup List');
+    $('#listAlert').html('');
+    listModal.show();
+  });
+
+  $('#lookup-lists').on('click', '.edit-list', function(){
+    var btn = $(this);
+    $('#list-id').val(btn.data('id'));
+    $('#list-name').val(btn.data('name'));
+    $('#list-description').val(btn.data('description'));
+    $('#list-memo').val(btn.data('memo'));
+    $('#listModalLabel').text('Edit Lookup List');
+    $('#listAlert').html('');
+    listModal.show();
+  });
+
+    $('#listForm').on('submit', function(e){
+      e.preventDefault();
+      $('#listLoading').removeClass('d-none');
+      var action = $('#list-id').val() ? 'update' : 'create';
+      var memoVal = $('#list-memo').val();
+      $.post('../api/lookup-lists.php', $(this).serialize() + '&entity=list&action=' + action, function(res){
+        $('#listLoading').addClass('d-none');
+        if(res.success){
+          $('#listAlert').html('<div class="alert alert-success">'+res.message+'</div>');
+          var l = res.list;
+          var row = $('#lookup-lists tbody tr').filter(function(){ return $(this).data('id') == l.id; });
+          if(row.length){
+            row.find('.name').text(l.name);
+            row.find('.description').text(l.description);
+            row.find('.edit-list').data('name', l.name).data('description', l.description).data('memo', memoVal);
+          }else{
+            var html = '<tr data-id="'+l.id+'">'
+              +'<td class="id">'+l.id+'</td>'
+              +'<td class="name">'+l.name+'</td>'
+              +'<td class="description">'+l.description+'</td>'
+              +'<td>'
+              +'<button class="btn btn-sm btn-warning edit-list" data-id="'+l.id+'" data-name="'+l.name+'" data-description="'+l.description+'">Edit</button> '
+              +'<button class="btn btn-sm btn-info items-list" data-id="'+l.id+'" data-name="'+l.name+'">Items</button> '
+              +'<button class="btn btn-sm btn-danger delete-list" data-id="'+l.id+'">Delete</button>'
+              +'</td></tr>';
+            var $new = $(html);
+            $new.find('.edit-list').data('memo', memoVal);
+            $('#lookup-lists tbody').append($new);
+          }
+        }else{
+          $('#listAlert').html('<div class="alert alert-danger">'+res.error+'</div>');
+        }
+      }, 'json').fail(function(){
+        $('#listLoading').addClass('d-none');
+        $('#listAlert').html('<div class="alert alert-danger">Server error.</div>');
+      });
+    });
+
+  $('#lookup-lists').on('click', '.delete-list', function(){
+    if(!confirm('Delete this list?')) return;
+    var row = $(this).closest('tr');
+    var id = $(this).data('id');
+    $.post('../api/lookup-lists.php', {entity:'list', action:'delete', id:id, csrf_token:csrfToken}, function(res){
+      if(res.success){
+        row.remove();
+      }else{
+        alert(res.error);
+      }
+    }, 'json');
+  });
+
+  $('#lookup-lists').on('click', '.items-list', function(){
+    var btn = $(this);
+    var listId = btn.data('id');
+    $('#itemModalLabel').text('Items for ' + btn.data('name'));
+    $('#itemForm')[0].reset();
+    $('#item-list-id').val(listId);
+    $('#item-id').val('');
+    $('#itemAlert').html('');
+    loadItems(listId);
+    itemModal.show();
+  });
+
+  function loadItems(listId){
+    $('#itemsTable tbody').html('<tr><td colspan="5" class="text-center">Loading...</td></tr>');
+    $.getJSON('../api/lookup-lists.php', {entity:'item', action:'list', list_id:listId}, function(res){
+      if(res.success){
+        var rows='';
+        $.each(res.items, function(i,it){
+          rows+='<tr data-id="'+it.id+'"><td class="label">'+it.label+'</td><td class="value">'+it.value+'</td><td class="sort_order">'+it.sort_order+'</td><td><button class="btn btn-sm btn-secondary attributes-item">Attributes</button></td><td><button class="btn btn-sm btn-warning edit-item">Edit</button> <button class="btn btn-sm btn-danger delete-item">Delete</button></td></tr>';
+        });
+        $('#itemsTable tbody').html(rows);
+      }else{
+        $('#itemsTable tbody').html('<tr><td colspan="5" class="text-center">'+res.error+'</td></tr>');
+      }
+    });
+  }
+
+  $('#itemForm').on('submit', function(e){
+    e.preventDefault();
+    $('#itemLoading').removeClass('d-none');
+    var action = $('#item-id').val() ? 'update':'create';
+    $.post('../api/lookup-lists.php', $(this).serialize() + '&entity=item&action='+action, function(res){
+      $('#itemLoading').addClass('d-none');
+      if(res.success){
+        $('#itemAlert').html('<div class="alert alert-success">'+res.message+'</div>');
+        $('#itemForm')[0].reset();
+        loadItems($('#item-list-id').val());
+      }else{
+        $('#itemAlert').html('<div class="alert alert-danger">'+res.error+'</div>');
+      }
+    }, 'json').fail(function(){
+      $('#itemLoading').addClass('d-none');
+      $('#itemAlert').html('<div class="alert alert-danger">Server error.</div>');
+    });
+  });
+
+  $('#itemsTable').on('click', '.edit-item', function(){
+    var tr = $(this).closest('tr');
+    $('#item-id').val(tr.data('id'));
+    $('#item-label').val(tr.find('.label').text());
+    $('#item-value').val(tr.find('.value').text());
+    $('#item-sort').val(tr.find('.sort_order').text());
+  });
+
+  $('#itemsTable').on('click', '.delete-item', function(){
+    if(!confirm('Delete item?')) return;
+    var tr = $(this).closest('tr');
+    var id = tr.data('id');
+    $.post('../api/lookup-lists.php', {entity:'item', action:'delete', id:id, csrf_token:csrfToken}, function(res){
+      if(res.success){
+        tr.remove();
+      }else{
+        alert(res.error);
+      }
+    }, 'json');
+  });
+
+  $('#itemsTable').on('click', '.attributes-item', function(){
+    var tr = $(this).closest('tr');
+    var itemId = tr.data('id');
+    $('#attrModalLabel').text('Attributes for ' + tr.find('.label').text());
+    $('#attrForm')[0].reset();
+    $('#attr-item-id').val(itemId);
+    $('#attr-id').val('');
+    $('#attrAlert').html('');
+    loadAttrs(itemId);
+    attrModal.show();
+  });
+
+  function loadAttrs(itemId){
+    $('#attrsTable tbody').html('<tr><td colspan="3" class="text-center">Loading...</td></tr>');
+    $.getJSON('../api/lookup-lists.php', {entity:'attribute', action:'list', item_id:itemId}, function(res){
+      if(res.success){
+        var rows='';
+        $.each(res.attrs, function(i,a){
+          rows+='<tr data-id="'+a.id+'"><td class="attr_key">'+a.attr_key+'</td><td class="attr_value">'+a.attr_value+'</td><td><button class="btn btn-sm btn-warning edit-attr">Edit</button> <button class="btn btn-sm btn-danger delete-attr">Delete</button></td></tr>';
+        });
+        $('#attrsTable tbody').html(rows);
+      }else{
+        $('#attrsTable tbody').html('<tr><td colspan="3" class="text-center">'+res.error+'</td></tr>');
+      }
+    });
+  }
+
+  $('#attrForm').on('submit', function(e){
+    e.preventDefault();
+    $('#attrLoading').removeClass('d-none');
+    var action = $('#attr-id').val() ? 'update':'create';
+    $.post('../api/lookup-lists.php', $(this).serialize() + '&entity=attribute&action='+action, function(res){
+      $('#attrLoading').addClass('d-none');
+      if(res.success){
+        $('#attrAlert').html('<div class="alert alert-success">'+res.message+'</div>');
+        $('#attrForm')[0].reset();
+        loadAttrs($('#attr-item-id').val());
+      }else{
+        $('#attrAlert').html('<div class="alert alert-danger">'+res.error+'</div>');
+      }
+    }, 'json').fail(function(){
+      $('#attrLoading').addClass('d-none');
+      $('#attrAlert').html('<div class="alert alert-danger">Server error.</div>');
+    });
+  });
+
+  $('#attrsTable').on('click', '.edit-attr', function(){
+    var tr = $(this).closest('tr');
+    $('#attr-id').val(tr.data('id'));
+    $('#attr-key').val(tr.find('.attr_key').text());
+    $('#attr-value').val(tr.find('.attr_value').text());
+  });
+
+  $('#attrsTable').on('click', '.delete-attr', function(){
+    if(!confirm('Delete attribute?')) return;
+    var tr = $(this).closest('tr');
+    var id = tr.data('id');
+    $.post('../api/lookup-lists.php', {entity:'attribute', action:'delete', id:id, csrf_token:csrfToken}, function(res){
+      if(res.success){
+        tr.remove();
+      }else{
+        alert(res.error);
+      }
+    }, 'json');
+  });
+});
+</script>
 <?php require '../admin_footer.php'; ?>


### PR DESCRIPTION
## Summary
- Add Bootstrap modals for managing lookup lists, items, and attributes
- Provide jQuery-driven AJAX forms with in-place table updates
- Expose JSON CRUD endpoints for lookup lists, items, and attributes

## Testing
- `php -l admin/lookup-lists/index.php`
- `php -l admin/api/lookup-lists.php`


------
https://chatgpt.com/codex/tasks/task_e_68943b71b7f88333acb0b27b5c31ec5c