### PR TITLE
Add system properties update trigger

### DIFF
--- a/_SQL/013_system_properties_triggers.sql
+++ b/_SQL/013_system_properties_triggers.sql
@@ -1,0 +1,27 @@
+-- Triggers for module_system_properties versioning
+
+DELIMITER $$
+DROP TRIGGER IF EXISTS trg_module_system_properties_au $$
+CREATE TRIGGER trg_module_system_properties_au
+AFTER UPDATE ON module_system_properties
+FOR EACH ROW
+BEGIN
+  -- prevent recursive trigger calls
+  IF (@module_system_properties_au_disabled IS NULL) THEN
+    SET @module_system_properties_au_disabled = TRUE;
+
+    -- record previous value with audit metadata
+    INSERT INTO module_system_properties_versions
+      (property_id, version_number, value, user_id, date_created)
+    VALUES
+      (OLD.id, OLD.version_number, OLD.value, NEW.user_updated, NOW());
+
+    -- increment version number on the updated record
+    UPDATE module_system_properties
+    SET version_number = OLD.version_number + 1
+    WHERE id = NEW.id;
+
+    SET @module_system_properties_au_disabled = NULL;
+  END IF;
+END $$
+DELIMITER ;

--- a/_SQL/atlis.sql
+++ b/_SQL/atlis.sql
@@ -810,6 +810,9 @@ ALTER TABLE `system_property_versions`
   ADD CONSTRAINT `system_property_versions_ibfk_2` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`);
 COMMIT;
 
+-- Triggers
+SOURCE 013_system_properties_triggers.sql;
+
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
 /*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;


### PR DESCRIPTION
## Summary
- add AFTER UPDATE trigger script for module system properties to log previous values and bump version numbers
- include trigger script in main atlis SQL dump

## Testing
- `mysql --version`
- `mysql -u root -e "SHOW DATABASES;"` *(fails: Can't connect to local MySQL server)*

------
https://chatgpt.com/codex/tasks/task_e_689bf67d04bc833395896350118da899