### PR TITLE
Add centralized admin module list for dashboard and navigation

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -1,23 +1,19 @@
-<?php require 'admin_header.php'; ?>
+<?php
+require 'admin_header.php';
+$modules = require __DIR__ . '/modules.php';
+?>
 <h2 class="mb-4">Admin Dashboard</h2>
 <div class="row g-3">
-  <div class="col-md-4">
-    <div class="card shadow-sm">
-      <div class="card-body">
-        <h5 class="card-title"><span class="me-2" data-feather="users"></span>Users</h5>
-        <p class="card-text">Manage system users.</p>
-        <a href="users/index.php" class="btn btn-primary btn-sm">Manage</a>
+  <?php foreach ($modules as $module): ?>
+    <div class="col-md-4">
+      <div class="card shadow-sm">
+        <div class="card-body">
+          <h5 class="card-title"><span class="me-2" data-feather="<?= htmlspecialchars($module['icon']); ?>"></span><?= htmlspecialchars($module['title']); ?></h5>
+          <p class="card-text"><?= htmlspecialchars($module['description']); ?></p>
+          <a href="<?= htmlspecialchars($module['path']); ?>" class="btn btn-primary btn-sm">Manage</a>
+        </div>
       </div>
     </div>
-  </div>
-  <div class="col-md-4">
-    <div class="card shadow-sm">
-      <div class="card-body">
-        <h5 class="card-title">Lookup Lists</h5>
-        <p class="card-text">Manage lookup lists and items.</p>
-        <a href="lookup-lists/index.php" class="btn btn-primary btn-sm">Manage</a>
-      </div>
-    </div>
-  </div>
+  <?php endforeach; ?>
 </div>
 <?php require 'admin_footer.php'; ?>

--- a/admin/left_navigation.php
+++ b/admin/left_navigation.php
@@ -1,3 +1,4 @@
+<?php $modules = require __DIR__ . '/modules.php'; ?>
 <nav class="navbar navbar-vertical navbar-expand-lg">
   <div class="collapse navbar-collapse" id="navbarVerticalCollapse">
     <div class="navbar-vertical-content">
@@ -7,31 +8,13 @@
             <div class="d-flex align-items-center"><span class="nav-link-icon"><span data-feather="home"></span></span><span class="nav-link-text">Dashboard</span></div>
           </a>
         </li>
+        <?php foreach ($modules as $module): ?>
         <li class="nav-item">
-          <a class="nav-link" href="<?php echo getURLDir(); ?>admin/users/index.php">
-            <div class="d-flex align-items-center"><span class="nav-link-icon"><span data-feather="users"></span></span><span class="nav-link-text">Users</span></div>
+          <a class="nav-link" href="<?php echo getURLDir(); ?>admin/<?= htmlspecialchars($module['path']); ?>">
+            <div class="d-flex align-items-center"><span class="nav-link-icon"><span data-feather="<?= htmlspecialchars($module['icon']); ?>"></span></span><span class="nav-link-text"><?= htmlspecialchars($module['title']); ?></span></div>
           </a>
         </li>
-        <li class="nav-item">
-          <a class="nav-link" href="<?php echo getURLDir(); ?>admin/person/index.php">
-            <div class="d-flex align-items-center"><span class="nav-link-icon"><span data-feather="user"></span></span><span class="nav-link-text">Persons</span></div>
-          </a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="<?php echo getURLDir(); ?>admin/lookup-lists/index.php">
-            <div class="d-flex align-items-center"><span class="nav-link-icon"><span data-feather="list"></span></span><span class="nav-link-text">Lookup Lists</span></div>
-          </a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="<?php echo getURLDir(); ?>admin/roles/index.php">
-            <div class="d-flex align-items-center"><span class="nav-link-icon"><span data-feather="shield"></span></span><span class="nav-link-text">Roles</span></div>
-          </a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="<?php echo getURLDir(); ?>admin/orgs/index.php">
-            <div class="d-flex align-items-center"><span class="nav-link-icon"><span data-feather="briefcase"></span></span><span class="nav-link-text">Organizations</span></div>
-          </a>
-        </li>
+        <?php endforeach; ?>
       </ul>
     </div>
   </div>

--- a/admin/modules.php
+++ b/admin/modules.php
@@ -1,0 +1,34 @@
+<?php
+return [
+  [
+    'title' => 'Users',
+    'path' => 'users/index.php',
+    'icon' => 'users',
+    'description' => 'Manage system users.'
+  ],
+  [
+    'title' => 'Persons',
+    'path' => 'person/index.php',
+    'icon' => 'user',
+    'description' => 'Manage person records.'
+  ],
+  [
+    'title' => 'Lookup Lists',
+    'path' => 'lookup-lists/index.php',
+    'icon' => 'list',
+    'description' => 'Manage lookup lists and items.'
+  ],
+  [
+    'title' => 'Roles',
+    'path' => 'roles/index.php',
+    'icon' => 'shield',
+    'description' => 'Manage user roles and permissions.'
+  ],
+  [
+    'title' => 'Organizations',
+    'path' => 'orgs/index.php',
+    'icon' => 'briefcase',
+    'description' => 'Manage organizations.'
+  ],
+];
+?>


### PR DESCRIPTION
## Summary
- centralize admin module definitions
- dynamically render admin dashboard cards and side nav links

## Testing
- `php -l admin/modules.php`
- `php -l admin/index.php`
- `php -l admin/left_navigation.php`


------
https://chatgpt.com/codex/tasks/task_e_689be58b914083339c9a0ff536f977b6