### PR TITLE
Fix admin guard path in lookup list API

### DIFF
--- a/admin/api/lookup-lists.php
+++ b/admin/api/lookup-lists.php
@@ -1,5 +1,5 @@
 <?php
-require_once __DIR__ . '/../includes/admin_guard.php';
+require_once __DIR__ . '/../../includes/admin_guard.php';
 header('Content-Type: application/json');
 
 $token = $_SESSION['csrf_token'] ?? '';


### PR DESCRIPTION
## Summary
- correct admin guard path in lookup list API

## Testing
- `php -l admin/api/lookup-lists.php`
- `curl -i -X POST -d "entity=list&action=create&name=Test&csrf_token=test" http://127.0.0.1:8000/admin/api/lookup-lists.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6894424a90f08333a0d7ea9914ebf794