### PR TITLE
Handle empty active_to date for lookup list items

### DIFF
--- a/admin/api/lookup-lists.php
+++ b/admin/api/lookup-lists.php
@@ -121,6 +121,7 @@ function handleItem($action){
     $code=trim($_POST['code']??'');
     $active_from=$_POST['active_from']??date('Y-m-d');
     $active_to=$_POST['active_to']??null;
+    if($active_to===''){ $active_to=null; }
     if($list_id<=0||$label===''){ echo json_encode(['success'=>false,'error'=>'Invalid data']); return; }
     $stmt=$pdo->prepare('SELECT id FROM lookup_list_items WHERE list_id=:list_id AND label=:label');
     $stmt->execute([':list_id'=>$list_id,':label'=>$label]);
@@ -147,6 +148,7 @@ function handleItem($action){
     $code=trim($_POST['code']??'');
     $active_from=$_POST['active_from']??date('Y-m-d');
     $active_to=$_POST['active_to']??null;
+    if($active_to===''){ $active_to=null; }
     if($id<=0||$label===''){ echo json_encode(['success'=>false,'error'=>'Invalid data']); return; }
     $stmt=$pdo->prepare('SELECT list_id FROM lookup_list_items WHERE id=:id');
     $stmt->execute([':id'=>$id]);

--- a/admin/lookup-lists/items.php
+++ b/admin/lookup-lists/items.php
@@ -26,7 +26,8 @@ if($_SERVER['REQUEST_METHOD']==='POST'){
     $label=trim($_POST['label'] ?? '');
     $code=trim($_POST['code'] ?? '');
     $active_from=$_POST['active_from'] ?? date('Y-m-d');
-    if(isset($_POST['active_to'])){ $active_to = $_POST['active_to']; }else{ $active_to = NULL; }
+    $active_to=$_POST['active_to'] ?? null;
+    if($active_to===''){ $active_to=null; }
     if($label===''){$error='Label is required.';}
     if(!$error){
       if($item_id){


### PR DESCRIPTION
## Summary
- Set `active_to` to null when empty during item creation and update via API
- Ensure lookup list item form saves `active_to` as null when left blank

## Testing
- `php -l admin/api/lookup-lists.php`
- `php -l admin/lookup-lists/items.php`


------
https://chatgpt.com/codex/tasks/task_e_689d6ffcf7008333bcd77caa6b23d7b9