### PR TITLE
Split user admin form for create and edit

### DIFF
--- a/admin/users/edit.php
+++ b/admin/users/edit.php
@@ -1,4 +1,5 @@
 <?php
+if (!defined('IN_APP')) { define('IN_APP', true); }
 require '../admin_header.php';
 require_permission('users','update');
 
@@ -116,6 +117,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <h2 class="mb-4">Edit User</h2>
 <?php if($error){ echo '<div class="alert alert-danger">'.htmlspecialchars($error).'</div>'; } ?>
 <?php if($message){ echo '<div class="alert alert-success">'.htmlspecialchars($message).'</div>'; } ?>
-<?php include '_form.php'; ?>
+<?php include 'form_edit.php'; ?>
 <?php require '../admin_footer.php'; ?>
 

--- a/admin/users/form_edit.php
+++ b/admin/users/form_edit.php
@@ -1,9 +1,11 @@
 <?php
-// Shared form for creating and editing users.
-// Expects lookup arrays ($roles, $typeOptions, $statusOptions) and
-// the following variables to be defined by the caller:
-// $token, $id, $username, $email, $first_name, $last_name,
+// Edit user form. Expects lookup arrays ($roles, $typeOptions, $statusOptions) and
+// variables: $token, $id, $username, $email, $first_name, $last_name,
 // $type, $status, $btnClass, $assigned (array of role ids)
+
+if (!defined('IN_APP')) {
+    exit('No direct script access allowed');
+}
 ?>
 <form method="post">
   <input type="hidden" name="csrf_token" value="<?= $token; ?>">
@@ -16,8 +18,8 @@
     <input type="email" class="form-control" name="email" value="<?= htmlspecialchars($email); ?>" required>
   </div>
   <div class="mb-3">
-    <label class="form-label">Password <?= $id ? '(leave blank to keep current)' : ''; ?></label>
-    <input type="password" class="form-control" name="password" <?= $id ? '' : 'required'; ?>>
+    <label class="form-label">Password (leave blank to keep current)</label>
+    <input type="password" class="form-control" name="password">
   </div>
   <div class="mb-3">
     <label class="form-label">First Name</label>

--- a/admin/users/form_new.php
+++ b/admin/users/form_new.php
@@ -1,0 +1,59 @@
+<?php
+// New user form. Expects lookup arrays ($roles, $typeOptions, $statusOptions) and
+// variables: $token, $username, $email, $first_name, $last_name,
+// $type, $status, $btnClass, $assigned (array of role ids)
+
+if (!defined('IN_APP')) {
+    exit('No direct script access allowed');
+}
+?>
+<form method="post">
+  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+  <div class="mb-3">
+    <label class="form-label">Username</label>
+    <input type="text" class="form-control" name="username" value="<?= htmlspecialchars($username); ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Email</label>
+    <input type="email" class="form-control" name="email" value="<?= htmlspecialchars($email); ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Password</label>
+    <input type="password" class="form-control" name="password" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">First Name</label>
+    <input type="text" class="form-control" name="first_name" value="<?= htmlspecialchars($first_name); ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Last Name</label>
+    <input type="text" class="form-control" name="last_name" value="<?= htmlspecialchars($last_name); ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Type</label>
+    <select class="form-select" name="type">
+      <?php foreach($typeOptions as $value => $label): ?>
+        <option value="<?= htmlspecialchars($value); ?>" <?= $type === $value ? 'selected' : ''; ?>><?= htmlspecialchars($label); ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Status</label>
+    <select class="form-select" name="status">
+      <?php foreach($statusOptions as $value => $label): ?>
+        <option value="<?= htmlspecialchars($value); ?>" <?= (string)$status === $value ? 'selected' : ''; ?>><?= htmlspecialchars($label); ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Roles</label>
+    <?php foreach($roles as $r): ?>
+      <div class="form-check">
+        <input class="form-check-input" type="checkbox" name="roles[]" value="<?= $r['id']; ?>" id="role<?= $r['id']; ?>" <?= in_array($r['id'], $assigned) ? 'checked' : ''; ?>>
+        <label class="form-check-label" for="role<?= $r['id']; ?>"><?= htmlspecialchars($r['name']); ?></label>
+      </div>
+    <?php endforeach; ?>
+  </div>
+  <button class="btn <?= $btnClass; ?>" type="submit">Save</button>
+  <a href="index.php" class="btn btn-secondary">Back</a>
+</form>

--- a/admin/users/new.php
+++ b/admin/users/new.php
@@ -1,4 +1,5 @@
 <?php
+if (!defined('IN_APP')) { define('IN_APP', true); }
 require '../admin_header.php';
 require_permission('users','create');
 
@@ -89,5 +90,5 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <h2 class="mb-4">Add User</h2>
 <?php if($error){ echo '<div class="alert alert-danger">'.htmlspecialchars($error).'</div>'; } ?>
 <?php if($message){ echo '<div class="alert alert-success">'.htmlspecialchars($message).'</div>'; } ?>
-<?php include '_form.php'; ?>
+<?php include 'form_new.php'; ?>
 <?php require '../admin_footer.php'; ?>


### PR DESCRIPTION
## Summary
- Separate user creation and editing into dedicated `form_new.php` and `form_edit.php`
- Enforce password entry on new users while making it optional on edit
- Guard form files from direct access and switch controllers to new forms

## Testing
- `php -l admin/users/form_new.php`
- `php -l admin/users/form_edit.php`
- `php -l admin/users/new.php`
- `php -l admin/users/edit.php`


------
https://chatgpt.com/codex/tasks/task_e_68943c50a6988333bbc4d91bee5a9aee