### PR TITLE
Add agency file metadata support

### DIFF
--- a/_SQL/atlis.sql
+++ b/_SQL/atlis.sql
@@ -363,17 +363,30 @@ CREATE TABLE `module_agency` (
   `organization_id` int(11) NOT NULL,
   `name` varchar(255) NOT NULL,
   `main_person` int(11) DEFAULT NULL,
-  `status` int(11) DEFAULT NULL
+  `status` int(11) DEFAULT NULL,
+  `file_name` varchar(255) DEFAULT NULL,
+  `file_path` varchar(255) DEFAULT NULL,
+  `file_size` int(11) DEFAULT NULL,
+  `file_type` varchar(255) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --
 -- Dumping data for table `module_agency`
 --
 
-INSERT INTO `module_agency` (`id`, `user_id`, `user_updated`, `date_created`, `date_updated`, `memo`, `organization_id`, `name`, `main_person`, `status`) VALUES
-(1, NULL, NULL,  '2025-08-06 16:27:31', '2025-08-06 16:27:31', NULL, 1, 'Atlis Technologies', 1, 3),
-(2, NULL, NULL, '2025-08-06 16:28:14', '2025-08-06 16:28:14', NULL, 2, '19th Circuit Court', NULL, 3),
-(3, 1, 1, '2025-08-06 21:25:06', '2025-08-06 21:25:06', NULL, 3, '', NULL, NULL);
+INSERT INTO `module_agency` (`id`, `user_id`, `user_updated`, `date_created`, `date_updated`, `memo`, `organization_id`, `name`, `main_person`, `status`, `file_name`, `file_path`, `file_size`, `file_type`) VALUES
+(1, NULL, NULL,  '2025-08-06 16:27:31', '2025-08-06 16:27:31', NULL, 1, 'Atlis Technologies', 1, 3, NULL, NULL, NULL, NULL),
+(2, NULL, NULL, '2025-08-06 16:28:14', '2025-08-06 16:28:14', NULL, 2, '19th Circuit Court', NULL, 3, NULL, NULL, NULL, NULL),
+(3, 1, 1, '2025-08-06 21:25:06', '2025-08-06 21:25:06', NULL, 3, '', NULL, NULL, NULL, NULL, NULL, NULL);
+
+--
+-- Alter table for existing deployments
+--
+ALTER TABLE `module_agency`
+  ADD COLUMN `file_name` varchar(255) DEFAULT NULL,
+  ADD COLUMN `file_path` varchar(255) DEFAULT NULL,
+  ADD COLUMN `file_size` int(11) DEFAULT NULL,
+  ADD COLUMN `file_type` varchar(255) DEFAULT NULL;
 
 -- --------------------------------------------------------
 

--- a/admin/orgs/index.php
+++ b/admin/orgs/index.php
@@ -95,12 +95,16 @@ $organizations = $orgStmt->fetchAll(PDO::FETCH_ASSOC);
           </td>
         </tr>
         <?php
-          $agencyStmt = $pdo->prepare('SELECT id, name, status FROM module_agency WHERE organization_id = :oid ORDER BY name');
+          $agencyStmt = $pdo->prepare('SELECT id, name, status, file_path, file_name, file_type FROM module_agency WHERE organization_id = :oid ORDER BY name');
           $agencyStmt->execute([':oid' => $org['id']]);
           $agencies = $agencyStmt->fetchAll(PDO::FETCH_ASSOC);
           foreach($agencies as $agency): ?>
           <tr class="bg-body-tertiary">
-            <td class="ps-4">Agency: <?= htmlspecialchars($agency['name']); ?></td>
+            <td class="ps-4">Agency: <?= htmlspecialchars($agency['name']); ?>
+              <?php if(!empty($agency['file_path'])): ?>
+                <br><a href="<?= htmlspecialchars($agency['file_path']); ?>" target="_blank">View File</a>
+              <?php endif; ?>
+            </td>
             <td>
               <?php $aStatus = $agencyStatuses[$agency['status']] ?? null; $aClass = ($aStatus['value'] ?? '') === 'active' ? 'badge-phoenix-success' : 'badge-phoenix-warning'; ?>
               <span class="badge badge-phoenix fs-10 <?= $aClass; ?>"><span class="badge-label"><?= htmlspecialchars($aStatus['label'] ?? ''); ?></span></span>


### PR DESCRIPTION
## Summary
- track uploaded file details for agencies
- capture and display stored file info in agency admin pages

## Testing
- `php -l admin/orgs/agency_edit.php`
- `php -l admin/orgs/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68944766fab88333bde8de38f52c55cd