### PR TITLE
Add reusable CSRF and flash message helpers

### DIFF
--- a/admin/admin_header.php
+++ b/admin/admin_header.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/../includes/admin_guard.php';
+require_once __DIR__ . '/../includes/helpers.php';
 require_once __DIR__ . '/../includes/html_header.php';
 ?>
 <main class="main" id="top">

--- a/admin/api/lookup-lists.php
+++ b/admin/api/lookup-lists.php
@@ -1,8 +1,7 @@
 <?php
 require_once __DIR__ . '/../../includes/admin_guard.php';
+require_once __DIR__ . '/../../includes/helpers.php';
 header('Content-Type: application/json');
-
-$token = $_SESSION['csrf_token'] ?? '';
 $entity = $_REQUEST['entity'] ?? '';
 $action = $_REQUEST['action'] ?? '';
 
@@ -25,8 +24,7 @@ try {
 }
 
 function verifyToken() {
-  global $token;
-  if (!hash_equals($token, $_POST['csrf_token'] ?? '')) {
+  if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
     echo json_encode(['success'=>false,'error'=>'Invalid CSRF token']);
     exit;
   }

--- a/admin/lookup-lists/attributes.php
+++ b/admin/lookup-lists/attributes.php
@@ -1,8 +1,7 @@
 <?php
 require '../admin_header.php';
 
-$token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
-$_SESSION['csrf_token'] = $token;
+$token = generate_csrf_token();
 $item_id = (int)($_GET['item_id'] ?? 0);
 $message = $error = '';
 
@@ -10,13 +9,13 @@ $stmt = $pdo->prepare('SELECT i.*, l.name AS list_name FROM lookup_list_items i 
 $stmt->execute([':id'=>$item_id]);
 $item = $stmt->fetch(PDO::FETCH_ASSOC);
 if(!$item){
-  echo '<div class="alert alert-danger">Item not found.</div>';
+  echo flash_message('Item not found.', 'danger');
   require '../admin_footer.php';
   exit;
 }
 
 if($_SERVER['REQUEST_METHOD']==='POST'){
-  if(!hash_equals($token, $_POST['csrf_token'] ?? '')){ die('Invalid CSRF token'); }
+  if(!verify_csrf_token($_POST['csrf_token'] ?? '')){ die('Invalid CSRF token'); }
   if(isset($_POST['delete_id'])){
     $delId=(int)$_POST['delete_id'];
     $pdo->prepare('DELETE FROM lookup_list_item_attributes WHERE id=:id')->execute([':id'=>$delId]);
@@ -49,8 +48,8 @@ $stmt->execute([':item_id'=>$item_id]);
 $attrs=$stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <h2 class="mb-4">Attributes for <?= htmlspecialchars($item['label']); ?></h2>
-<?php if($error){ echo '<div class="alert alert-danger">'.htmlspecialchars($error).'</div>'; } ?>
-<?php if($message){ echo '<div class="alert alert-success">'.htmlspecialchars($message).'</div>'; } ?>
+<?= flash_message($error, 'danger'); ?>
+<?= flash_message($message); ?>
 <form method="post" class="row g-2 mb-3">
   <input type="hidden" name="csrf_token" value="<?= $token; ?>">
   <input type="hidden" name="id" value="<?= htmlspecialchars($_POST['id'] ?? ''); ?>">

--- a/admin/lookup-lists/edit.php
+++ b/admin/lookup-lists/edit.php
@@ -1,8 +1,7 @@
 <?php
 require '../admin_header.php';
 
-$token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
-$_SESSION['csrf_token'] = $token;
+$token = generate_csrf_token();
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 $name = $description = $memo = '';
 $message = $error = '';
@@ -19,7 +18,7 @@ if ($id) {
 }
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-  if (!hash_equals($token, $_POST['csrf_token'] ?? '')) {
+  if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
     die('Invalid CSRF token');
   }
   $name = trim($_POST['name'] ?? '');
@@ -45,8 +44,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 ?>
 <h2 class="mb-4"><?= $id ? 'Edit' : 'Add'; ?> Lookup List</h2>
-<?php if($error){ echo '<div class="alert alert-danger">'.htmlspecialchars($error).'</div>'; } ?>
-<?php if($message){ echo '<div class="alert alert-success">'.htmlspecialchars($message).'</div>'; } ?>
+<?= flash_message($error, 'danger'); ?>
+<?= flash_message($message); ?>
 <form method="post">
   <input type="hidden" name="csrf_token" value="<?= $token; ?>">
   <div class="mb-3">

--- a/admin/lookup-lists/index.php
+++ b/admin/lookup-lists/index.php
@@ -1,8 +1,7 @@
 <?php
 require '../admin_header.php';
 
-$token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
-$_SESSION['csrf_token'] = $token;
+$token = generate_csrf_token();
 $stmt = $pdo->query('SELECT id, name, description, memo FROM lookup_lists ORDER BY name');
 $lists = $stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -1,0 +1,23 @@
+<?php
+
+function generate_csrf_token(): string {
+    if (empty($_SESSION['csrf_token'])) {
+        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    }
+    return $_SESSION['csrf_token'];
+}
+
+function verify_csrf_token(?string $token): bool {
+    return isset($_SESSION['csrf_token']) && hash_equals($_SESSION['csrf_token'], (string)$token);
+}
+
+function flash_message(string $message, string $type = 'success'): string {
+    if ($message === '') {
+        return '';
+    }
+    $type = htmlspecialchars($type, ENT_QUOTES, 'UTF-8');
+    $msg  = htmlspecialchars($message, ENT_QUOTES, 'UTF-8');
+    return '<div class="alert alert-' . $type . '">' . $msg . '</div>';
+}
+
+?>


### PR DESCRIPTION
## Summary
- add helpers for CSRF token generation/verification and HTML flash messages
- integrate helpers into admin header and lookup-list pages
- update lookup-list API to rely on the shared CSRF verifier

## Testing
- `php -l includes/helpers.php`
- `php -l admin/admin_header.php`
- `php -l admin/lookup-lists/index.php`
- `php -l admin/lookup-lists/attributes.php`
- `php -l admin/lookup-lists/items.php`
- `php -l admin/lookup-lists/edit.php`
- `php -l admin/api/lookup-lists.php`


------
https://chatgpt.com/codex/tasks/task_e_6894469966908333991d8e79f651dac8