### PR TITLE
Centralize CSRF token and flash messaging helpers

### DIFF
--- a/admin/admin_header.php
+++ b/admin/admin_header.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__ . '/../includes/admin_guard.php';
 require_once __DIR__ . '/../includes/html_header.php';
+require_once __DIR__ . '/../includes/helpers.php';
 ?>
 <main class="main" id="top">
   <?php require __DIR__ . '/left_navigation.php'; ?>

--- a/admin/lookup-lists/edit.php
+++ b/admin/lookup-lists/edit.php
@@ -1,8 +1,7 @@
 <?php
 require '../admin_header.php';
 
-$token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
-$_SESSION['csrf_token'] = $token;
+$token = generate_csrf_token();
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 $name = $description = $memo = '';
 $message = $error = '';
@@ -19,9 +18,7 @@ if ($id) {
 }
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-  if (!hash_equals($token, $_POST['csrf_token'] ?? '')) {
-    die('Invalid CSRF token');
-  }
+  verify_csrf_token($_POST['csrf_token'] ?? '');
   $name = trim($_POST['name'] ?? '');
   $description = trim($_POST['description'] ?? '');
   $memo = trim($_POST['memo'] ?? '');
@@ -45,8 +42,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 ?>
 <h2 class="mb-4"><?= $id ? 'Edit' : 'Add'; ?> Lookup List</h2>
-<?php if($error){ echo '<div class="alert alert-danger">'.htmlspecialchars($error).'</div>'; } ?>
-<?php if($message){ echo '<div class="alert alert-success">'.htmlspecialchars($message).'</div>'; } ?>
+<?php flash_message('danger', $error); ?>
+<?php flash_message('success', $message); ?>
 <form method="post">
   <input type="hidden" name="csrf_token" value="<?= $token; ?>">
   <div class="mb-3">

--- a/admin/lookup-lists/index.php
+++ b/admin/lookup-lists/index.php
@@ -1,14 +1,11 @@
 <?php
 require '../admin_header.php';
 
-$token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
-$_SESSION['csrf_token'] = $token;
+$token = generate_csrf_token();
 $message = '';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete_id'])) {
-  if (!hash_equals($token, $_POST['csrf_token'] ?? '')) {
-    die('Invalid CSRF token');
-  }
+  verify_csrf_token($_POST['csrf_token'] ?? '');
   $delId = (int)$_POST['delete_id'];
   $stmt = $pdo->prepare('DELETE FROM lookup_lists WHERE id = :id');
   $stmt->execute([':id' => $delId]);
@@ -20,7 +17,7 @@ $stmt = $pdo->query('SELECT id, name, description FROM lookup_lists ORDER BY nam
 $lists = $stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <h2 class="mb-4">Lookup Lists</h2>
-<?php if($message){ echo '<div class="alert alert-success">'.htmlspecialchars($message).'</div>'; } ?>
+<?php flash_message('success', $message); ?>
 <a href="edit.php" class="btn btn-sm btn-success mb-3">Add Lookup List</a>
 <div id="lookup-lists" data-list='{"valueNames":["id","name","description"],"page":10,"pagination":true}'>
   <div class="row justify-content-between g-2 mb-3">

--- a/admin/lookup-lists/items.php
+++ b/admin/lookup-lists/items.php
@@ -1,8 +1,7 @@
 <?php
 require '../admin_header.php';
 
-$token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
-$_SESSION['csrf_token'] = $token;
+$token = generate_csrf_token();
 $list_id = (int)($_GET['list_id'] ?? 0);
 $message = $error = '';
 
@@ -10,13 +9,13 @@ $stmt = $pdo->prepare('SELECT * FROM lookup_lists WHERE id=:id');
 $stmt->execute([':id'=>$list_id]);
 $list = $stmt->fetch(PDO::FETCH_ASSOC);
 if(!$list){
-  echo '<div class="alert alert-danger">Lookup list not found.</div>';
+  flash_message('danger', 'Lookup list not found.');
   require '../admin_footer.php';
   exit;
 }
 
 if($_SERVER['REQUEST_METHOD']==='POST'){
-  if(!hash_equals($token, $_POST['csrf_token'] ?? '')){ die('Invalid CSRF token'); }
+  verify_csrf_token($_POST['csrf_token'] ?? '');
   if(isset($_POST['delete_id'])){
     $delId=(int)$_POST['delete_id'];
     $pdo->prepare('DELETE FROM lookup_list_items WHERE id=:id')->execute([':id'=>$delId]);
@@ -50,8 +49,8 @@ $stmt->execute([':list_id'=>$list_id]);
 $items=$stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <h2 class="mb-4">Items for <?= htmlspecialchars($list['name']); ?></h2>
-<?php if($error){ echo '<div class="alert alert-danger">'.htmlspecialchars($error).'</div>'; } ?>
-<?php if($message){ echo '<div class="alert alert-success">'.htmlspecialchars($message).'</div>'; } ?>
+<?php flash_message('danger', $error); ?>
+<?php flash_message('success', $message); ?>
 <form method="post" class="row g-2 mb-3">
   <input type="hidden" name="csrf_token" value="<?= $token; ?>">
   <input type="hidden" name="id" value="<?= htmlspecialchars($_POST['id'] ?? ''); ?>">

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -1,0 +1,22 @@
+<?php
+
+function generate_csrf_token(){
+  $token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
+  $_SESSION['csrf_token'] = $token;
+  return $token;
+}
+
+function verify_csrf_token($token){
+  if(!hash_equals($_SESSION['csrf_token'] ?? '', $token ?? '')){
+    die('Invalid CSRF token');
+  }
+  return true;
+}
+
+function flash_message($type, $message){
+  if($message){
+    echo '<div class="alert alert-' . htmlspecialchars($type) . '">' . htmlspecialchars($message) . '</div>';
+  }
+}
+
+?>


### PR DESCRIPTION
## Summary
- add reusable `generate_csrf_token()`, `verify_csrf_token()`, and `flash_message()` helpers
- load helpers in `admin_header.php`
- refactor lookup list module pages to use new CSRF and flash helpers

## Testing
- `php -l includes/helpers.php`
- `php -l admin/admin_header.php`
- `php -l admin/lookup-lists/index.php`
- `php -l admin/lookup-lists/edit.php`
- `php -l admin/lookup-lists/attributes.php`
- `php -l admin/lookup-lists/items.php`


------
https://chatgpt.com/codex/tasks/task_e_68943b6dfb2c8333a09288c690787cb0