### PR TITLE
Centralize lookup list access with color classes

### DIFF
--- a/admin/orgs/agency_edit.php
+++ b/admin/orgs/agency_edit.php
@@ -41,9 +41,8 @@ $orgOptions = $orgStmt->fetchAll(PDO::FETCH_KEY_PAIR);
 $personStmt = $pdo->query('SELECT id, CONCAT(first_name, " ", last_name) AS name FROM person ORDER BY first_name, last_name');
 $personOptions = $personStmt->fetchAll(PDO::FETCH_KEY_PAIR);
 
-$statusStmt = $pdo->prepare("SELECT li.id, li.label FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'AGENCY_STATUS' AND li.active_from <= CURDATE() AND (li.active_to IS NULL OR li.active_to >= CURDATE()) ORDER BY li.sort_order, li.label");
-$statusStmt->execute();
-$statusOptions = $statusStmt->fetchAll(PDO::FETCH_KEY_PAIR);
+$statusItems   = get_lookup_items($pdo, 'AGENCY_STATUS');
+$statusOptions = array_column($statusItems, 'label', 'id');
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   if (!hash_equals($token, $_POST['csrf_token'] ?? '')) {

--- a/admin/orgs/division_edit.php
+++ b/admin/orgs/division_edit.php
@@ -33,9 +33,8 @@ $agencyOptions = $agencyStmt->fetchAll(PDO::FETCH_KEY_PAIR);
 $personStmt = $pdo->query('SELECT id, CONCAT(first_name, " ", last_name) AS name FROM person ORDER BY first_name, last_name');
 $personOptions = $personStmt->fetchAll(PDO::FETCH_KEY_PAIR);
 
-$statusStmt = $pdo->prepare("SELECT li.id, li.label FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'DIVISION_STATUS' AND li.active_from <= CURDATE() AND (li.active_to IS NULL OR li.active_to >= CURDATE()) ORDER BY li.sort_order, li.label");
-$statusStmt->execute();
-$statusOptions = $statusStmt->fetchAll(PDO::FETCH_KEY_PAIR);
+$statusItems   = get_lookup_items($pdo, 'DIVISION_STATUS');
+$statusOptions = array_column($statusItems, 'label', 'id');
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   if (!hash_equals($token, $_POST['csrf_token'] ?? '')) {

--- a/admin/orgs/index.php
+++ b/admin/orgs/index.php
@@ -34,26 +34,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   }
 }
 
-$orgStatusStmt = $pdo->prepare("SELECT li.id, li.label, li.value FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'ORGANIZATION_STATUS' AND li.active_from <= CURDATE() AND (li.active_to IS NULL OR li.active_to >= CURDATE())");
-$orgStatusStmt->execute();
-$orgStatuses = [];
-foreach ($orgStatusStmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
-  $orgStatuses[$row['id']] = $row;
-}
-
-$agencyStatusStmt = $pdo->prepare("SELECT li.id, li.label, li.value FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'AGENCY_STATUS' AND li.active_from <= CURDATE() AND (li.active_to IS NULL OR li.active_to >= CURDATE())");
-$agencyStatusStmt->execute();
-$agencyStatuses = [];
-foreach ($agencyStatusStmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
-  $agencyStatuses[$row['id']] = $row;
-}
-
-$divisionStatusStmt = $pdo->prepare("SELECT li.id, li.label, li.value FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'DIVISION_STATUS' AND li.active_from <= CURDATE() AND (li.active_to IS NULL OR li.active_to >= CURDATE())");
-$divisionStatusStmt->execute();
-$divisionStatuses = [];
-foreach ($divisionStatusStmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
-  $divisionStatuses[$row['id']] = $row;
-}
+$orgStatuses      = array_column(get_lookup_items($pdo, 'ORGANIZATION_STATUS'), null, 'id');
+$agencyStatuses   = array_column(get_lookup_items($pdo, 'AGENCY_STATUS'), null, 'id');
+$divisionStatuses = array_column(get_lookup_items($pdo, 'DIVISION_STATUS'), null, 'id');
 
 $orgStmt = $pdo->query('SELECT id, name, status FROM module_organization ORDER BY name');
 $organizations = $orgStmt->fetchAll(PDO::FETCH_ASSOC);
@@ -77,8 +60,8 @@ $organizations = $orgStmt->fetchAll(PDO::FETCH_ASSOC);
         <tr>
           <td><?= htmlspecialchars($org['name']); ?></td>
           <td>
-            <?php $status = $orgStatuses[$org['status']] ?? null; $class = ($status['value'] ?? '') === 'active' ? 'badge-phoenix-success' : 'badge-phoenix-warning'; ?>
-            <span class="badge badge-phoenix fs-10 <?= $class; ?>"><span class="badge-label"><?= htmlspecialchars($status['label'] ?? ''); ?></span></span>
+            <?php $status = $orgStatuses[$org['status']] ?? null; $class = $status['color_class'] ?? 'secondary'; ?>
+            <span class="badge badge-phoenix fs-10 badge-phoenix-<?= htmlspecialchars($class); ?>"><span class="badge-label"><?= htmlspecialchars($status['label'] ?? ''); ?></span></span>
           </td>
           <td>
             <a class="btn btn-sm btn-warning" href="organization_edit.php?id=<?= $org['id']; ?>">Edit</a>
@@ -106,8 +89,8 @@ $organizations = $orgStmt->fetchAll(PDO::FETCH_ASSOC);
               <?php endif; ?>
             </td>
             <td>
-              <?php $aStatus = $agencyStatuses[$agency['status']] ?? null; $aClass = ($aStatus['value'] ?? '') === 'active' ? 'badge-phoenix-success' : 'badge-phoenix-warning'; ?>
-              <span class="badge badge-phoenix fs-10 <?= $aClass; ?>"><span class="badge-label"><?= htmlspecialchars($aStatus['label'] ?? ''); ?></span></span>
+              <?php $aStatus = $agencyStatuses[$agency['status']] ?? null; $aClass = $aStatus['color_class'] ?? 'secondary'; ?>
+              <span class="badge badge-phoenix fs-10 badge-phoenix-<?= htmlspecialchars($aClass); ?>"><span class="badge-label"><?= htmlspecialchars($aStatus['label'] ?? ''); ?></span></span>
             </td>
             <td>
               <a class="btn btn-sm btn-warning" href="agency_edit.php?id=<?= $agency['id']; ?>">Edit</a>
@@ -131,8 +114,8 @@ $organizations = $orgStmt->fetchAll(PDO::FETCH_ASSOC);
             <tr class="bg-body-secondary">
               <td class="ps-5">Division: <?= htmlspecialchars($division['name']); ?></td>
               <td>
-                <?php $dStatus = $divisionStatuses[$division['status']] ?? null; $dClass = ($dStatus['value'] ?? '') === 'active' ? 'badge-phoenix-success' : 'badge-phoenix-warning'; ?>
-                <span class="badge badge-phoenix fs-10 <?= $dClass; ?>"><span class="badge-label"><?= htmlspecialchars($dStatus['label'] ?? ''); ?></span></span>
+                <?php $dStatus = $divisionStatuses[$division['status']] ?? null; $dClass = $dStatus['color_class'] ?? 'secondary'; ?>
+                <span class="badge badge-phoenix fs-10 badge-phoenix-<?= htmlspecialchars($dClass); ?>"><span class="badge-label"><?= htmlspecialchars($dStatus['label'] ?? ''); ?></span></span>
               </td>
               <td>
                 <a class="btn btn-sm btn-warning" href="division_edit.php?id=<?= $division['id']; ?>">Edit</a>

--- a/admin/orgs/organization_edit.php
+++ b/admin/orgs/organization_edit.php
@@ -28,9 +28,8 @@ $_SESSION['csrf_token'] = $token;
 $personStmt = $pdo->query('SELECT id, CONCAT(first_name, " ", last_name) AS name FROM person ORDER BY first_name, last_name');
 $personOptions = $personStmt->fetchAll(PDO::FETCH_KEY_PAIR);
 
-$statusStmt = $pdo->prepare("SELECT li.id, li.label FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'ORGANIZATION_STATUS' AND li.active_from <= CURDATE() AND (li.active_to IS NULL OR li.active_to >= CURDATE()) ORDER BY li.sort_order, li.label");
-$statusStmt->execute();
-$statusOptions = $statusStmt->fetchAll(PDO::FETCH_KEY_PAIR);
+$statusItems   = get_lookup_items($pdo, 'ORGANIZATION_STATUS');
+$statusOptions = array_column($statusItems, 'label', 'id');
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   if (!hash_equals($token, $_POST['csrf_token'] ?? '')) {

--- a/admin/users/edit.php
+++ b/admin/users/edit.php
@@ -37,13 +37,11 @@ $_SESSION['csrf_token'] = $token;
 
 $roles = $pdo->query('SELECT id, name FROM admin_roles ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
 
-$typeStmt = $pdo->prepare("SELECT li.value, li.label FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'USER_TYPE' AND li.active_from <= CURDATE() AND (li.active_to IS NULL OR li.active_to >= CURDATE()) ORDER BY li.sort_order, li.label");
-$typeStmt->execute();
-$typeOptions = $typeStmt->fetchAll(PDO::FETCH_KEY_PAIR);
+$typeItems   = get_lookup_items($pdo, 'USER_TYPE');
+$typeOptions = array_column($typeItems, 'label', 'value');
 
-$statusStmt = $pdo->prepare("SELECT li.value, li.label FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'USER_STATUS' AND li.active_from <= CURDATE() AND (li.active_to IS NULL OR li.active_to >= CURDATE()) ORDER BY li.sort_order, li.label");
-$statusStmt->execute();
-$statusOptions = $statusStmt->fetchAll(PDO::FETCH_KEY_PAIR);
+$statusItems   = get_lookup_items($pdo, 'USER_STATUS');
+$statusOptions = array_column($statusItems, 'label', 'value');
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!hash_equals($token, $_POST['csrf_token'] ?? '')) {

--- a/admin/users/index.php
+++ b/admin/users/index.php
@@ -6,13 +6,13 @@ $token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
 $_SESSION['csrf_token'] = $token;
 $message = '';
 
-$typeStmt = $pdo->prepare("SELECT li.value, li.label FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'USER_TYPE' AND li.active_from <= CURDATE() AND (li.active_to IS NULL OR li.active_to >= CURDATE()) ORDER BY li.sort_order, li.label");
-$typeStmt->execute();
-$typeOptions = $typeStmt->fetchAll(PDO::FETCH_KEY_PAIR);
+$typeItems   = get_lookup_items($pdo, 'USER_TYPE');
+$typeOptions = array_column($typeItems, 'label', 'value');
+$typeColors  = array_column($typeItems, 'color_class', 'value');
 
-$statusStmt = $pdo->prepare("SELECT li.value, li.label FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'USER_STATUS' AND li.active_from <= CURDATE() AND (li.active_to IS NULL OR li.active_to >= CURDATE()) ORDER BY li.sort_order, li.label");
-$statusStmt->execute();
-$statusOptions = $statusStmt->fetchAll(PDO::FETCH_KEY_PAIR);
+$statusItems   = get_lookup_items($pdo, 'USER_STATUS');
+$statusOptions = array_column($statusItems, 'label', 'value');
+$statusColors  = array_column($statusItems, 'color_class', 'value');
 
 $roleStmt = $pdo->query('SELECT name FROM admin_roles ORDER BY name');
 $roleOptions = $roleStmt->fetchAll(PDO::FETCH_COLUMN);
@@ -106,16 +106,21 @@ $users = $stmt->fetchAll(PDO::FETCH_ASSOC);
               <?php endforeach; ?>
             </td>
             <td class="type">
-              <span class="badge badge-phoenix fs-10 badge-phoenix-info">
-                <span class="badge-label"><?= htmlspecialchars($typeOptions[$u['type']] ?? $u['type']); ?></span>
+              <?php
+                $typeLabel = $typeOptions[$u['type']] ?? $u['type'];
+                $typeClass = $typeColors[$u['type']] ?? 'secondary';
+              ?>
+              <span class="badge badge-phoenix fs-10 badge-phoenix-<?= htmlspecialchars($typeClass); ?>">
+                <span class="badge-label"><?= htmlspecialchars($typeLabel); ?></span>
               </span>
             </td>
             <td class="status">
               <?php
-                $statusLabel = $statusOptions[(string)$u['status']] ?? ($u['status'] ? 'Active' : 'Inactive');
-                $statusClass = $u['status'] ? 'badge-phoenix-success' : 'badge-phoenix-warning';
+                $statusKey   = (string)$u['status'];
+                $statusLabel = $statusOptions[$statusKey] ?? ($u['status'] ? 'Active' : 'Inactive');
+                $statusClass = $statusColors[$statusKey] ?? 'secondary';
               ?>
-              <span class="badge badge-phoenix fs-10 <?= $statusClass; ?>">
+              <span class="badge badge-phoenix fs-10 badge-phoenix-<?= htmlspecialchars($statusClass); ?>">
                 <span class="badge-label"><?= htmlspecialchars($statusLabel); ?></span>
               </span>
             </td>

--- a/admin/users/new.php
+++ b/admin/users/new.php
@@ -15,13 +15,11 @@ $btnClass = 'btn-success';
 
 $roles = $pdo->query('SELECT id, name FROM admin_roles ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
 
-$typeStmt = $pdo->prepare("SELECT li.value, li.label FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'USER_TYPE' AND li.active_from <= CURDATE() AND (li.active_to IS NULL OR li.active_to >= CURDATE()) ORDER BY li.sort_order, li.label");
-$typeStmt->execute();
-$typeOptions = $typeStmt->fetchAll(PDO::FETCH_KEY_PAIR);
+$typeItems   = get_lookup_items($pdo, 'USER_TYPE');
+$typeOptions = array_column($typeItems, 'label', 'value');
 
-$statusStmt = $pdo->prepare("SELECT li.value, li.label FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'USER_STATUS' AND li.active_from <= CURDATE() AND (li.active_to IS NULL OR li.active_to >= CURDATE()) ORDER BY li.sort_order, li.label");
-$statusStmt->execute();
-$statusOptions = $statusStmt->fetchAll(PDO::FETCH_KEY_PAIR);
+$statusItems   = get_lookup_items($pdo, 'USER_STATUS');
+$statusOptions = array_column($statusItems, 'label', 'value');
 
 $type = array_key_first($typeOptions) ?? $type;
 $status = (int)(array_key_first($statusOptions) ?? $status);

--- a/includes/lookup_helpers.php
+++ b/includes/lookup_helpers.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Helper functions for lookup list items.
+ */
+
+/**
+ * Fetch active lookup list items by list name or ID.
+ *
+ * @param PDO         $pdo  PDO connection.
+ * @param int|string  $list Lookup list ID or name.
+ * @return array              Array of items with id, label, value and color_class.
+ */
+function get_lookup_items(PDO $pdo, int|string $list): array {
+    $param = is_numeric($list) ? ':list_id' : ':list_name';
+    $where = is_numeric($list) ? 'li.list_id = :list_id' : 'l.name = :list_name';
+
+    $sql = "SELECT li.id, li.label, li.value,
+                   COALESCE(attr.attr_value, 'secondary') AS color_class
+            FROM lookup_list_items li
+            JOIN lookup_lists l ON li.list_id = l.id
+            LEFT JOIN lookup_list_item_attributes attr
+                   ON li.id = attr.item_id AND attr.attr_key = 'COLOR-CLASS'
+            WHERE $where
+              AND li.active_from <= CURDATE()
+              AND (li.active_to IS NULL OR li.active_to >= CURDATE())
+            ORDER BY li.sort_order, li.label";
+
+    $stmt = $pdo->prepare($sql);
+    $params = is_numeric($list) ? [':list_id' => $list] : [':list_name' => $list];
+    $stmt->execute($params);
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
+
+?>

--- a/includes/php_header.php
+++ b/includes/php_header.php
@@ -5,6 +5,7 @@ date_default_timezone_set('America/Denver');
 
 // connect to Database
 require 'config.php';
+require_once __DIR__ . '/lookup_helpers.php';
 
 $today = date('Y-m-d H:i:s');
 $today_date = date('Y-m-d');

--- a/module/agency/include/board_view.php
+++ b/module/agency/include/board_view.php
@@ -3,18 +3,20 @@
 $columns = [];
 foreach ($agencies as $agency) {
   $status = $agency['status_label'] ?? 'Unassigned';
-  $columns[$status][] = $agency;
+  $color  = $agency['status_color'] ?? 'secondary';
+  $columns[$status]['color'] = $color;
+  $columns[$status]['items'][] = $agency;
 }
 ?>
 <div class="row g-3">
-  <?php foreach ($columns as $status => $items): ?>
+  <?php foreach ($columns as $status => $data): ?>
     <div class="col-12 col-md-6 col-lg-4">
       <div class="card">
         <div class="card-header bg-body-tertiary">
-          <h6 class="mb-0"><?php echo htmlspecialchars($status); ?></h6>
+          <h6 class="mb-0"><span class="badge badge-phoenix badge-phoenix-<?= htmlspecialchars($data['color']); ?>"><?php echo htmlspecialchars($status); ?></span></h6>
         </div>
         <div class="card-body">
-          <?php foreach ($items as $agency): ?>
+          <?php foreach (($data['items'] ?? []) as $agency): ?>
             <div class="card mb-2">
               <div class="card-body p-2">
                 <?php echo htmlspecialchars($agency['name']); ?>

--- a/module/agency/include/card_view.php
+++ b/module/agency/include/card_view.php
@@ -8,7 +8,11 @@
         <div class="card h-100">
           <div class="card-body">
             <h5 class="card-title mb-1"><?php echo htmlspecialchars($agency['name']); ?></h5>
-            <p class="mb-0"><span class="badge bg-secondary"><?php echo htmlspecialchars($agency['status_label'] ?? ''); ?></span></p>
+            <p class="mb-0">
+              <span class="badge badge-phoenix fs-10 badge-phoenix-<?= htmlspecialchars($agency['status_color'] ?? 'secondary'); ?>">
+                <span class="badge-label"><?php echo htmlspecialchars($agency['status_label'] ?? ''); ?></span>
+              </span>
+            </p>
           </div>
         </div>
       </div>

--- a/module/agency/include/list_view.php
+++ b/module/agency/include/list_view.php
@@ -15,7 +15,11 @@
           <?php foreach ($agencies as $agency): ?>
             <tr>
               <td class="align-middle name"><?php echo htmlspecialchars($agency['name']); ?></td>
-              <td class="align-middle status"><span class="badge bg-secondary"><?php echo htmlspecialchars($agency['status_label'] ?? ''); ?></span></td>
+              <td class="align-middle status">
+                <span class="badge badge-phoenix fs-10 badge-phoenix-<?= htmlspecialchars($agency['status_color'] ?? 'secondary'); ?>">
+                  <span class="badge-label"><?php echo htmlspecialchars($agency['status_label'] ?? ''); ?></span>
+                </span>
+              </td>
             </tr>
           <?php endforeach; ?>
         </tbody>


### PR DESCRIPTION
## Summary
- add `get_lookup_items` helper to unify active lookup list retrieval with color support
- replace ad-hoc lookup queries in users, organizations, and agency modules with helper
- apply Phoenix badge classes driven by lookup COLOR-CLASS attributes

## Testing
- `php -l includes/lookup_helpers.php`
- `php -l includes/php_header.php admin/users/index.php admin/users/edit.php admin/users/new.php admin/orgs/index.php admin/orgs/organization_edit.php admin/orgs/agency_edit.php admin/orgs/division_edit.php module/agency/index.php module/agency/include/list_view.php module/agency/include/card_view.php module/agency/include/board_view.php`


------
https://chatgpt.com/codex/tasks/task_e_689d1d0aaf488333b0d9abb008cf6b6c