### PR TITLE
Add dynamic badge color mapping for admin roles

### DIFF
--- a/_SQL/admin_role_badges.sql
+++ b/_SQL/admin_role_badges.sql
@@ -1,0 +1,19 @@
+-- Lookup list for admin role badge colors
+INSERT INTO lookup_lists (id, user_id, user_updated, name, description)
+VALUES (10, 1, 1, 'ADMIN_ROLE_BADGES', 'Badge colors for admin roles');
+
+INSERT INTO lookup_list_items (id, user_id, user_updated, list_id, label, code, active_from, active_to) VALUES
+(29, 1, 1, 10, 'Admin', 'Admin', CURDATE(), NULL),
+(30, 1, 1, 10, 'Manage Person', 'Manage Person', CURDATE(), NULL),
+(31, 1, 1, 10, 'Manage Agency', 'Manage Agency', CURDATE(), NULL),
+(32, 1, 1, 10, 'Manage Organization', 'Manage Organization', CURDATE(), NULL),
+(33, 1, 1, 10, 'Manage Division', 'Manage Division', CURDATE(), NULL),
+(34, 1, 1, 10, 'Manage System Properties', 'Manage System Properties', CURDATE(), NULL);
+
+INSERT INTO lookup_list_item_attributes (id, user_id, user_updated, item_id, attr_code, attr_value) VALUES
+(1, 1, 1, 29, 'COLOR-CLASS', 'danger'),
+(2, 1, 1, 30, 'COLOR-CLASS', 'info'),
+(3, 1, 1, 31, 'COLOR-CLASS', 'warning'),
+(4, 1, 1, 32, 'COLOR-CLASS', 'success'),
+(5, 1, 1, 33, 'COLOR-CLASS', 'primary'),
+(6, 1, 1, 34, 'COLOR-CLASS', 'purple');

--- a/admin/users/edit.php
+++ b/admin/users/edit.php
@@ -36,12 +36,15 @@ $token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
 $_SESSION['csrf_token'] = $token;
 
 $roles = $pdo->query('SELECT id, name FROM admin_roles ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
+$roleColors = array_column(get_lookup_items($pdo, 'ADMIN_ROLE_BADGES'), 'color_class', 'code');
 
 $typeItems   = get_lookup_items($pdo, 'USER_TYPE');
-$typeOptions = array_column($typeItems, 'label', 'value');
+$typeOptions = array_column($typeItems, 'label', 'code');
+$typeColors  = array_column($typeItems, 'color_class', 'code');
 
 $statusItems   = get_lookup_items($pdo, 'USER_STATUS');
-$statusOptions = array_column($statusItems, 'label', 'value');
+$statusOptions = array_column($statusItems, 'label', 'code');
+$statusColors  = array_column($statusItems, 'color_class', 'code');
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!hash_equals($token, $_POST['csrf_token'] ?? '')) {

--- a/admin/users/form_edit.php
+++ b/admin/users/form_edit.php
@@ -1,5 +1,6 @@
 <?php
 // Edit user form. Expects lookup arrays ($roles, $typeOptions, $statusOptions) and
+// color maps ($roleColors, $typeColors, $statusColors) along with
 // variables: $token, $id, $username, $email, $first_name, $last_name,
 // $type, $status, $btnClass, $assigned (array of role ids)
 
@@ -41,30 +42,42 @@ if (!defined('IN_APP')) {
         </div>
         <div class="mb-3">
           <label class="form-label">Type</label>
-          <select class="form-select" name="type">
-            <?php foreach($typeOptions as $code => $label): ?>
-              <option value="<?= htmlspecialchars($code); ?>" <?= $type === $code ? 'selected' : ''; ?>><?= htmlspecialchars($label); ?></option>
+          <div>
+            <?php foreach($typeOptions as $code => $label): $class = $typeColors[$code] ?? 'secondary'; ?>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="type" id="type<?= $code; ?>" value="<?= htmlspecialchars($code); ?>" <?= $type === $code ? 'checked' : ''; ?>>
+                <label class="form-check-label" for="type<?= $code; ?>">
+                  <span class="badge badge-phoenix fs-10 badge-phoenix-<?= htmlspecialchars($class); ?>"><span class="badge-label"><?= htmlspecialchars($label); ?></span></span>
+                </label>
+              </div>
             <?php endforeach; ?>
-          </select>
+          </div>
         </div>
         <div class="mb-3">
           <label class="form-label">Status</label>
-          <select class="form-select" name="status">
-            <?php foreach($statusOptions as $code => $label): ?>
-              <option value="<?= htmlspecialchars($code); ?>" <?= (string)$status === $code ? 'selected' : ''; ?>><?= htmlspecialchars($label); ?></option>
+          <div>
+            <?php foreach($statusOptions as $code => $label): $class = $statusColors[$code] ?? 'secondary'; ?>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="status" id="status<?= $code; ?>" value="<?= htmlspecialchars($code); ?>" <?= (string)$status === (string)$code ? 'checked' : ''; ?>>
+                <label class="form-check-label" for="status<?= $code; ?>">
+                  <span class="badge badge-phoenix fs-10 badge-phoenix-<?= htmlspecialchars($class); ?>"><span class="badge-label"><?= htmlspecialchars($label); ?></span></span>
+                </label>
+              </div>
             <?php endforeach; ?>
-          </select>
+          </div>
         </div>
       </div>
       <div class="tab-pane" role="tabpanel" id="user-tab3" aria-labelledby="user-tab3">
         <div class="mb-3">
           <label class="form-label">Roles</label>
-          <?php foreach($roles as $r): ?>
-            <div class="form-check">
-              <input class="form-check-input" type="checkbox" name="roles[]" value="<?= $r['id']; ?>" id="role<?= $r['id']; ?>" <?= in_array($r['id'], $assigned) ? 'checked' : ''; ?>>
-              <label class="form-check-label" for="role<?= $r['id']; ?>"><?= htmlspecialchars($r['name']); ?></label>
-            </div>
-          <?php endforeach; ?>
+            <?php foreach($roles as $r): $rClass = $roleColors[$r['name']] ?? 'secondary'; ?>
+              <div class="form-check">
+                <input class="form-check-input" type="checkbox" name="roles[]" value="<?= $r['id']; ?>" id="role<?= $r['id']; ?>" <?= in_array($r['id'], $assigned) ? 'checked' : ''; ?>>
+                <label class="form-check-label" for="role<?= $r['id']; ?>">
+                  <span class="badge badge-phoenix fs-10 badge-phoenix-<?= htmlspecialchars($rClass); ?>"><span class="badge-label"><?= htmlspecialchars($r['name']); ?></span></span>
+                </label>
+              </div>
+            <?php endforeach; ?>
         </div>
       </div>
     </div>

--- a/admin/users/form_new.php
+++ b/admin/users/form_new.php
@@ -1,5 +1,6 @@
 <?php
 // New user form. Expects lookup arrays ($roles, $typeOptions, $statusOptions) and
+// color maps ($roleColors, $typeColors, $statusColors) along with
 // variables: $token, $username, $email, $first_name, $last_name,
 // $type, $status, $btnClass, $assigned (array of role ids)
 
@@ -41,30 +42,42 @@ if (!defined('IN_APP')) {
         </div>
         <div class="mb-3">
           <label class="form-label">Type</label>
-          <select class="form-select" name="type">
-            <?php foreach($typeOptions as $code => $label): ?>
-              <option value="<?= htmlspecialchars($code); ?>" <?= $type === $code ? 'selected' : ''; ?>><?= htmlspecialchars($label); ?></option>
+          <div>
+            <?php foreach($typeOptions as $code => $label): $class = $typeColors[$code] ?? 'secondary'; ?>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="type" id="type<?= $code; ?>" value="<?= htmlspecialchars($code); ?>" <?= $type === $code ? 'checked' : ''; ?>>
+                <label class="form-check-label" for="type<?= $code; ?>">
+                  <span class="badge badge-phoenix fs-10 badge-phoenix-<?= htmlspecialchars($class); ?>"><span class="badge-label"><?= htmlspecialchars($label); ?></span></span>
+                </label>
+              </div>
             <?php endforeach; ?>
-          </select>
+          </div>
         </div>
         <div class="mb-3">
           <label class="form-label">Status</label>
-          <select class="form-select" name="status">
-            <?php foreach($statusOptions as $code => $label): ?>
-              <option value="<?= htmlspecialchars($code); ?>" <?= (string)$status === $code ? 'selected' : ''; ?>><?= htmlspecialchars($label); ?></option>
+          <div>
+            <?php foreach($statusOptions as $code => $label): $class = $statusColors[$code] ?? 'secondary'; ?>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="status" id="status<?= $code; ?>" value="<?= htmlspecialchars($code); ?>" <?= (string)$status === (string)$code ? 'checked' : ''; ?>>
+                <label class="form-check-label" for="status<?= $code; ?>">
+                  <span class="badge badge-phoenix fs-10 badge-phoenix-<?= htmlspecialchars($class); ?>"><span class="badge-label"><?= htmlspecialchars($label); ?></span></span>
+                </label>
+              </div>
             <?php endforeach; ?>
-          </select>
+          </div>
         </div>
       </div>
       <div class="tab-pane" role="tabpanel" id="user-tab3" aria-labelledby="user-tab3">
         <div class="mb-3">
           <label class="form-label">Roles</label>
-          <?php foreach($roles as $r): ?>
-            <div class="form-check">
-              <input class="form-check-input" type="checkbox" name="roles[]" value="<?= $r['id']; ?>" id="role<?= $r['id']; ?>" <?= in_array($r['id'], $assigned) ? 'checked' : ''; ?>>
-              <label class="form-check-label" for="role<?= $r['id']; ?>"><?= htmlspecialchars($r['name']); ?></label>
-            </div>
-          <?php endforeach; ?>
+            <?php foreach($roles as $r): $rClass = $roleColors[$r['name']] ?? 'secondary'; ?>
+              <div class="form-check">
+                <input class="form-check-input" type="checkbox" name="roles[]" value="<?= $r['id']; ?>" id="role<?= $r['id']; ?>" <?= in_array($r['id'], $assigned) ? 'checked' : ''; ?>>
+                <label class="form-check-label" for="role<?= $r['id']; ?>">
+                  <span class="badge badge-phoenix fs-10 badge-phoenix-<?= htmlspecialchars($rClass); ?>"><span class="badge-label"><?= htmlspecialchars($r['name']); ?></span></span>
+                </label>
+              </div>
+            <?php endforeach; ?>
         </div>
       </div>
     </div>

--- a/admin/users/index.php
+++ b/admin/users/index.php
@@ -7,15 +7,16 @@ $_SESSION['csrf_token'] = $token;
 $message = '';
 
 $typeItems   = get_lookup_items($pdo, 'USER_TYPE');
-$typeOptions = array_column($typeItems, 'label', 'value');
-$typeColors  = array_column($typeItems, 'color_class', 'value');
+$typeOptions = array_column($typeItems, 'label', 'code');
+$typeColors  = array_column($typeItems, 'color_class', 'code');
 
 $statusItems   = get_lookup_items($pdo, 'USER_STATUS');
-$statusOptions = array_column($statusItems, 'label', 'value');
-$statusColors  = array_column($statusItems, 'color_class', 'value');
+$statusOptions = array_column($statusItems, 'label', 'code');
+$statusColors  = array_column($statusItems, 'color_class', 'code');
 
-$roleStmt = $pdo->query('SELECT name FROM admin_roles ORDER BY name');
-$roleOptions = $roleStmt->fetchAll(PDO::FETCH_COLUMN);
+$roleItems   = get_lookup_items($pdo, 'ADMIN_ROLE_BADGES');
+$roleOptions = array_column($roleItems, 'label', 'code');
+$roleColors  = array_column($roleItems, 'color_class', 'code');
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete_id'])) {
   if (!hash_equals($token, $_POST['csrf_token'] ?? '')) {
@@ -54,8 +55,8 @@ $users = $stmt->fetchAll(PDO::FETCH_ASSOC);
     <div class="col-auto">
       <select class="form-select form-select-sm" id="filterRole">
         <option value="">All Roles</option>
-        <?php foreach($roleOptions as $rName): ?>
-          <option value="<?= htmlspecialchars($rName); ?>"><?= htmlspecialchars($rName); ?></option>
+        <?php foreach($roleOptions as $code => $label): ?>
+          <option value="<?= htmlspecialchars($label); ?>"><?= htmlspecialchars($label); ?></option>
         <?php endforeach; ?>
       </select>
     </div>
@@ -99,9 +100,9 @@ $users = $stmt->fetchAll(PDO::FETCH_ASSOC);
             <td class="name"><?= htmlspecialchars(trim(($u['first_name'] ?? '').' '.($u['last_name'] ?? ''))); ?></td>
             <td class="roles">
               <?php $roleNames = $u['roles'] ? explode(',', $u['roles']) : []; ?>
-              <?php foreach($roleNames as $role): ?>
-                <span class="badge badge-phoenix fs-10 badge-phoenix-secondary me-1">
-                  <span class="badge-label"><?= htmlspecialchars(trim($role)); ?></span>
+              <?php foreach($roleNames as $role): $rTrim = trim($role); $rClass = $roleColors[$rTrim] ?? 'secondary'; ?>
+                <span class="badge badge-phoenix fs-10 badge-phoenix-<?= htmlspecialchars($rClass); ?> me-1">
+                  <span class="badge-label"><?= htmlspecialchars($rTrim); ?></span>
                 </span>
               <?php endforeach; ?>
             </td>

--- a/admin/users/new.php
+++ b/admin/users/new.php
@@ -14,12 +14,15 @@ $message = $error = '';
 $btnClass = 'btn-success';
 
 $roles = $pdo->query('SELECT id, name FROM admin_roles ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
+$roleColors = array_column(get_lookup_items($pdo, 'ADMIN_ROLE_BADGES'), 'color_class', 'code');
 
 $typeItems   = get_lookup_items($pdo, 'USER_TYPE');
-$typeOptions = array_column($typeItems, 'label', 'value');
+$typeOptions = array_column($typeItems, 'label', 'code');
+$typeColors  = array_column($typeItems, 'color_class', 'code');
 
 $statusItems   = get_lookup_items($pdo, 'USER_STATUS');
-$statusOptions = array_column($statusItems, 'label', 'value');
+$statusOptions = array_column($statusItems, 'label', 'code');
+$statusColors  = array_column($statusItems, 'color_class', 'code');
 
 $type = array_key_first($typeOptions) ?? $type;
 $status = (int)(array_key_first($statusOptions) ?? $status);

--- a/includes/lookup_helpers.php
+++ b/includes/lookup_helpers.php
@@ -14,8 +14,8 @@ function get_lookup_items(PDO $pdo, int|string $list): array {
     $param = is_numeric($list) ? ':list_id' : ':list_name';
     $where = is_numeric($list) ? 'li.list_id = :list_id' : 'l.name = :list_name';
 
-    $sql = "SELECT li.id, li.label, li.code,
-                   COALESCE(attr.attr_code, 'secondary') AS color_class
+    $sql = "SELECT li.id, li.label, li.code, li.code AS value,
+                   COALESCE(attr.attr_value, 'secondary') AS color_class
             FROM lookup_list_items li
             JOIN lookup_lists l ON li.list_id = l.id
             LEFT JOIN lookup_list_item_attributes attr


### PR DESCRIPTION
## Summary
- add SQL lookup for `ADMIN_ROLE_BADGES` mapping each role to a badge color
- fetch and display role, type, and status color classes on user list
- render type, status, and roles with color-coded badges on user forms

## Testing
- `php -l includes/lookup_helpers.php`
- `php -l admin/users/index.php`
- `php -l admin/users/new.php`
- `php -l admin/users/edit.php`
- `php -l admin/users/form_new.php`
- `php -l admin/users/form_edit.php`


------
https://chatgpt.com/codex/tasks/task_e_689d5e6565ec8333bf6ce7ea2e8626ad