### PR TITLE
Validate lookup list and item operations

### DIFF
--- a/admin/lookup-lists/index.php
+++ b/admin/lookup-lists/index.php
@@ -213,9 +213,13 @@ $(function(){
       if(res.success){
         row.remove();
       }else{
-        alert(res.error);
+        $('#listAlert').html('<div class="alert alert-danger">'+res.error+'</div>');
+        listModal.show();
       }
-    }, 'json');
+    }, 'json').fail(function(){
+      $('#listAlert').html('<div class="alert alert-danger">Server error.</div>');
+      listModal.show();
+    });
   });
 
   $('#lookup-lists').on('click', '.items-list', function(){
@@ -280,9 +284,11 @@ $(function(){
       if(res.success){
         tr.remove();
       }else{
-        alert(res.error);
+        $('#itemAlert').html('<div class="alert alert-danger">'+res.error+'</div>');
       }
-    }, 'json');
+    }, 'json').fail(function(){
+      $('#itemAlert').html('<div class="alert alert-danger">Server error.</div>');
+    });
   });
 
   $('#itemsTable').on('click', '.attributes-item', function(){
@@ -346,9 +352,11 @@ $(function(){
       if(res.success){
         tr.remove();
       }else{
-        alert(res.error);
+        $('#attrAlert').html('<div class="alert alert-danger">'+res.error+'</div>');
       }
-    }, 'json');
+    }, 'json').fail(function(){
+      $('#attrAlert').html('<div class="alert alert-danger">Server error.</div>');
+    });
   });
 });
 </script>


### PR DESCRIPTION
## Summary
- prevent duplicate lookup list names and handle FK violations
- guard lookup list items against duplicate labels or references
- surface API error messages in list management UI

## Testing
- `php -l admin/api/lookup-lists.php`
- `php -l admin/lookup-lists/index.php`


------
https://chatgpt.com/codex/tasks/task_e_6894469c317c83338835cc71956d38e7