### PR TITLE
Add active date range for lookup list items

### DIFF
--- a/_SQL/004_lookup_list_items.sql
+++ b/_SQL/004_lookup_list_items.sql
@@ -8,6 +8,8 @@ CREATE TABLE `lookup_list_items` (
   `list_id` int(11) NOT NULL,
   `label` varchar(255) NOT NULL,
   `value` varchar(255) DEFAULT NULL,
+  `active_from` date DEFAULT CURDATE(),
+  `active_to` date DEFAULT NULL,
   `sort_order` int(11) DEFAULT 0,
   PRIMARY KEY (`id`),
   KEY `fk_lookup_list_items_list_id` (`list_id`),

--- a/_SQL/013_lookup_list_items_active_dates.sql
+++ b/_SQL/013_lookup_list_items_active_dates.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `lookup_list_items`
+  ADD COLUMN `active_from` DATE DEFAULT CURDATE() AFTER `value`,
+  ADD COLUMN `active_to` DATE DEFAULT NULL AFTER `active_from`;

--- a/_SQL/atlis.sql
+++ b/_SQL/atlis.sql
@@ -282,6 +282,8 @@ CREATE TABLE `lookup_list_items` (
   `list_id` int(11) NOT NULL,
   `label` varchar(255) NOT NULL,
   `value` varchar(255) DEFAULT NULL,
+  `active_from` date DEFAULT curdate(),
+  `active_to` date DEFAULT NULL,
   `sort_order` int(11) DEFAULT 0
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
@@ -289,22 +291,22 @@ CREATE TABLE `lookup_list_items` (
 -- Dumping data for table `lookup_list_items`
 --
 
-INSERT INTO `lookup_list_items` (`id`, `user_id`, `user_updated`, `date_created`, `date_updated`, `memo`, `list_id`, `label`, `value`, `sort_order`) VALUES
-(1, 1, 1, '2025-08-06 16:07:33', '2025-08-08 22:15:24', NULL, 1, 'ACTIVE', 'Active', 1),
-(2, 1, 1, '2025-08-06 16:07:33', '2025-08-08 22:15:35', NULL, 1, 'INACTIVE', 'Inactive', 2),
-(3, 1, 1, '2025-08-06 16:07:33', '2025-08-08 22:14:47', NULL, 2, 'ACTIVE', 'Active', 1),
-(4, 1, 1, '2025-08-06 16:07:33', '2025-08-08 22:14:59', NULL, 2, 'INACTIVE', 'Inactive', 2),
-(5, 1, 1, '2025-08-06 16:07:33', '2025-08-08 21:58:45', NULL, 3, 'ACTIVE', 'Active', 1),
-(6, 1, 1, '2025-08-06 16:07:33', '2025-08-08 21:59:22', NULL, 3, 'INACTIVE', 'Inactive', 2),
-(7, 1, 1, '2025-08-06 20:13:30', '2025-08-06 20:13:46', NULL, 5, 'ACTIVE', 'Active', 1),
-(8, 1, 1, '2025-08-06 20:13:41', '2025-08-06 20:13:41', NULL, 5, 'INACTIVE', 'Inactive', 2),
-(9, 1, 1, '2025-08-06 20:13:58', '2025-08-06 20:13:58', NULL, 4, 'ADMIN', 'Admin', 1),
-(10, 1, 1, '2025-08-06 20:14:03', '2025-08-06 20:14:03', NULL, 4, 'USER', 'User', 2),
-(11, 1, 1, '2025-08-06 20:26:20', '2025-08-06 20:26:20', NULL, 7, 'DEFAULT', 'Default', 0),
-(12, 1, 1, '2025-08-06 20:26:38', '2025-08-06 20:26:38', NULL, 7, 'COLOR-CLASS', 'Color / Class', 0),
-(13, 1, 1, '2025-08-08 22:02:51', '2025-08-08 22:02:51', NULL, 1, 'PENDING', 'Pending', 0),
-(27, 1, 1, '2025-08-08 22:14:28', '2025-08-08 22:14:28', NULL, 3, 'PENDING', 'Pending', 0),
-(28, 1, 1, '2025-08-08 22:14:38', '2025-08-08 22:14:38', NULL, 2, 'PENDING', 'Pending', 0);
+INSERT INTO `lookup_list_items` (`id`, `user_id`, `user_updated`, `date_created`, `date_updated`, `memo`, `list_id`, `label`, `value`, `active_from`, `active_to`, `sort_order`) VALUES
+(1, 1, 1, '2025-08-06 16:07:33', '2025-08-08 22:15:24', NULL, 1, 'ACTIVE', 'Active', curdate(), NULL, 1),
+(2, 1, 1, '2025-08-06 16:07:33', '2025-08-08 22:15:35', NULL, 1, 'INACTIVE', 'Inactive', curdate(), NULL, 2),
+(3, 1, 1, '2025-08-06 16:07:33', '2025-08-08 22:14:47', NULL, 2, 'ACTIVE', 'Active', curdate(), NULL, 1),
+(4, 1, 1, '2025-08-06 16:07:33', '2025-08-08 22:14:59', NULL, 2, 'INACTIVE', 'Inactive', curdate(), NULL, 2),
+(5, 1, 1, '2025-08-06 16:07:33', '2025-08-08 21:58:45', NULL, 3, 'ACTIVE', 'Active', curdate(), NULL, 1),
+(6, 1, 1, '2025-08-06 16:07:33', '2025-08-08 21:59:22', NULL, 3, 'INACTIVE', 'Inactive', curdate(), NULL, 2),
+(7, 1, 1, '2025-08-06 20:13:30', '2025-08-06 20:13:46', NULL, 5, 'ACTIVE', 'Active', curdate(), NULL, 1),
+(8, 1, 1, '2025-08-06 20:13:41', '2025-08-06 20:13:41', NULL, 5, 'INACTIVE', 'Inactive', curdate(), NULL, 2),
+(9, 1, 1, '2025-08-06 20:13:58', '2025-08-06 20:13:58', NULL, 4, 'ADMIN', 'Admin', curdate(), NULL, 1),
+(10, 1, 1, '2025-08-06 20:14:03', '2025-08-06 20:14:03', NULL, 4, 'USER', 'User', curdate(), NULL, 2),
+(11, 1, 1, '2025-08-06 20:26:20', '2025-08-06 20:26:20', NULL, 7, 'DEFAULT', 'Default', curdate(), NULL, 0),
+(12, 1, 1, '2025-08-06 20:26:38', '2025-08-06 20:26:38', NULL, 7, 'COLOR-CLASS', 'Color / Class', curdate(), NULL, 0),
+(13, 1, 1, '2025-08-08 22:02:51', '2025-08-08 22:02:51', NULL, 1, 'PENDING', 'Pending', curdate(), NULL, 0),
+(27, 1, 1, '2025-08-08 22:14:28', '2025-08-08 22:14:28', NULL, 3, 'PENDING', 'Pending', curdate(), NULL, 0),
+(28, 1, 1, '2025-08-08 22:14:38', '2025-08-08 22:14:38', NULL, 2, 'PENDING', 'Pending', curdate(), NULL, 0);
 
 -- --------------------------------------------------------
 

--- a/admin/api/lookup-lists.php
+++ b/admin/api/lookup-lists.php
@@ -111,7 +111,7 @@ function handleItem($action){
   if(in_array($action,['create','update','delete'])){ verifyToken(); }
   if($action==='list'){
     $list_id=(int)($_GET['list_id']??0);
-    $stmt=$pdo->prepare('SELECT id,label,value,sort_order FROM lookup_list_items WHERE list_id=:list_id ORDER BY sort_order,label');
+    $stmt=$pdo->prepare('SELECT id,label,value,active_from,active_to,sort_order FROM lookup_list_items WHERE list_id=:list_id AND active_from <= CURDATE() AND (active_to IS NULL OR active_to >= CURDATE()) ORDER BY sort_order,label');
     $stmt->execute([':list_id'=>$list_id]);
     $items=$stmt->fetchAll(PDO::FETCH_ASSOC);
     echo json_encode(['success'=>true,'items'=>$items]);
@@ -119,6 +119,8 @@ function handleItem($action){
     $list_id=(int)($_POST['list_id']??0);
     $label=trim($_POST['label']??'');
     $value=trim($_POST['value']??'');
+    $active_from=$_POST['active_from']??date('Y-m-d');
+    $active_to=$_POST['active_to']??null;
     $sort=(int)($_POST['sort_order']??0);
     if($list_id<=0||$label===''){ echo json_encode(['success'=>false,'error'=>'Invalid data']); return; }
     $stmt=$pdo->prepare('SELECT id FROM lookup_list_items WHERE list_id=:list_id AND label=:label');
@@ -128,11 +130,11 @@ function handleItem($action){
       return;
     }
     try{
-      $stmt=$pdo->prepare('INSERT INTO lookup_list_items (user_id,user_updated,list_id,label,value,sort_order) VALUES (:uid,:uid,:list_id,:label,:value,:sort)');
-      $stmt->execute([':uid'=>$this_user_id,':list_id'=>$list_id,':label'=>$label,':value'=>$value,':sort'=>$sort]);
+      $stmt=$pdo->prepare('INSERT INTO lookup_list_items (user_id,user_updated,list_id,label,value,active_from,active_to,sort_order) VALUES (:uid,:uid,:list_id,:label,:value,:active_from,:active_to,:sort)');
+      $stmt->execute([':uid'=>$this_user_id,':list_id'=>$list_id,':label'=>$label,':value'=>$value,':active_from'=>$active_from,':active_to'=>$active_to,':sort'=>$sort]);
       $id=$pdo->lastInsertId();
       audit_log($pdo,$this_user_id,'lookup_list_items',$id,'CREATE','Created lookup list item');
-      echo json_encode(['success'=>true,'message'=>'Item created','item'=>['id'=>$id,'label'=>$label,'value'=>$value,'sort_order'=>$sort]]);
+      echo json_encode(['success'=>true,'message'=>'Item created','item'=>['id'=>$id,'label'=>$label,'value'=>$value,'active_from'=>$active_from,'active_to'=>$active_to,'sort_order'=>$sort]]);
     }catch(PDOException $e){
       if($e->getCode()==='23000'){
         echo json_encode(['success'=>false,'error'=>'Label already exists']);
@@ -144,6 +146,8 @@ function handleItem($action){
     $id=(int)($_POST['id']??0);
     $label=trim($_POST['label']??'');
     $value=trim($_POST['value']??'');
+    $active_from=$_POST['active_from']??date('Y-m-d');
+    $active_to=$_POST['active_to']??null;
     $sort=(int)($_POST['sort_order']??0);
     if($id<=0||$label===''){ echo json_encode(['success'=>false,'error'=>'Invalid data']); return; }
     $stmt=$pdo->prepare('SELECT list_id FROM lookup_list_items WHERE id=:id');
@@ -157,10 +161,10 @@ function handleItem($action){
       return;
     }
     try{
-      $stmt=$pdo->prepare('UPDATE lookup_list_items SET label=:label,value=:value,sort_order=:sort,user_updated=:uid WHERE id=:id');
-      $stmt->execute([':label'=>$label,':value'=>$value,':sort'=>$sort,':uid'=>$this_user_id,':id'=>$id]);
+      $stmt=$pdo->prepare('UPDATE lookup_list_items SET label=:label,value=:value,active_from=:active_from,active_to=:active_to,sort_order=:sort,user_updated=:uid WHERE id=:id');
+      $stmt->execute([':label'=>$label,':value'=>$value,':active_from'=>$active_from,':active_to'=>$active_to,':sort'=>$sort,':uid'=>$this_user_id,':id'=>$id]);
       audit_log($pdo,$this_user_id,'lookup_list_items',$id,'UPDATE','Updated lookup list item');
-      echo json_encode(['success'=>true,'message'=>'Item updated','item'=>['id'=>$id,'label'=>$label,'value'=>$value,'sort_order'=>$sort]]);
+      echo json_encode(['success'=>true,'message'=>'Item updated','item'=>['id'=>$id,'label'=>$label,'value'=>$value,'active_from'=>$active_from,'active_to'=>$active_to,'sort_order'=>$sort]]);
     }catch(PDOException $e){
       if($e->getCode()==='23000'){
         echo json_encode(['success'=>false,'error'=>'Label already exists']);

--- a/admin/api/system-properties.php
+++ b/admin/api/system-properties.php
@@ -9,7 +9,7 @@ try{
   switch($action){
     case 'list':
       require_permission('system_properties','read');
-      $stmt = $pdo->query('SELECT sp.id, sp.name, sp.value, c.label AS category, t.label AS type FROM system_properties sp JOIN lookup_list_items c ON sp.category_id=c.id JOIN lookup_list_items t ON sp.type_id=t.id ORDER BY sp.name');
+      $stmt = $pdo->query('SELECT sp.id, sp.name, sp.value, c.label AS category, t.label AS type FROM system_properties sp JOIN lookup_list_items c ON sp.category_id=c.id AND c.active_from <= CURDATE() AND (c.active_to IS NULL OR c.active_to >= CURDATE()) JOIN lookup_list_items t ON sp.type_id=t.id AND t.active_from <= CURDATE() AND (t.active_to IS NULL OR t.active_to >= CURDATE()) ORDER BY sp.name');
       echo json_encode(['success'=>true,'properties'=>$stmt->fetchAll(PDO::FETCH_ASSOC)]);
       break;
     case 'create':
@@ -105,14 +105,14 @@ function handleSave($isUpdate=false){
 
 function lookupExists($id){
   global $pdo;
-  $stmt=$pdo->prepare('SELECT 1 FROM lookup_list_items WHERE id=:id');
+  $stmt=$pdo->prepare('SELECT 1 FROM lookup_list_items WHERE id=:id AND active_from <= CURDATE() AND (active_to IS NULL OR active_to >= CURDATE())');
   $stmt->execute([':id'=>$id]);
   return (bool)$stmt->fetchColumn();
 }
 
 function validateValue($typeId,$value){
   global $pdo;
-  $stmt=$pdo->prepare('SELECT label FROM lookup_list_items WHERE id=:id');
+  $stmt=$pdo->prepare('SELECT label FROM lookup_list_items WHERE id=:id AND active_from <= CURDATE() AND (active_to IS NULL OR active_to >= CURDATE())');
   $stmt->execute([':id'=>$typeId]);
   $label=$stmt->fetchColumn();
   if(!$label) return false;

--- a/admin/lookup-lists/attributes.php
+++ b/admin/lookup-lists/attributes.php
@@ -5,7 +5,7 @@ $token = generate_csrf_token();
 $item_id = (int)($_GET['item_id'] ?? 0);
 $message = $error = '';
 
-$stmt = $pdo->prepare('SELECT i.*, l.name AS list_name FROM lookup_list_items i JOIN lookup_lists l ON i.list_id = l.id WHERE i.id = :id');
+$stmt = $pdo->prepare('SELECT i.*, l.name AS list_name FROM lookup_list_items i JOIN lookup_lists l ON i.list_id = l.id WHERE i.id = :id AND i.active_from <= CURDATE() AND (i.active_to IS NULL OR i.active_to >= CURDATE())');
 $stmt->execute([':id'=>$item_id]);
 $item = $stmt->fetch(PDO::FETCH_ASSOC);
 if(!$item){

--- a/admin/lookup-lists/index.php
+++ b/admin/lookup-lists/index.php
@@ -91,9 +91,11 @@ $lists = $stmt->fetchAll(PDO::FETCH_ASSOC);
           <input type="hidden" name="csrf_token" value="<?= $token; ?>">
           <input type="hidden" name="list_id" id="item-list-id">
           <input type="hidden" name="id" id="item-id">
-          <div class="col-md-4"><input class="form-control" name="label" id="item-label" placeholder="Label" required></div>
-          <div class="col-md-4"><input class="form-control" name="value" id="item-value" placeholder="Value"></div>
-          <div class="col-md-2"><input class="form-control" type="number" name="sort_order" id="item-sort" placeholder="Sort"></div>
+          <div class="col-md-3"><input class="form-control" name="label" id="item-label" placeholder="Label" required></div>
+          <div class="col-md-2"><input class="form-control" name="value" id="item-value" placeholder="Value"></div>
+          <div class="col-md-2"><input class="form-control" type="date" name="active_from" id="item-active-from" value="<?= date('Y-m-d'); ?>" required></div>
+          <div class="col-md-2"><input class="form-control" type="date" name="active_to" id="item-active-to"></div>
+          <div class="col-md-1"><input class="form-control" type="number" name="sort_order" id="item-sort" placeholder="Sort"></div>
           <div class="col-md-2">
             <button class="btn btn-primary w-100" type="submit" id="itemSaveBtn">
               <span class="spinner-border spinner-border-sm d-none" id="itemLoading"></span>
@@ -102,7 +104,7 @@ $lists = $stmt->fetchAll(PDO::FETCH_ASSOC);
           </div>
         </form>
         <table class="table table-striped table-sm" id="itemsTable">
-          <thead><tr><th>Label</th><th>Value</th><th>Sort</th><th>Attributes</th><th>Actions</th></tr></thead>
+          <thead><tr><th>Label</th><th>Value</th><th>Active From</th><th>Active To</th><th>Sort</th><th>Attributes</th><th>Actions</th></tr></thead>
           <tbody></tbody>
         </table>
       </div>
@@ -234,16 +236,16 @@ $(function(){
   });
 
   function loadItems(listId){
-    $('#itemsTable tbody').html('<tr><td colspan="5" class="text-center">Loading...</td></tr>');
+    $('#itemsTable tbody').html('<tr><td colspan="7" class="text-center">Loading...</td></tr>');
     $.getJSON('../api/lookup-lists.php', {entity:'item', action:'list', list_id:listId}, function(res){
       if(res.success){
         var rows='';
         $.each(res.items, function(i,it){
-          rows+='<tr data-id="'+it.id+'"><td class="label">'+it.label+'</td><td class="value">'+it.value+'</td><td class="sort_order">'+it.sort_order+'</td><td><button class="btn btn-sm btn-secondary attributes-item">Attributes</button></td><td><button class="btn btn-sm btn-warning edit-item">Edit</button> <button class="btn btn-sm btn-danger delete-item">Delete</button></td></tr>';
+          rows+='<tr data-id="'+it.id+'"><td class="label">'+it.label+'</td><td class="value">'+it.value+'</td><td class="active_from">'+(it.active_from||'')+'</td><td class="active_to">'+(it.active_to||'')+'</td><td class="sort_order">'+it.sort_order+'</td><td><button class="btn btn-sm btn-secondary attributes-item">Attributes</button></td><td><button class="btn btn-sm btn-warning edit-item">Edit</button> <button class="btn btn-sm btn-danger delete-item">Delete</button></td></tr>';
         });
         $('#itemsTable tbody').html(rows);
       }else{
-        $('#itemsTable tbody').html('<tr><td colspan="5" class="text-center">'+res.error+'</td></tr>');
+        $('#itemsTable tbody').html('<tr><td colspan="7" class="text-center">'+res.error+'</td></tr>');
       }
     });
   }
@@ -272,6 +274,8 @@ $(function(){
     $('#item-id').val(tr.data('id'));
     $('#item-label').val(tr.find('.label').text());
     $('#item-value').val(tr.find('.value').text());
+    $('#item-active-from').val(tr.find('.active_from').text());
+    $('#item-active-to').val(tr.find('.active_to').text());
     $('#item-sort').val(tr.find('.sort_order').text());
   });
 

--- a/admin/lookup-lists/items.php
+++ b/admin/lookup-lists/items.php
@@ -25,17 +25,19 @@ if($_SERVER['REQUEST_METHOD']==='POST'){
     $item_id=(int)($_POST['id'] ?? 0);
     $label=trim($_POST['label'] ?? '');
     $value=trim($_POST['value'] ?? '');
+    $active_from=$_POST['active_from'] ?? date('Y-m-d');
+    $active_to=$_POST['active_to'] ?? null;
     $sort=(int)($_POST['sort_order'] ?? 0);
     if($label===''){$error='Label is required.';}
     if(!$error){
       if($item_id){
-        $stmt=$pdo->prepare('UPDATE lookup_list_items SET label=:label, value=:value, sort_order=:sort, user_updated=:uid WHERE id=:id');
-        $stmt->execute([':label'=>$label, ':value'=>$value, ':sort'=>$sort, ':uid'=>$this_user_id, ':id'=>$item_id]);
+        $stmt=$pdo->prepare('UPDATE lookup_list_items SET label=:label, value=:value, active_from=:active_from, active_to=:active_to, sort_order=:sort, user_updated=:uid WHERE id=:id');
+        $stmt->execute([':label'=>$label, ':value'=>$value, ':active_from'=>$active_from, ':active_to'=>$active_to, ':sort'=>$sort, ':uid'=>$this_user_id, ':id'=>$item_id]);
         audit_log($pdo,$this_user_id,'lookup_list_items',$item_id,'UPDATE','Updated lookup list item');
         $message='Item updated.';
       }else{
-        $stmt=$pdo->prepare('INSERT INTO lookup_list_items (user_id,user_updated,list_id,label,value,sort_order) VALUES (:uid,:uid,:list_id,:label,:value,:sort)');
-        $stmt->execute([':uid'=>$this_user_id, ':list_id'=>$list_id, ':label'=>$label, ':value'=>$value, ':sort'=>$sort]);
+        $stmt=$pdo->prepare('INSERT INTO lookup_list_items (user_id,user_updated,list_id,label,value,active_from,active_to,sort_order) VALUES (:uid,:uid,:list_id,:label,:value,:active_from,:active_to,:sort)');
+        $stmt->execute([':uid'=>$this_user_id, ':list_id'=>$list_id, ':label'=>$label, ':value'=>$value, ':active_from'=>$active_from, ':active_to'=>$active_to, ':sort'=>$sort]);
         $item_id=$pdo->lastInsertId();
         audit_log($pdo,$this_user_id,'lookup_list_items',$item_id,'CREATE','Created lookup list item');
         $message='Item added.';
@@ -44,7 +46,7 @@ if($_SERVER['REQUEST_METHOD']==='POST'){
   }
 }
 
-$stmt=$pdo->prepare('SELECT * FROM lookup_list_items WHERE list_id=:list_id ORDER BY sort_order,label');
+$stmt=$pdo->prepare('SELECT * FROM lookup_list_items WHERE list_id=:list_id AND active_from <= CURDATE() AND (active_to IS NULL OR active_to >= CURDATE()) ORDER BY sort_order,label');
 $stmt->execute([':list_id'=>$list_id]);
 $items=$stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
@@ -55,12 +57,14 @@ $items=$stmt->fetchAll(PDO::FETCH_ASSOC);
   <input type="hidden" name="csrf_token" value="<?= $token; ?>">
   <input type="hidden" name="id" value="<?= htmlspecialchars($_POST['id'] ?? ''); ?>">
   <div class="col-md-3"><input class="form-control" name="label" placeholder="Label" value="<?= htmlspecialchars($_POST['label'] ?? ''); ?>" required></div>
-  <div class="col-md-3"><input class="form-control" name="value" placeholder="Value" value="<?= htmlspecialchars($_POST['value'] ?? ''); ?>"></div>
-  <div class="col-md-2"><input class="form-control" type="number" name="sort_order" placeholder="Sort" value="<?= htmlspecialchars($_POST['sort_order'] ?? 0); ?>"></div>
-  <div class="col-md-2"><button class="btn btn-success" type="submit" id="saveBtn">Save Item</button></div>
-  <div class="col-md-2"><a class="btn btn-secondary" href="index.php">Back</a></div>
+  <div class="col-md-2"><input class="form-control" name="value" placeholder="Value" value="<?= htmlspecialchars($_POST['value'] ?? ''); ?>"></div>
+  <div class="col-md-2"><input class="form-control" type="date" name="active_from" value="<?= htmlspecialchars($_POST['active_from'] ?? date('Y-m-d')); ?>" required></div>
+  <div class="col-md-2"><input class="form-control" type="date" name="active_to" value="<?= htmlspecialchars($_POST['active_to'] ?? ''); ?>"></div>
+  <div class="col-md-1"><input class="form-control" type="number" name="sort_order" placeholder="Sort" value="<?= htmlspecialchars($_POST['sort_order'] ?? 0); ?>"></div>
+  <div class="col-md-1"><button class="btn btn-success w-100" type="submit" id="saveBtn">Save</button></div>
+  <div class="col-md-1"><a class="btn btn-secondary w-100" href="index.php">Back</a></div>
 </form>
-<div id="items" data-list='{"valueNames":["label","value","sort_order"],"page":10,"pagination":true}'>
+<div id="items" data-list='{"valueNames":["label","value","active_from","active_to","sort_order"],"page":10,"pagination":true}'>
   <div class="row justify-content-between g-2 mb-3">
     <div class="col-auto">
       <input class="form-control form-control-sm search" placeholder="Search" />
@@ -69,17 +73,19 @@ $items=$stmt->fetchAll(PDO::FETCH_ASSOC);
   <div class="table-responsive">
     <table class="table table-striped table-sm mb-0">
       <thead>
-        <tr><th class="sort" data-sort="label">Label</th><th class="sort" data-sort="value">Value</th><th class="sort" data-sort="sort_order">Sort</th><th>Attributes</th><th>Actions</th></tr>
+        <tr><th class="sort" data-sort="label">Label</th><th class="sort" data-sort="value">Value</th><th class="sort" data-sort="active_from">Active From</th><th class="sort" data-sort="active_to">Active To</th><th class="sort" data-sort="sort_order">Sort</th><th>Attributes</th><th>Actions</th></tr>
       </thead>
       <tbody class="list">
         <?php foreach($items as $it): ?>
           <tr>
             <td class="label"><?= htmlspecialchars($it['label']); ?></td>
             <td class="value"><?= htmlspecialchars($it['value']); ?></td>
+            <td class="active_from"><?= htmlspecialchars($it['active_from']); ?></td>
+            <td class="active_to"><?= htmlspecialchars($it['active_to']); ?></td>
             <td class="sort_order"><?= htmlspecialchars($it['sort_order']); ?></td>
             <td><a class="btn btn-sm btn-info" href="attributes.php?item_id=<?= $it['id']; ?>&list_id=<?= $list_id; ?>">Attributes</a></td>
             <td>
-              <button class="btn btn-sm btn-warning" onclick="fillForm(<?= $it['id']; ?>,'<?= htmlspecialchars($it['label'],ENT_QUOTES); ?>','<?= htmlspecialchars($it['value'],ENT_QUOTES); ?>',<?= (int)$it['sort_order']; ?>);return false;">Edit</button>
+              <button class="btn btn-sm btn-warning" onclick="fillForm(<?= $it['id']; ?>,'<?= htmlspecialchars($it['label'],ENT_QUOTES); ?>','<?= htmlspecialchars($it['value'],ENT_QUOTES); ?>','<?= htmlspecialchars($it['active_from']); ?>','<?= htmlspecialchars($it['active_to']); ?>',<?= (int)$it['sort_order']; ?>);return false;">Edit</button>
               <form method="post" class="d-inline">
                 <input type="hidden" name="delete_id" value="<?= $it['id']; ?>">
                 <input type="hidden" name="csrf_token" value="<?= $token; ?>">
@@ -97,11 +103,13 @@ $items=$stmt->fetchAll(PDO::FETCH_ASSOC);
   </div>
 </div>
 <script>
-function fillForm(id,label,value,sort){
+function fillForm(id,label,value,active_from,active_to,sort){
   const f=document.forms[0];
   f.id.value=id;
   f.label.value=label;
   f.value.value=value;
+  f.active_from.value=active_from;
+  f.active_to.value=active_to;
   f.sort_order.value=sort;
   const btn=document.getElementById('saveBtn');
   btn.classList.remove('btn-success');

--- a/admin/orgs/agency_edit.php
+++ b/admin/orgs/agency_edit.php
@@ -41,7 +41,7 @@ $orgOptions = $orgStmt->fetchAll(PDO::FETCH_KEY_PAIR);
 $personStmt = $pdo->query('SELECT id, CONCAT(first_name, " ", last_name) AS name FROM person ORDER BY first_name, last_name');
 $personOptions = $personStmt->fetchAll(PDO::FETCH_KEY_PAIR);
 
-$statusStmt = $pdo->prepare("SELECT li.id, li.label FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'AGENCY_STATUS' ORDER BY li.sort_order, li.label");
+$statusStmt = $pdo->prepare("SELECT li.id, li.label FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'AGENCY_STATUS' AND li.active_from <= CURDATE() AND (li.active_to IS NULL OR li.active_to >= CURDATE()) ORDER BY li.sort_order, li.label");
 $statusStmt->execute();
 $statusOptions = $statusStmt->fetchAll(PDO::FETCH_KEY_PAIR);
 

--- a/admin/orgs/division_edit.php
+++ b/admin/orgs/division_edit.php
@@ -33,7 +33,7 @@ $agencyOptions = $agencyStmt->fetchAll(PDO::FETCH_KEY_PAIR);
 $personStmt = $pdo->query('SELECT id, CONCAT(first_name, " ", last_name) AS name FROM person ORDER BY first_name, last_name');
 $personOptions = $personStmt->fetchAll(PDO::FETCH_KEY_PAIR);
 
-$statusStmt = $pdo->prepare("SELECT li.id, li.label FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'DIVISION_STATUS' ORDER BY li.sort_order, li.label");
+$statusStmt = $pdo->prepare("SELECT li.id, li.label FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'DIVISION_STATUS' AND li.active_from <= CURDATE() AND (li.active_to IS NULL OR li.active_to >= CURDATE()) ORDER BY li.sort_order, li.label");
 $statusStmt->execute();
 $statusOptions = $statusStmt->fetchAll(PDO::FETCH_KEY_PAIR);
 

--- a/admin/orgs/index.php
+++ b/admin/orgs/index.php
@@ -34,21 +34,21 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   }
 }
 
-$orgStatusStmt = $pdo->prepare("SELECT li.id, li.label, li.value FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'ORGANIZATION_STATUS'");
+$orgStatusStmt = $pdo->prepare("SELECT li.id, li.label, li.value FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'ORGANIZATION_STATUS' AND li.active_from <= CURDATE() AND (li.active_to IS NULL OR li.active_to >= CURDATE())");
 $orgStatusStmt->execute();
 $orgStatuses = [];
 foreach ($orgStatusStmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
   $orgStatuses[$row['id']] = $row;
 }
 
-$agencyStatusStmt = $pdo->prepare("SELECT li.id, li.label, li.value FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'AGENCY_STATUS'");
+$agencyStatusStmt = $pdo->prepare("SELECT li.id, li.label, li.value FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'AGENCY_STATUS' AND li.active_from <= CURDATE() AND (li.active_to IS NULL OR li.active_to >= CURDATE())");
 $agencyStatusStmt->execute();
 $agencyStatuses = [];
 foreach ($agencyStatusStmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
   $agencyStatuses[$row['id']] = $row;
 }
 
-$divisionStatusStmt = $pdo->prepare("SELECT li.id, li.label, li.value FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'DIVISION_STATUS'");
+$divisionStatusStmt = $pdo->prepare("SELECT li.id, li.label, li.value FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'DIVISION_STATUS' AND li.active_from <= CURDATE() AND (li.active_to IS NULL OR li.active_to >= CURDATE())");
 $divisionStatusStmt->execute();
 $divisionStatuses = [];
 foreach ($divisionStatusStmt->fetchAll(PDO::FETCH_ASSOC) as $row) {

--- a/admin/orgs/organization_edit.php
+++ b/admin/orgs/organization_edit.php
@@ -28,7 +28,7 @@ $_SESSION['csrf_token'] = $token;
 $personStmt = $pdo->query('SELECT id, CONCAT(first_name, " ", last_name) AS name FROM person ORDER BY first_name, last_name');
 $personOptions = $personStmt->fetchAll(PDO::FETCH_KEY_PAIR);
 
-$statusStmt = $pdo->prepare("SELECT li.id, li.label FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'ORGANIZATION_STATUS' ORDER BY li.sort_order, li.label");
+$statusStmt = $pdo->prepare("SELECT li.id, li.label FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'ORGANIZATION_STATUS' AND li.active_from <= CURDATE() AND (li.active_to IS NULL OR li.active_to >= CURDATE()) ORDER BY li.sort_order, li.label");
 $statusStmt->execute();
 $statusOptions = $statusStmt->fetchAll(PDO::FETCH_KEY_PAIR);
 

--- a/admin/system-properties/edit.php
+++ b/admin/system-properties/edit.php
@@ -6,7 +6,7 @@ $token = generate_csrf_token();
 
 function fetchLookupItems($name){
   global $pdo;
-  $stmt = $pdo->prepare('SELECT lli.id, lli.label FROM lookup_lists ll JOIN lookup_list_items lli ON ll.id = lli.list_id WHERE ll.name = :name ORDER BY lli.sort_order, lli.label');
+  $stmt = $pdo->prepare('SELECT lli.id, lli.label FROM lookup_lists ll JOIN lookup_list_items lli ON ll.id = lli.list_id WHERE ll.name = :name AND lli.active_from <= CURDATE() AND (lli.active_to IS NULL OR lli.active_to >= CURDATE()) ORDER BY lli.sort_order, lli.label');
   $stmt->execute([':name'=>$name]);
   return $stmt->fetchAll(PDO::FETCH_ASSOC);
 }

--- a/admin/system-properties/index.php
+++ b/admin/system-properties/index.php
@@ -4,7 +4,7 @@ require_permission('system_properties','read');
 
 $token = generate_csrf_token();
 
-$stmt = $pdo->query('SELECT sp.id, sp.name, sp.value, sp.memo, c.label AS category, t.label AS type FROM system_properties sp JOIN lookup_list_items c ON sp.category_id = c.id JOIN lookup_list_items t ON sp.type_id = t.id ORDER BY sp.name');
+$stmt = $pdo->query('SELECT sp.id, sp.name, sp.value, sp.memo, c.label AS category, t.label AS type FROM system_properties sp JOIN lookup_list_items c ON sp.category_id = c.id AND c.active_from <= CURDATE() AND (c.active_to IS NULL OR c.active_to >= CURDATE()) JOIN lookup_list_items t ON sp.type_id = t.id AND t.active_from <= CURDATE() AND (t.active_to IS NULL OR t.active_to >= CURDATE()) ORDER BY sp.name');
 $props = $stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <h2 class="mb-4">System Properties</h2>

--- a/admin/users/edit.php
+++ b/admin/users/edit.php
@@ -37,11 +37,11 @@ $_SESSION['csrf_token'] = $token;
 
 $roles = $pdo->query('SELECT id, name FROM admin_roles ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
 
-$typeStmt = $pdo->prepare("SELECT li.value, li.label FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'USER_TYPE' ORDER BY li.sort_order, li.label");
+$typeStmt = $pdo->prepare("SELECT li.value, li.label FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'USER_TYPE' AND li.active_from <= CURDATE() AND (li.active_to IS NULL OR li.active_to >= CURDATE()) ORDER BY li.sort_order, li.label");
 $typeStmt->execute();
 $typeOptions = $typeStmt->fetchAll(PDO::FETCH_KEY_PAIR);
 
-$statusStmt = $pdo->prepare("SELECT li.value, li.label FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'USER_STATUS' ORDER BY li.sort_order, li.label");
+$statusStmt = $pdo->prepare("SELECT li.value, li.label FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'USER_STATUS' AND li.active_from <= CURDATE() AND (li.active_to IS NULL OR li.active_to >= CURDATE()) ORDER BY li.sort_order, li.label");
 $statusStmt->execute();
 $statusOptions = $statusStmt->fetchAll(PDO::FETCH_KEY_PAIR);
 

--- a/admin/users/index.php
+++ b/admin/users/index.php
@@ -6,11 +6,11 @@ $token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
 $_SESSION['csrf_token'] = $token;
 $message = '';
 
-$typeStmt = $pdo->prepare("SELECT li.value, li.label FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'USER_TYPE' ORDER BY li.sort_order, li.label");
+$typeStmt = $pdo->prepare("SELECT li.value, li.label FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'USER_TYPE' AND li.active_from <= CURDATE() AND (li.active_to IS NULL OR li.active_to >= CURDATE()) ORDER BY li.sort_order, li.label");
 $typeStmt->execute();
 $typeOptions = $typeStmt->fetchAll(PDO::FETCH_KEY_PAIR);
 
-$statusStmt = $pdo->prepare("SELECT li.value, li.label FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'USER_STATUS' ORDER BY li.sort_order, li.label");
+$statusStmt = $pdo->prepare("SELECT li.value, li.label FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'USER_STATUS' AND li.active_from <= CURDATE() AND (li.active_to IS NULL OR li.active_to >= CURDATE()) ORDER BY li.sort_order, li.label");
 $statusStmt->execute();
 $statusOptions = $statusStmt->fetchAll(PDO::FETCH_KEY_PAIR);
 

--- a/admin/users/new.php
+++ b/admin/users/new.php
@@ -15,11 +15,11 @@ $btnClass = 'btn-success';
 
 $roles = $pdo->query('SELECT id, name FROM admin_roles ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
 
-$typeStmt = $pdo->prepare("SELECT li.value, li.label FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'USER_TYPE' ORDER BY li.sort_order, li.label");
+$typeStmt = $pdo->prepare("SELECT li.value, li.label FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'USER_TYPE' AND li.active_from <= CURDATE() AND (li.active_to IS NULL OR li.active_to >= CURDATE()) ORDER BY li.sort_order, li.label");
 $typeStmt->execute();
 $typeOptions = $typeStmt->fetchAll(PDO::FETCH_KEY_PAIR);
 
-$statusStmt = $pdo->prepare("SELECT li.value, li.label FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'USER_STATUS' ORDER BY li.sort_order, li.label");
+$statusStmt = $pdo->prepare("SELECT li.value, li.label FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'USER_STATUS' AND li.active_from <= CURDATE() AND (li.active_to IS NULL OR li.active_to >= CURDATE()) ORDER BY li.sort_order, li.label");
 $statusStmt->execute();
 $statusOptions = $statusStmt->fetchAll(PDO::FETCH_KEY_PAIR);
 

--- a/module/agency/index.php
+++ b/module/agency/index.php
@@ -7,7 +7,7 @@ $action = $_GET['action'] ?? 'card';
 // Fetch agencies and status labels
 $sql = "SELECT a.id, a.name, li.label AS status_label
         FROM module_agency a
-        LEFT JOIN lookup_list_items li ON a.status = li.id
+        LEFT JOIN lookup_list_items li ON a.status = li.id AND li.active_from <= CURDATE() AND (li.active_to IS NULL OR li.active_to >= CURDATE())
         LEFT JOIN lookup_lists l ON li.list_id = l.id AND l.name = 'AGENCY_STATUS'
         ORDER BY a.name";
 $stmt = $pdo->query($sql);


### PR DESCRIPTION
## Summary
- add `active_from` and `active_to` columns to lookup list items and migrations
- expose active date fields through lookup list item API and admin UI
- filter lookup list items globally by active date range

## Testing
- `php -l admin/api/lookup-lists.php admin/lookup-lists/index.php admin/lookup-lists/items.php admin/lookup-lists/attributes.php admin/system-properties/edit.php admin/system-properties/index.php admin/api/system-properties.php admin/users/edit.php admin/users/index.php admin/users/new.php admin/orgs/organization_edit.php admin/orgs/agency_edit.php admin/orgs/index.php admin/orgs/division_edit.php module/agency/index.php`
- `mysql -uroot testdb -e "SELECT label,active_from,active_to FROM lookup_list_items WHERE list_id=1 AND active_from <= CURDATE() AND (active_to IS NULL OR active_to >= CURDATE()) ORDER BY label;"`


------
https://chatgpt.com/codex/tasks/task_e_689bf61e1e74833395ddcd764e9d637c