### PR TITLE
Add Orgs admin module with RBAC roles

### DIFF
--- a/_SQL/atlis.sql
+++ b/_SQL/atlis.sql
@@ -81,7 +81,15 @@ INSERT INTO `admin_permissions` (`id`, `user_id`, `user_updated`, `date_created`
 (13, NULL, NULL, '2025-08-06 21:16:21', '2025-08-06 21:16:21', NULL, 'roles', 'create'),
 (14, NULL, NULL, '2025-08-06 21:16:21', '2025-08-06 21:16:21', NULL, 'roles', 'read'),
 (15, NULL, NULL, '2025-08-06 21:16:21', '2025-08-06 21:16:21', NULL, 'roles', 'update'),
-(16, NULL, NULL, '2025-08-06 21:16:21', '2025-08-06 21:16:21', NULL, 'roles', 'delete');
+(16, NULL, NULL, '2025-08-06 21:16:21', '2025-08-06 21:16:21', NULL, 'roles', 'delete'),
+(17, NULL, NULL, '2025-08-06 21:16:21', '2025-08-06 21:16:21', NULL, 'organization', 'create'),
+(18, NULL, NULL, '2025-08-06 21:16:21', '2025-08-06 21:16:21', NULL, 'organization', 'read'),
+(19, NULL, NULL, '2025-08-06 21:16:21', '2025-08-06 21:16:21', NULL, 'organization', 'update'),
+(20, NULL, NULL, '2025-08-06 21:16:21', '2025-08-06 21:16:21', NULL, 'organization', 'delete'),
+(21, NULL, NULL, '2025-08-06 21:16:21', '2025-08-06 21:16:21', NULL, 'division', 'create'),
+(22, NULL, NULL, '2025-08-06 21:16:21', '2025-08-06 21:16:21', NULL, 'division', 'read'),
+(23, NULL, NULL, '2025-08-06 21:16:21', '2025-08-06 21:16:21', NULL, 'division', 'update'),
+(24, NULL, NULL, '2025-08-06 21:16:21', '2025-08-06 21:16:21', NULL, 'division', 'delete');
 
 -- --------------------------------------------------------
 
@@ -107,7 +115,9 @@ CREATE TABLE `admin_roles` (
 INSERT INTO `admin_roles` (`id`, `user_id`, `user_updated`, `date_created`, `date_updated`, `memo`, `name`, `description`) VALUES
 (1, NULL, NULL, '2025-08-06 16:07:43', '2025-08-06 16:07:43', NULL, 'Admin', 'System administrator with full permissions'),
 (2, NULL, NULL, '2025-08-06 16:07:59', '2025-08-06 16:07:59', NULL, 'Manage Person', 'Can manage person records'),
-(3, NULL, NULL, '2025-08-06 19:39:18', '2025-08-06 19:39:18', NULL, 'Manage Agency', 'Can manage agency records');
+(3, NULL, NULL, '2025-08-06 19:39:18', '2025-08-06 19:39:18', NULL, 'Manage Agency', 'Can manage agency records'),
+(4, NULL, NULL, '2025-08-06 21:16:21', '2025-08-06 21:16:21', NULL, 'Manage Organization', 'Can manage organization records'),
+(5, NULL, NULL, '2025-08-06 21:16:21', '2025-08-06 21:16:21', NULL, 'Manage Division', 'Can manage division records');
 
 -- --------------------------------------------------------
 
@@ -152,7 +162,23 @@ INSERT INTO `admin_role_permissions` (`id`, `user_id`, `user_updated`, `date_cre
 (28, NULL, NULL, '2025-08-06 21:16:21', '2025-08-06 21:16:21', NULL, 1, 13),
 (29, NULL, NULL, '2025-08-06 21:16:21', '2025-08-06 21:16:21', NULL, 1, 16),
 (30, NULL, NULL, '2025-08-06 21:16:21', '2025-08-06 21:16:21', NULL, 1, 14),
-(31, NULL, NULL, '2025-08-06 21:16:21', '2025-08-06 21:16:21', NULL, 1, 15);
+(31, NULL, NULL, '2025-08-06 21:16:21', '2025-08-06 21:16:21', NULL, 1, 15),
+(32, NULL, NULL, '2025-08-06 21:16:21', '2025-08-06 21:16:21', NULL, 1, 17),
+(33, NULL, NULL, '2025-08-06 21:16:21', '2025-08-06 21:16:21', NULL, 1, 20),
+(34, NULL, NULL, '2025-08-06 21:16:21', '2025-08-06 21:16:21', NULL, 1, 18),
+(35, NULL, NULL, '2025-08-06 21:16:21', '2025-08-06 21:16:21', NULL, 1, 19),
+(36, NULL, NULL, '2025-08-06 21:16:21', '2025-08-06 21:16:21', NULL, 1, 21),
+(37, NULL, NULL, '2025-08-06 21:16:21', '2025-08-06 21:16:21', NULL, 1, 24),
+(38, NULL, NULL, '2025-08-06 21:16:21', '2025-08-06 21:16:21', NULL, 1, 22),
+(39, NULL, NULL, '2025-08-06 21:16:21', '2025-08-06 21:16:21', NULL, 1, 23),
+(40, NULL, NULL, '2025-08-06 21:16:21', '2025-08-06 21:16:21', NULL, 4, 17),
+(41, NULL, NULL, '2025-08-06 21:16:21', '2025-08-06 21:16:21', NULL, 4, 20),
+(42, NULL, NULL, '2025-08-06 21:16:21', '2025-08-06 21:16:21', NULL, 4, 18),
+(43, NULL, NULL, '2025-08-06 21:16:21', '2025-08-06 21:16:21', NULL, 4, 19),
+(44, NULL, NULL, '2025-08-06 21:16:21', '2025-08-06 21:16:21', NULL, 5, 21),
+(45, NULL, NULL, '2025-08-06 21:16:21', '2025-08-06 21:16:21', NULL, 5, 24),
+(46, NULL, NULL, '2025-08-06 21:16:21', '2025-08-06 21:16:21', NULL, 5, 22),
+(47, NULL, NULL, '2025-08-06 21:16:21', '2025-08-06 21:16:21', NULL, 5, 23);
 
 -- --------------------------------------------------------
 

--- a/admin/admin_header.php
+++ b/admin/admin_header.php
@@ -4,5 +4,5 @@ require_once __DIR__ . '/../includes/html_header.php';
 ?>
 <main class="main" id="top">
   <?php require __DIR__ . '/left_navigation.php'; ?>
-  <?php require __DIR__ . '../../includes/navigation.php'; ?>
+  <?php require __DIR__ . '/../includes/navigation.php'; ?>
   <div id="main_content" class="content">

--- a/admin/orgs/agency_edit.php
+++ b/admin/orgs/agency_edit.php
@@ -1,0 +1,119 @@
+<?php
+require '../admin_header.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$organization_id = isset($_GET['organization_id']) ? (int)$_GET['organization_id'] : null;
+$name = '';
+$main_person = null;
+$status = null;
+$existing = null;
+$btnClass = $id ? 'btn-warning' : 'btn-success';
+
+if ($id) {
+  require_permission('agency','update');
+  $stmt = $pdo->prepare('SELECT organization_id, name, main_person, status FROM module_agency WHERE id = :id');
+  $stmt->execute([':id' => $id]);
+  $existing = $stmt->fetch(PDO::FETCH_ASSOC);
+  if ($existing) {
+    $organization_id = $existing['organization_id'];
+    $name = $existing['name'];
+    $main_person = $existing['main_person'];
+    $status = $existing['status'];
+  }
+} else {
+  require_permission('agency','create');
+}
+
+$token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
+$_SESSION['csrf_token'] = $token;
+
+$orgStmt = $pdo->query('SELECT id, name FROM module_organization ORDER BY name');
+$orgOptions = $orgStmt->fetchAll(PDO::FETCH_KEY_PAIR);
+
+$personStmt = $pdo->query('SELECT id, CONCAT(first_name, " ", last_name) AS name FROM person ORDER BY first_name, last_name');
+$personOptions = $personStmt->fetchAll(PDO::FETCH_KEY_PAIR);
+
+$statusStmt = $pdo->prepare("SELECT li.id, li.label FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'AGENCY_STATUS' ORDER BY li.sort_order, li.label");
+$statusStmt->execute();
+$statusOptions = $statusStmt->fetchAll(PDO::FETCH_KEY_PAIR);
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  if (!hash_equals($token, $_POST['csrf_token'] ?? '')) {
+    die('Invalid CSRF token');
+  }
+  $organization_id = $_POST['organization_id'] !== '' ? (int)$_POST['organization_id'] : null;
+  $name = trim($_POST['name'] ?? '');
+  $main_person = $_POST['main_person'] !== '' ? (int)$_POST['main_person'] : null;
+  $status = $_POST['status'] !== '' ? (int)$_POST['status'] : null;
+  if ($id) {
+    $stmt = $pdo->prepare('UPDATE module_agency SET organization_id=:organization_id, name=:name, main_person=:main_person, status=:status, user_updated=:uid WHERE id=:id');
+    $stmt->execute([':organization_id'=>$organization_id, ':name'=>$name, ':main_person'=>$main_person, ':status'=>$status, ':uid'=>$this_user_id, ':id'=>$id]);
+    admin_audit_log($pdo, $this_user_id, 'module_agency', $id, 'UPDATE', json_encode($existing), json_encode(['organization_id'=>$organization_id,'name'=>$name,'main_person'=>$main_person,'status'=>$status]), 'Updated agency');
+  } else {
+    $stmt = $pdo->prepare('INSERT INTO module_agency (organization_id, name, main_person, status, user_id, user_updated) VALUES (:organization_id, :name, :main_person, :status, :uid, :uid)');
+    $stmt->execute([':organization_id'=>$organization_id, ':name'=>$name, ':main_person'=>$main_person, ':status'=>$status, ':uid'=>$this_user_id]);
+    $id = $pdo->lastInsertId();
+    admin_audit_log($pdo, $this_user_id, 'module_agency', $id, 'CREATE', null, json_encode(['organization_id'=>$organization_id,'name'=>$name,'main_person'=>$main_person,'status'=>$status]), 'Created agency');
+  }
+
+  // handle file upload (max 5MB) saved to /module/agency/uploads/
+  if (!empty($_FILES['upload_file']['name'])) {
+    $maxSize = 5 * 1024 * 1024; // 5MB
+    if ($_FILES['upload_file']['size'] <= $maxSize && is_uploaded_file($_FILES['upload_file']['tmp_name'])) {
+      $ext = strtolower(pathinfo($_FILES['upload_file']['name'], PATHINFO_EXTENSION));
+      $uploadDir = __DIR__ . '/../../module/agency/uploads/';
+      if (!is_dir($uploadDir)) {
+        mkdir($uploadDir, 0775, true);
+      }
+      foreach (glob($uploadDir . 'agency_' . $id . '.*') as $old) {
+        @unlink($old);
+      }
+      $dest = $uploadDir . 'agency_' . $id . '.' . $ext;
+      move_uploaded_file($_FILES['upload_file']['tmp_name'], $dest);
+    }
+  }
+  header('Location: index.php');
+  exit;
+}
+?>
+<h2 class="mb-4"><?= $id ? 'Edit' : 'Add'; ?> Agency</h2>
+<form method="post" enctype="multipart/form-data">
+  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+  <div class="mb-3">
+    <label class="form-label">Organization</label>
+    <select name="organization_id" class="form-select" required>
+      <option value="">-- Select --</option>
+      <?php foreach($orgOptions as $oid => $oname): ?>
+        <option value="<?= $oid; ?>" <?= (int)$oid === (int)$organization_id ? 'selected' : ''; ?>><?= htmlspecialchars($oname); ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Name</label>
+    <input type="text" name="name" class="form-control" value="<?= htmlspecialchars($name); ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Main Person</label>
+    <select name="main_person" class="form-select">
+      <option value="">-- None --</option>
+      <?php foreach($personOptions as $pid => $pname): ?>
+        <option value="<?= $pid; ?>" <?= (int)$pid === (int)$main_person ? 'selected' : ''; ?>><?= htmlspecialchars($pname); ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Status</label>
+    <select name="status" class="form-select">
+      <?php foreach($statusOptions as $sid => $slabel): ?>
+        <option value="<?= $sid; ?>" <?= (int)$sid === (int)$status ? 'selected' : ''; ?>><?= htmlspecialchars($slabel); ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Upload File</label>
+    <input type="file" name="upload_file" class="form-control" accept="image/*,application/pdf">
+  </div>
+  <button class="btn <?= $btnClass; ?>" type="submit">Save</button>
+  <a href="index.php" class="btn btn-secondary">Cancel</a>
+</form>
+<?php require '../admin_footer.php'; ?>

--- a/admin/orgs/division_edit.php
+++ b/admin/orgs/division_edit.php
@@ -1,0 +1,98 @@
+<?php
+require '../admin_header.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$agency_id = isset($_GET['agency_id']) ? (int)$_GET['agency_id'] : null;
+$name = '';
+$main_person = null;
+$status = null;
+$existing = null;
+$btnClass = $id ? 'btn-warning' : 'btn-success';
+
+if ($id) {
+  require_permission('division','update');
+  $stmt = $pdo->prepare('SELECT agency_id, name, main_person, status FROM module_division WHERE id = :id');
+  $stmt->execute([':id' => $id]);
+  $existing = $stmt->fetch(PDO::FETCH_ASSOC);
+  if ($existing) {
+    $agency_id = $existing['agency_id'];
+    $name = $existing['name'];
+    $main_person = $existing['main_person'];
+    $status = $existing['status'];
+  }
+} else {
+  require_permission('division','create');
+}
+
+$token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
+$_SESSION['csrf_token'] = $token;
+
+$agencyStmt = $pdo->query('SELECT a.id, CONCAT(o.name, " - ", a.name) AS name FROM module_agency a JOIN module_organization o ON a.organization_id = o.id ORDER BY o.name, a.name');
+$agencyOptions = $agencyStmt->fetchAll(PDO::FETCH_KEY_PAIR);
+
+$personStmt = $pdo->query('SELECT id, CONCAT(first_name, " ", last_name) AS name FROM person ORDER BY first_name, last_name');
+$personOptions = $personStmt->fetchAll(PDO::FETCH_KEY_PAIR);
+
+$statusStmt = $pdo->prepare("SELECT li.id, li.label FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'DIVISION_STATUS' ORDER BY li.sort_order, li.label");
+$statusStmt->execute();
+$statusOptions = $statusStmt->fetchAll(PDO::FETCH_KEY_PAIR);
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  if (!hash_equals($token, $_POST['csrf_token'] ?? '')) {
+    die('Invalid CSRF token');
+  }
+  $agency_id = $_POST['agency_id'] !== '' ? (int)$_POST['agency_id'] : null;
+  $name = trim($_POST['name'] ?? '');
+  $main_person = $_POST['main_person'] !== '' ? (int)$_POST['main_person'] : null;
+  $status = $_POST['status'] !== '' ? (int)$_POST['status'] : null;
+  if ($id) {
+    $stmt = $pdo->prepare('UPDATE module_division SET agency_id=:agency_id, name=:name, main_person=:main_person, status=:status, user_updated=:uid WHERE id=:id');
+    $stmt->execute([':agency_id'=>$agency_id, ':name'=>$name, ':main_person'=>$main_person, ':status'=>$status, ':uid'=>$this_user_id, ':id'=>$id]);
+    admin_audit_log($pdo, $this_user_id, 'module_division', $id, 'UPDATE', json_encode($existing), json_encode(['agency_id'=>$agency_id,'name'=>$name,'main_person'=>$main_person,'status'=>$status]), 'Updated division');
+  } else {
+    $stmt = $pdo->prepare('INSERT INTO module_division (agency_id, name, main_person, status, user_id, user_updated) VALUES (:agency_id, :name, :main_person, :status, :uid, :uid)');
+    $stmt->execute([':agency_id'=>$agency_id, ':name'=>$name, ':main_person'=>$main_person, ':status'=>$status, ':uid'=>$this_user_id]);
+    $id = $pdo->lastInsertId();
+    admin_audit_log($pdo, $this_user_id, 'module_division', $id, 'CREATE', null, json_encode(['agency_id'=>$agency_id,'name'=>$name,'main_person'=>$main_person,'status'=>$status]), 'Created division');
+  }
+  header('Location: index.php');
+  exit;
+}
+?>
+<h2 class="mb-4"><?= $id ? 'Edit' : 'Add'; ?> Division</h2>
+<form method="post">
+  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+  <div class="mb-3">
+    <label class="form-label">Agency</label>
+    <select name="agency_id" class="form-select" required>
+      <option value="">-- Select --</option>
+      <?php foreach($agencyOptions as $aid => $aname): ?>
+        <option value="<?= $aid; ?>" <?= (int)$aid === (int)$agency_id ? 'selected' : ''; ?>><?= htmlspecialchars($aname); ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Name</label>
+    <input type="text" name="name" class="form-control" value="<?= htmlspecialchars($name); ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Main Person</label>
+    <select name="main_person" class="form-select">
+      <option value="">-- None --</option>
+      <?php foreach($personOptions as $pid => $pname): ?>
+        <option value="<?= $pid; ?>" <?= (int)$pid === (int)$main_person ? 'selected' : ''; ?>><?= htmlspecialchars($pname); ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Status</label>
+    <select name="status" class="form-select">
+      <?php foreach($statusOptions as $sid => $slabel): ?>
+        <option value="<?= $sid; ?>" <?= (int)$sid === (int)$status ? 'selected' : ''; ?>><?= htmlspecialchars($slabel); ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <button class="btn <?= $btnClass; ?>" type="submit">Save</button>
+  <a href="index.php" class="btn btn-secondary">Cancel</a>
+</form>
+<?php require '../admin_footer.php'; ?>

--- a/admin/orgs/index.php
+++ b/admin/orgs/index.php
@@ -1,0 +1,150 @@
+<?php
+require '../admin_header.php';
+require_permission('organization','read');
+
+$token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
+$_SESSION['csrf_token'] = $token;
+$message = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  if (!hash_equals($token, $_POST['csrf_token'] ?? '')) {
+    die('Invalid CSRF token');
+  }
+  if (isset($_POST['delete_organization_id'])) {
+    require_permission('organization','delete');
+    $id = (int)$_POST['delete_organization_id'];
+    $stmt = $pdo->prepare('DELETE FROM module_organization WHERE id = :id');
+    $stmt->execute([':id' => $id]);
+    audit_log($pdo, $this_user_id, 'module_organization', $id, 'DELETE', 'Deleted organization');
+    $message = 'Organization deleted.';
+  } elseif (isset($_POST['delete_agency_id'])) {
+    require_permission('agency','delete');
+    $id = (int)$_POST['delete_agency_id'];
+    $stmt = $pdo->prepare('DELETE FROM module_agency WHERE id = :id');
+    $stmt->execute([':id' => $id]);
+    audit_log($pdo, $this_user_id, 'module_agency', $id, 'DELETE', 'Deleted agency');
+    $message = 'Agency deleted.';
+  } elseif (isset($_POST['delete_division_id'])) {
+    require_permission('division','delete');
+    $id = (int)$_POST['delete_division_id'];
+    $stmt = $pdo->prepare('DELETE FROM module_division WHERE id = :id');
+    $stmt->execute([':id' => $id]);
+    audit_log($pdo, $this_user_id, 'module_division', $id, 'DELETE', 'Deleted division');
+    $message = 'Division deleted.';
+  }
+}
+
+$orgStatusStmt = $pdo->prepare("SELECT li.id, li.label, li.value FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'ORGANIZATION_STATUS'");
+$orgStatusStmt->execute();
+$orgStatuses = [];
+foreach ($orgStatusStmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+  $orgStatuses[$row['id']] = $row;
+}
+
+$agencyStatusStmt = $pdo->prepare("SELECT li.id, li.label, li.value FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'AGENCY_STATUS'");
+$agencyStatusStmt->execute();
+$agencyStatuses = [];
+foreach ($agencyStatusStmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+  $agencyStatuses[$row['id']] = $row;
+}
+
+$divisionStatusStmt = $pdo->prepare("SELECT li.id, li.label, li.value FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'DIVISION_STATUS'");
+$divisionStatusStmt->execute();
+$divisionStatuses = [];
+foreach ($divisionStatusStmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+  $divisionStatuses[$row['id']] = $row;
+}
+
+$orgStmt = $pdo->query('SELECT id, name, status FROM module_organization ORDER BY name');
+$organizations = $orgStmt->fetchAll(PDO::FETCH_ASSOC);
+?>
+<h2 class="mb-4">Organizations</h2>
+<?php if($message){ echo '<div class="alert alert-success">'.htmlspecialchars($message).'</div>'; } ?>
+<?php if (user_has_permission('organization','create')): ?>
+  <a href="organization_edit.php" class="btn btn-sm btn-success mb-3">Add Organization</a>
+<?php endif; ?>
+<div class="table-responsive">
+  <table class="table fs-9 mb-0 border-top border-translucent">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Status</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <?php foreach($organizations as $org): ?>
+        <tr>
+          <td><?= htmlspecialchars($org['name']); ?></td>
+          <td>
+            <?php $status = $orgStatuses[$org['status']] ?? null; $class = ($status['value'] ?? '') === 'active' ? 'badge-phoenix-success' : 'badge-phoenix-warning'; ?>
+            <span class="badge badge-phoenix fs-10 <?= $class; ?>"><span class="badge-label"><?= htmlspecialchars($status['label'] ?? ''); ?></span></span>
+          </td>
+          <td>
+            <a class="btn btn-sm btn-warning" href="organization_edit.php?id=<?= $org['id']; ?>">Edit</a>
+            <?php if (user_has_permission('organization','delete')): ?>
+              <form method="post" class="d-inline">
+                <input type="hidden" name="delete_organization_id" value="<?= $org['id']; ?>">
+                <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+                <button class="btn btn-sm btn-danger" onclick="return confirm('Delete this organization?');">Delete</button>
+              </form>
+            <?php endif; ?>
+            <?php if (user_has_permission('agency','create')): ?>
+              <a class="btn btn-sm btn-success" href="agency_edit.php?organization_id=<?= $org['id']; ?>">Add Agency</a>
+            <?php endif; ?>
+          </td>
+        </tr>
+        <?php
+          $agencyStmt = $pdo->prepare('SELECT id, name, status FROM module_agency WHERE organization_id = :oid ORDER BY name');
+          $agencyStmt->execute([':oid' => $org['id']]);
+          $agencies = $agencyStmt->fetchAll(PDO::FETCH_ASSOC);
+          foreach($agencies as $agency): ?>
+          <tr class="bg-body-tertiary">
+            <td class="ps-4">Agency: <?= htmlspecialchars($agency['name']); ?></td>
+            <td>
+              <?php $aStatus = $agencyStatuses[$agency['status']] ?? null; $aClass = ($aStatus['value'] ?? '') === 'active' ? 'badge-phoenix-success' : 'badge-phoenix-warning'; ?>
+              <span class="badge badge-phoenix fs-10 <?= $aClass; ?>"><span class="badge-label"><?= htmlspecialchars($aStatus['label'] ?? ''); ?></span></span>
+            </td>
+            <td>
+              <a class="btn btn-sm btn-warning" href="agency_edit.php?id=<?= $agency['id']; ?>">Edit</a>
+              <?php if (user_has_permission('agency','delete')): ?>
+                <form method="post" class="d-inline">
+                  <input type="hidden" name="delete_agency_id" value="<?= $agency['id']; ?>">
+                  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+                  <button class="btn btn-sm btn-danger" onclick="return confirm('Delete this agency?');">Delete</button>
+                </form>
+              <?php endif; ?>
+              <?php if (user_has_permission('division','create')): ?>
+                <a class="btn btn-sm btn-success" href="division_edit.php?agency_id=<?= $agency['id']; ?>">Add Division</a>
+              <?php endif; ?>
+            </td>
+          </tr>
+          <?php
+            $divisionStmt = $pdo->prepare('SELECT id, name, status FROM module_division WHERE agency_id = :aid ORDER BY name');
+            $divisionStmt->execute([':aid' => $agency['id']]);
+            $divisions = $divisionStmt->fetchAll(PDO::FETCH_ASSOC);
+            foreach($divisions as $division): ?>
+            <tr class="bg-body-secondary">
+              <td class="ps-5">Division: <?= htmlspecialchars($division['name']); ?></td>
+              <td>
+                <?php $dStatus = $divisionStatuses[$division['status']] ?? null; $dClass = ($dStatus['value'] ?? '') === 'active' ? 'badge-phoenix-success' : 'badge-phoenix-warning'; ?>
+                <span class="badge badge-phoenix fs-10 <?= $dClass; ?>"><span class="badge-label"><?= htmlspecialchars($dStatus['label'] ?? ''); ?></span></span>
+              </td>
+              <td>
+                <a class="btn btn-sm btn-warning" href="division_edit.php?id=<?= $division['id']; ?>">Edit</a>
+                <?php if (user_has_permission('division','delete')): ?>
+                  <form method="post" class="d-inline">
+                    <input type="hidden" name="delete_division_id" value="<?= $division['id']; ?>">
+                    <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+                    <button class="btn btn-sm btn-danger" onclick="return confirm('Delete this division?');">Delete</button>
+                  </form>
+                <?php endif; ?>
+              </td>
+            </tr>
+            <?php endforeach; ?>
+          <?php endforeach; ?>
+      <?php endforeach; ?>
+    </tbody>
+  </table>
+</div>
+<?php require '../admin_footer.php'; ?>

--- a/admin/orgs/organization_edit.php
+++ b/admin/orgs/organization_edit.php
@@ -1,0 +1,83 @@
+<?php
+require '../admin_header.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$name = '';
+$main_person = null;
+$status = null;
+$existing = null;
+$btnClass = $id ? 'btn-warning' : 'btn-success';
+
+if ($id) {
+  require_permission('organization','update');
+  $stmt = $pdo->prepare('SELECT name, main_person, status FROM module_organization WHERE id = :id');
+  $stmt->execute([':id' => $id]);
+  $existing = $stmt->fetch(PDO::FETCH_ASSOC);
+  if ($existing) {
+    $name = $existing['name'];
+    $main_person = $existing['main_person'];
+    $status = $existing['status'];
+  }
+} else {
+  require_permission('organization','create');
+}
+
+$token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
+$_SESSION['csrf_token'] = $token;
+
+$personStmt = $pdo->query('SELECT id, CONCAT(first_name, " ", last_name) AS name FROM person ORDER BY first_name, last_name');
+$personOptions = $personStmt->fetchAll(PDO::FETCH_KEY_PAIR);
+
+$statusStmt = $pdo->prepare("SELECT li.id, li.label FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'ORGANIZATION_STATUS' ORDER BY li.sort_order, li.label");
+$statusStmt->execute();
+$statusOptions = $statusStmt->fetchAll(PDO::FETCH_KEY_PAIR);
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  if (!hash_equals($token, $_POST['csrf_token'] ?? '')) {
+    die('Invalid CSRF token');
+  }
+  $name = trim($_POST['name'] ?? '');
+  $main_person = $_POST['main_person'] !== '' ? (int)$_POST['main_person'] : null;
+  $status = $_POST['status'] !== '' ? (int)$_POST['status'] : null;
+  if ($id) {
+    $stmt = $pdo->prepare('UPDATE module_organization SET name=:name, main_person=:main_person, status=:status, user_updated=:uid WHERE id=:id');
+    $stmt->execute([':name'=>$name, ':main_person'=>$main_person, ':status'=>$status, ':uid'=>$this_user_id, ':id'=>$id]);
+    admin_audit_log($pdo, $this_user_id, 'module_organization', $id, 'UPDATE', json_encode($existing), json_encode(['name'=>$name,'main_person'=>$main_person,'status'=>$status]), 'Updated organization');
+  } else {
+    $stmt = $pdo->prepare('INSERT INTO module_organization (name, main_person, status, user_id, user_updated) VALUES (:name, :main_person, :status, :uid, :uid)');
+    $stmt->execute([':name'=>$name, ':main_person'=>$main_person, ':status'=>$status, ':uid'=>$this_user_id]);
+    $id = $pdo->lastInsertId();
+    admin_audit_log($pdo, $this_user_id, 'module_organization', $id, 'CREATE', null, json_encode(['name'=>$name,'main_person'=>$main_person,'status'=>$status]), 'Created organization');
+  }
+  header('Location: index.php');
+  exit;
+}
+?>
+<h2 class="mb-4"><?= $id ? 'Edit' : 'Add'; ?> Organization</h2>
+<form method="post">
+  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+  <div class="mb-3">
+    <label class="form-label">Name</label>
+    <input type="text" name="name" class="form-control" value="<?= htmlspecialchars($name); ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Main Person</label>
+    <select name="main_person" class="form-select">
+      <option value="">-- None --</option>
+      <?php foreach($personOptions as $pid => $pname): ?>
+        <option value="<?= $pid; ?>" <?= (int)$pid === (int)$main_person ? 'selected' : ''; ?>><?= htmlspecialchars($pname); ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Status</label>
+    <select name="status" class="form-select">
+      <?php foreach($statusOptions as $sid => $slabel): ?>
+        <option value="<?= $sid; ?>" <?= (int)$sid === (int)$status ? 'selected' : ''; ?>><?= htmlspecialchars($slabel); ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <button class="btn <?= $btnClass; ?>" type="submit">Save</button>
+  <a href="index.php" class="btn btn-secondary">Cancel</a>
+</form>
+<?php require '../admin_footer.php'; ?>

--- a/module/agency/index.php
+++ b/module/agency/index.php
@@ -8,6 +8,7 @@ $action = $_GET['action'] ?? 'card';
 $sql = "SELECT a.id, a.name, li.label AS status_label
         FROM module_agency a
         LEFT JOIN lookup_list_items li ON a.status = li.id
+        LEFT JOIN lookup_lists l ON li.list_id = l.id AND l.name = 'AGENCY_STATUS'
         ORDER BY a.name";
 $stmt = $pdo->query($sql);
 $agencies = $stmt->fetchAll(PDO::FETCH_ASSOC);


### PR DESCRIPTION
## Summary
- Add Phoenix-styled Orgs admin interface with hierarchical organization, agency, and division lists
- Implement create/edit pages for organizations, agencies, and divisions using separate lookup list statuses
- Register organization and division permissions and roles in SQL and fix admin navigation include
- Save agency uploads to shared frontend directory and join agency statuses to dedicated lookup list

## Testing
- `php -l admin/orgs/index.php`
- `php -l admin/orgs/organization_edit.php`
- `php -l admin/orgs/agency_edit.php`
- `php -l admin/orgs/division_edit.php`
- `php -l admin/admin_header.php`
- `php -l module/agency/index.php`


------
https://chatgpt.com/codex/tasks/task_e_689439484e308333b1659ae7e458228a