### PR TITLE
Guard project card fields against null

### DIFF
--- a/module/project/include/card_view.php
+++ b/module/project/include/card_view.php
@@ -7,10 +7,12 @@
       <div class="col-12 col-md-6 col-lg-4">
         <div class="card h-100">
           <div class="card-body">
-            <h5 class="card-title mb-1"><?php echo htmlspecialchars($project['name']); ?></h5>
+            <h5 class="card-title mb-1"><?php echo htmlspecialchars($project['name'] ?? ''); ?></h5>
             <p class="mb-0">
-              <span class="badge badge-phoenix fs-10 badge-phoenix-<?php echo htmlspecialchars($project['status_color']); ?>">
-                <span class="badge-label"><?php echo htmlspecialchars($project['status_label']); ?></span>
+              <span class="badge badge-phoenix fs-10 badge-phoenix-<?php echo htmlspecialchars(
+                $project['status_color'] ?? ''
+              ); ?>">
+                <span class="badge-label"><?php echo htmlspecialchars($project['status_label'] ?? ''); ?></span>
               </span>
             </p>
           </div>

--- a/module/project/index.php
+++ b/module/project/index.php
@@ -9,8 +9,8 @@ $stmt = $pdo->query('SELECT id, name, status FROM module_projects ORDER BY name'
 $projects = $stmt->fetchAll(PDO::FETCH_ASSOC);
 foreach ($projects as &$project) {
   $status = $statusMap[$project['status']] ?? null;
-  $project['status_label'] = $status['label'] ?? null;
-  $project['status_color'] = $status['color_class'] ?? 'secondary';
+  $project['status_label'] = $status['label'] ?? '';
+  $project['status_color'] = $status['color_class'] ?? '';
 }
 unset($project);
 


### PR DESCRIPTION
## Summary
- Default project card `htmlspecialchars` fields to empty strings to avoid null
- Default missing project status lookup values to empty strings

## Testing
- `php -l module/project/include/card_view.php`
- `php -l module/project/index.php`


------
https://chatgpt.com/codex/tasks/task_e_689d6378d0e083339d92217c380663ab