### PR TITLE
Harden agency file uploads

### DIFF
--- a/admin/orgs/index.php
+++ b/admin/orgs/index.php
@@ -102,7 +102,7 @@ $organizations = $orgStmt->fetchAll(PDO::FETCH_ASSOC);
           <tr class="bg-body-tertiary">
             <td class="ps-4">Agency: <?= htmlspecialchars($agency['name']); ?>
               <?php if(!empty($agency['file_path'])): ?>
-                <br><a href="<?= htmlspecialchars($agency['file_path']); ?>" target="_blank">View File</a>
+                <br><a href="/module/agency/download.php?id=<?= $agency['id']; ?>" target="_blank">View File</a>
               <?php endif; ?>
             </td>
             <td>

--- a/module/agency/download.php
+++ b/module/agency/download.php
@@ -1,0 +1,33 @@
+<?php
+require '../../includes/php_header.php';
+require_permission('agency','read');
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+if (!$id) {
+  header('HTTP/1.1 400 Bad Request');
+  exit('Bad Request');
+}
+
+$stmt = $pdo->prepare('SELECT file_name, file_path, file_size, file_type FROM module_agency WHERE id = ?');
+$stmt->execute([$id]);
+$file = $stmt->fetch(PDO::FETCH_ASSOC);
+
+if (!$file || empty($file['file_path'])) {
+  header('HTTP/1.1 404 Not Found');
+  exit('File not found');
+}
+
+$uploadDir = dirname(__DIR__, 3) . '/uploads/agency/';
+$path = $uploadDir . $file['file_path'];
+
+if (!is_file($path) || !is_readable($path)) {
+  header('HTTP/1.1 404 Not Found');
+  exit('File not found');
+}
+
+header('Content-Type: ' . $file['file_type']);
+header('Content-Length: ' . $file['file_size']);
+header('Content-Disposition: attachment; filename="' . basename($file['file_name']) . '"');
+readfile($path);
+exit;
+?>


### PR DESCRIPTION
## Summary
- validate agency uploads against allowed MIME types and store with random names outside the web root
- add audit logging for uploads and serve files through a permission-checked download script

## Testing
- `php -l admin/orgs/agency_edit.php`
- `php -l admin/orgs/index.php`
- `php -l module/agency/download.php`


------
https://chatgpt.com/codex/tasks/task_e_689d1b08b2588333945e42e295543a0d