### PR TITLE
Add project and task modules with views and CRUD handlers

### DIFF
--- a/includes/left_navigation.php
+++ b/includes/left_navigation.php
@@ -24,16 +24,20 @@
                       </div>
                     </a>
                   </li>
-                <li class="nav-item"><a class="nav-link" href="<?php echo getURLDir(); ?>/module/project">
-                    <div class="d-flex align-items-center"><span class="nav-link-text">Projects</span>
-                    </div>
-                  </a>
-                </li>
-                <li class="nav-item"><a class="nav-link" href="<?php echo getURLDir(); ?>/module/task">
-                    <div class="d-flex align-items-center"><span class="nav-link-text">Tasks</span>
-                    </div>
-                  </a>
-                </li>
+                  <?php if (user_has_permission('project','read')): ?>
+                  <li class="nav-item"><a class="nav-link" href="<?php echo getURLDir(); ?>/module/project">
+                      <div class="d-flex align-items-center"><span class="nav-link-text">Projects</span>
+                      </div>
+                    </a>
+                  </li>
+                  <?php endif; ?>
+                  <?php if (user_has_permission('task','read')): ?>
+                  <li class="nav-item"><a class="nav-link" href="<?php echo getURLDir(); ?>/module/task">
+                      <div class="d-flex align-items-center"><span class="nav-link-text">Tasks</span>
+                      </div>
+                    </a>
+                  </li>
+                  <?php endif; ?>
                 <li class="nav-item"><a class="nav-link" href="<?php echo getURLDir(); ?>/module/kanban">
                     <div class="d-flex align-items-center"><span class="nav-link-text">Kanban</span>
                     </div>

--- a/includes/navigation.php
+++ b/includes/navigation.php
@@ -34,24 +34,28 @@
         <?php // ================ ?>
 
 
-      <?php // PROJECTS NAV LINK ?>
-      <li class="nav-item dropdown">
-        <a class="nav-link dropdown-toggle lh-1" href="<?php echo getURLDir(); ?>/module/project">
-          <span class="uil fs-8 me-2 fas fa-project-diagram"></span>Projects</a>
-      </li>
-      <?php // ================ ?>
-      <?php // END PROJECTS NAV LINK ?>
-      <?php // ================ ?>
+        <?php // PROJECTS NAV LINK ?>
+        <?php if (user_has_permission('project','read')): ?>
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle lh-1" href="<?php echo getURLDir(); ?>/module/project">
+            <span class="uil fs-8 me-2 fas fa-project-diagram"></span>Projects</a>
+        </li>
+        <?php endif; ?>
+        <?php // ================ ?>
+        <?php // END PROJECTS NAV LINK ?>
+        <?php // ================ ?>
 
 
-      <?php // TASKS NAV LINK ?>
-      <li class="nav-item dropdown">
-        <a class="nav-link dropdown-toggle lh-1" href="<?php echo getURLDir(); ?>/module/task">
-          <span class="uil fs-8 me-2 fas fa-tasks"></span>Tasks</a>
-      </li>
-      <?php // ================ ?>
-      <?php // END TASKS NAV LINK ?>
-      <?php // ================ ?>
+        <?php // TASKS NAV LINK ?>
+        <?php if (user_has_permission('task','read')): ?>
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle lh-1" href="<?php echo getURLDir(); ?>/module/task">
+            <span class="uil fs-8 me-2 fas fa-tasks"></span>Tasks</a>
+        </li>
+        <?php endif; ?>
+        <?php // ================ ?>
+        <?php // END TASKS NAV LINK ?>
+        <?php // ================ ?>
 
 
       <?php // KANBAN NAV LINK ?>

--- a/module/project/functions/create.php
+++ b/module/project/functions/create.php
@@ -1,0 +1,23 @@
+<?php
+require '../../../includes/php_header.php';
+require_permission('project', 'create');
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  $name = $_POST['name'] ?? '';
+  $status = $_POST['status'] ?? null;
+  $description = $_POST['description'] ?? null;
+
+  $stmt = $pdo->prepare('INSERT INTO module_projects (user_id, user_updated, name, status, description) VALUES (:uid, :uid, :name, :status, :description)');
+  $stmt->execute([
+    ':uid' => $this_user_id,
+    ':name' => $name,
+    ':status' => $status,
+    ':description' => $description
+  ]);
+  $id = $pdo->lastInsertId();
+  audit_log($pdo, $this_user_id, 'module_projects', $id, 'CREATE', 'Created project');
+}
+
+header('Location: ../index.php');
+exit;
+

--- a/module/project/functions/delete.php
+++ b/module/project/functions/delete.php
@@ -1,0 +1,16 @@
+<?php
+require '../../../includes/php_header.php';
+require_permission('project', 'delete');
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  $id = (int)($_POST['id'] ?? 0);
+  if ($id) {
+    $stmt = $pdo->prepare('DELETE FROM module_projects WHERE id = :id');
+    $stmt->execute([':id' => $id]);
+    audit_log($pdo, $this_user_id, 'module_projects', $id, 'DELETE', 'Deleted project');
+  }
+}
+
+header('Location: ../index.php');
+exit;
+

--- a/module/project/functions/update.php
+++ b/module/project/functions/update.php
@@ -1,0 +1,26 @@
+<?php
+require '../../../includes/php_header.php';
+require_permission('project', 'update');
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  $id = (int)($_POST['id'] ?? 0);
+  $name = $_POST['name'] ?? '';
+  $status = $_POST['status'] ?? null;
+  $description = $_POST['description'] ?? null;
+
+  if ($id) {
+    $stmt = $pdo->prepare('UPDATE module_projects SET name = :name, status = :status, description = :description, user_updated = :uid WHERE id = :id');
+    $stmt->execute([
+      ':uid' => $this_user_id,
+      ':name' => $name,
+      ':status' => $status,
+      ':description' => $description,
+      ':id' => $id
+    ]);
+    audit_log($pdo, $this_user_id, 'module_projects', $id, 'UPDATE', 'Updated project');
+  }
+}
+
+header('Location: ../index.php');
+exit;
+

--- a/module/project/include/board_view.php
+++ b/module/project/include/board_view.php
@@ -1,0 +1,18 @@
+<?php
+// Board view of projects grouped by status
+?>
+<div class="row g-3">
+  <?php foreach ($statusMap as $id => $status): ?>
+    <div class="col-12 col-md-6 col-lg-4">
+      <h5 class="mb-3"><?php echo htmlspecialchars($status['label'] ?? ''); ?></h5>
+      <?php foreach ($projects as $proj): if (($proj['status'] ?? '') == $id): ?>
+        <div class="card mb-2">
+          <div class="card-body p-2">
+            <?php echo htmlspecialchars($proj['name'] ?? ''); ?>
+          </div>
+        </div>
+      <?php endif; endforeach; ?>
+    </div>
+  <?php endforeach; ?>
+</div>
+

--- a/module/project/include/create_edit_view.php
+++ b/module/project/include/create_edit_view.php
@@ -1,0 +1,28 @@
+<?php
+// Create or edit project form
+$editing = !empty($current_project);
+$actionUrl = $editing ? 'functions/update.php' : 'functions/create.php';
+?>
+<form method="post" action="<?php echo $actionUrl; ?>">
+  <?php if ($editing): ?>
+    <input type="hidden" name="id" value="<?php echo htmlspecialchars($current_project['id']); ?>">
+  <?php endif; ?>
+  <div class="mb-3">
+    <label class="form-label">Name</label>
+    <input type="text" name="name" class="form-control" value="<?php echo htmlspecialchars($current_project['name'] ?? ''); ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Status</label>
+    <select name="status" class="form-select">
+      <?php foreach ($statusMap as $id => $status): ?>
+        <option value="<?php echo htmlspecialchars($id); ?>" <?php if (($current_project['status'] ?? '') == $id) echo 'selected'; ?>><?php echo htmlspecialchars($status['label']); ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Description</label>
+    <textarea name="description" class="form-control" rows="4"><?php echo htmlspecialchars($current_project['description'] ?? ''); ?></textarea>
+  </div>
+  <button type="submit" class="btn btn-primary"><?php echo $editing ? 'Update' : 'Create'; ?></button>
+</form>
+

--- a/module/project/include/details_view.php
+++ b/module/project/include/details_view.php
@@ -1,0 +1,19 @@
+<?php
+// Details view of a single project
+?>
+<?php if (!empty($current_project)): ?>
+  <div class="card">
+    <div class="card-body">
+      <h3 class="mb-3"><?php echo htmlspecialchars($current_project['name'] ?? ''); ?></h3>
+      <p class="mb-3">
+        <span class="badge badge-phoenix fs-10 badge-phoenix-<?php echo htmlspecialchars($statusMap[$current_project['status']]['color_class'] ?? 'secondary'); ?>">
+          <span class="badge-label"><?php echo htmlspecialchars($statusMap[$current_project['status']]['label'] ?? ''); ?></span>
+        </span>
+      </p>
+      <p><?php echo nl2br(htmlspecialchars($current_project['description'] ?? '')); ?></p>
+    </div>
+  </div>
+<?php else: ?>
+  <p>No project found.</p>
+<?php endif; ?>
+

--- a/module/project/include/list_view.php
+++ b/module/project/include/list_view.php
@@ -1,0 +1,26 @@
+<?php
+// List view of projects
+?>
+<div class="table-responsive">
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Status</th>
+      </tr>
+    </thead>
+    <tbody>
+      <?php foreach ($projects as $proj): ?>
+        <tr>
+          <td><?php echo htmlspecialchars($proj['name'] ?? ''); ?></td>
+          <td>
+            <span class="badge badge-phoenix fs-10 badge-phoenix-<?php echo htmlspecialchars($proj['status_color'] ?? ''); ?>">
+              <span class="badge-label"><?php echo htmlspecialchars($proj['status_label'] ?? ''); ?></span>
+            </span>
+          </td>
+        </tr>
+      <?php endforeach; ?>
+    </tbody>
+  </table>
+</div>
+

--- a/module/project/index.php
+++ b/module/project/index.php
@@ -14,13 +14,38 @@ foreach ($projects as &$project) {
 }
 unset($project);
 
+if ($action === 'details' || ($action === 'create-edit' && isset($_GET['id']))) {
+  $project_id = (int)($_GET['id'] ?? 0);
+  $stmt = $pdo->prepare('SELECT id, name, description, status FROM module_projects WHERE id = :id');
+  $stmt->execute([':id' => $project_id]);
+  $current_project = $stmt->fetch(PDO::FETCH_ASSOC);
+}
+
+if ($action === 'create-edit') {
+  if (!empty($current_project)) {
+    require_permission('project', 'update');
+  } else {
+    require_permission('project', 'create');
+  }
+}
+
 require '../../includes/html_header.php';
 ?>
 <main class="main" id="top">
   <?php require '../../includes/left_navigation.php'; ?>
   <?php require '../../includes/navigation.php'; ?>
   <div id="main_content" class="content">
-    <?php require 'include/card_view.php'; ?>
+    <?php
+      $viewMap = [
+        'card' => 'card_view.php',
+        'list' => 'list_view.php',
+        'board' => 'board_view.php',
+        'details' => 'details_view.php',
+        'create-edit' => 'create_edit_view.php'
+      ];
+      $viewFile = $viewMap[$action] ?? 'card_view.php';
+      require 'include/' . $viewFile;
+    ?>
     <?php require '../../includes/html_footer.php'; ?>
   </div>
 </main>

--- a/module/task/functions/create.php
+++ b/module/task/functions/create.php
@@ -1,0 +1,25 @@
+<?php
+require '../../../includes/php_header.php';
+require_permission('task', 'create');
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  $name = $_POST['name'] ?? '';
+  $status = $_POST['status'] ?? null;
+  $priority = $_POST['priority'] ?? null;
+  $description = $_POST['description'] ?? null;
+
+  $stmt = $pdo->prepare('INSERT INTO module_tasks (user_id, user_updated, name, status, priority, description) VALUES (:uid, :uid, :name, :status, :priority, :description)');
+  $stmt->execute([
+    ':uid' => $this_user_id,
+    ':name' => $name,
+    ':status' => $status,
+    ':priority' => $priority,
+    ':description' => $description
+  ]);
+  $id = $pdo->lastInsertId();
+  audit_log($pdo, $this_user_id, 'module_tasks', $id, 'CREATE', 'Created task');
+}
+
+header('Location: ../index.php');
+exit;
+

--- a/module/task/functions/delete.php
+++ b/module/task/functions/delete.php
@@ -1,0 +1,16 @@
+<?php
+require '../../../includes/php_header.php';
+require_permission('task', 'delete');
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  $id = (int)($_POST['id'] ?? 0);
+  if ($id) {
+    $stmt = $pdo->prepare('DELETE FROM module_tasks WHERE id = :id');
+    $stmt->execute([':id' => $id]);
+    audit_log($pdo, $this_user_id, 'module_tasks', $id, 'DELETE', 'Deleted task');
+  }
+}
+
+header('Location: ../index.php');
+exit;
+

--- a/module/task/functions/update.php
+++ b/module/task/functions/update.php
@@ -1,0 +1,28 @@
+<?php
+require '../../../includes/php_header.php';
+require_permission('task', 'update');
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  $id = (int)($_POST['id'] ?? 0);
+  $name = $_POST['name'] ?? '';
+  $status = $_POST['status'] ?? null;
+  $priority = $_POST['priority'] ?? null;
+  $description = $_POST['description'] ?? null;
+
+  if ($id) {
+    $stmt = $pdo->prepare('UPDATE module_tasks SET name = :name, status = :status, priority = :priority, description = :description, user_updated = :uid WHERE id = :id');
+    $stmt->execute([
+      ':uid' => $this_user_id,
+      ':name' => $name,
+      ':status' => $status,
+      ':priority' => $priority,
+      ':description' => $description,
+      ':id' => $id
+    ]);
+    audit_log($pdo, $this_user_id, 'module_tasks', $id, 'UPDATE', 'Updated task');
+  }
+}
+
+header('Location: ../index.php');
+exit;
+

--- a/module/task/include/board_view.php
+++ b/module/task/include/board_view.php
@@ -1,0 +1,18 @@
+<?php
+// Board view of tasks grouped by status
+?>
+<div class="row g-3">
+  <?php foreach ($statusMap as $id => $status): ?>
+    <div class="col-12 col-md-6 col-lg-4">
+      <h5 class="mb-3"><?php echo htmlspecialchars($status['label'] ?? ''); ?></h5>
+      <?php foreach ($tasks as $task): if (($task['status'] ?? '') == $id): ?>
+        <div class="card mb-2">
+          <div class="card-body p-2">
+            <?php echo htmlspecialchars($task['name'] ?? ''); ?>
+          </div>
+        </div>
+      <?php endif; endforeach; ?>
+    </div>
+  <?php endforeach; ?>
+</div>
+

--- a/module/task/include/card_view.php
+++ b/module/task/include/card_view.php
@@ -1,0 +1,25 @@
+<?php
+// Card view of tasks
+?>
+<div class="container-fluid">
+  <div class="row g-3">
+    <?php foreach ($tasks as $task): ?>
+      <div class="col-12 col-md-6 col-lg-4">
+        <div class="card h-100">
+          <div class="card-body">
+            <h5 class="card-title mb-1"><?php echo htmlspecialchars($task['name'] ?? ''); ?></h5>
+            <p class="mb-0">
+              <span class="badge badge-phoenix fs-10 badge-phoenix-<?php echo htmlspecialchars($task['status_color'] ?? ''); ?>">
+                <span class="badge-label"><?php echo htmlspecialchars($task['status_label'] ?? ''); ?></span>
+              </span>
+              <span class="badge badge-phoenix fs-10 badge-phoenix-secondary ms-1">
+                <span class="badge-label"><?php echo htmlspecialchars($task['priority_label'] ?? ''); ?></span>
+              </span>
+            </p>
+          </div>
+        </div>
+      </div>
+    <?php endforeach; ?>
+  </div>
+</div>
+

--- a/module/task/include/create_edit_view.php
+++ b/module/task/include/create_edit_view.php
@@ -1,0 +1,36 @@
+<?php
+// Create or edit task form
+$editing = !empty($current_task);
+$actionUrl = $editing ? 'functions/update.php' : 'functions/create.php';
+?>
+<form method="post" action="<?php echo $actionUrl; ?>">
+  <?php if ($editing): ?>
+    <input type="hidden" name="id" value="<?php echo htmlspecialchars($current_task['id']); ?>">
+  <?php endif; ?>
+  <div class="mb-3">
+    <label class="form-label">Name</label>
+    <input type="text" name="name" class="form-control" value="<?php echo htmlspecialchars($current_task['name'] ?? ''); ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Status</label>
+    <select name="status" class="form-select">
+      <?php foreach ($statusMap as $id => $status): ?>
+        <option value="<?php echo htmlspecialchars($id); ?>" <?php if (($current_task['status'] ?? '') == $id) echo 'selected'; ?>><?php echo htmlspecialchars($status['label']); ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Priority</label>
+    <select name="priority" class="form-select">
+      <?php foreach ($priorityMap as $id => $priority): ?>
+        <option value="<?php echo htmlspecialchars($id); ?>" <?php if (($current_task['priority'] ?? '') == $id) echo 'selected'; ?>><?php echo htmlspecialchars($priority['label']); ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Description</label>
+    <textarea name="description" class="form-control" rows="4"><?php echo htmlspecialchars($current_task['description'] ?? ''); ?></textarea>
+  </div>
+  <button type="submit" class="btn btn-primary"><?php echo $editing ? 'Update' : 'Create'; ?></button>
+</form>
+

--- a/module/task/include/details_view.php
+++ b/module/task/include/details_view.php
@@ -1,0 +1,22 @@
+<?php
+// Details view of a single task
+?>
+<?php if (!empty($current_task)): ?>
+  <div class="card">
+    <div class="card-body">
+      <h3 class="mb-3"><?php echo htmlspecialchars($current_task['name'] ?? ''); ?></h3>
+      <p class="mb-3">
+        <span class="badge badge-phoenix fs-10 badge-phoenix-<?php echo htmlspecialchars($statusMap[$current_task['status']]['color_class'] ?? 'secondary'); ?>">
+          <span class="badge-label"><?php echo htmlspecialchars($statusMap[$current_task['status']]['label'] ?? ''); ?></span>
+        </span>
+        <span class="badge badge-phoenix fs-10 badge-phoenix-secondary ms-1">
+          <span class="badge-label"><?php echo htmlspecialchars($priorityMap[$current_task['priority']]['label'] ?? ''); ?></span>
+        </span>
+      </p>
+      <p><?php echo nl2br(htmlspecialchars($current_task['description'] ?? '')); ?></p>
+    </div>
+  </div>
+<?php else: ?>
+  <p>No task found.</p>
+<?php endif; ?>
+

--- a/module/task/index.php
+++ b/module/task/index.php
@@ -2,6 +2,8 @@
 require '../../includes/php_header.php';
 require_permission('task','read');
 
+$action = $_GET['action'] ?? 'list';
+
 $statusMap = array_column(get_lookup_items($pdo, 'TASK_STATUS'), null, 'id');
 $priorityMap = array_column(get_lookup_items($pdo, 'TASK_PRIORITY'), null, 'id');
 
@@ -16,13 +18,38 @@ foreach ($tasks as &$task) {
 }
 unset($task);
 
+if ($action === 'details' || ($action === 'create-edit' && isset($_GET['id']))) {
+  $task_id = (int)($_GET['id'] ?? 0);
+  $stmt = $pdo->prepare('SELECT id, name, description, status, priority FROM module_tasks WHERE id = :id');
+  $stmt->execute([':id' => $task_id]);
+  $current_task = $stmt->fetch(PDO::FETCH_ASSOC);
+}
+
+if ($action === 'create-edit') {
+  if (!empty($current_task)) {
+    require_permission('task', 'update');
+  } else {
+    require_permission('task', 'create');
+  }
+}
+
 require '../../includes/html_header.php';
 ?>
 <main class="main" id="top">
   <?php require '../../includes/left_navigation.php'; ?>
   <?php require '../../includes/navigation.php'; ?>
   <div id="main_content" class="content">
-    <?php require 'include/list_view.php'; ?>
+    <?php
+      $viewMap = [
+        'card' => 'card_view.php',
+        'list' => 'list_view.php',
+        'board' => 'board_view.php',
+        'details' => 'details_view.php',
+        'create-edit' => 'create_edit_view.php'
+      ];
+      $viewFile = $viewMap[$action] ?? 'list_view.php';
+      require 'include/' . $viewFile;
+    ?>
     <?php require '../../includes/html_footer.php'; ?>
   </div>
 </main>


### PR DESCRIPTION
## Summary
- Expand project and task modules with card, list, board, detail, and create/edit views
- Implement create, update, and delete handlers with permission checks
- Gate navigation links and view access based on user permissions

## Testing
- `php -l includes/left_navigation.php`
- `php -l includes/navigation.php`
- `php -l module/project/index.php`
- `php -l module/task/index.php`
- `php -l module/project/functions/create.php`
- `php -l module/project/functions/delete.php`
- `php -l module/project/functions/update.php`
- `php -l module/project/include/board_view.php`
- `php -l module/project/include/create_edit_view.php`
- `php -l module/project/include/details_view.php`
- `php -l module/project/include/list_view.php`
- `php -l module/task/functions/create.php`
- `php -l module/task/functions/delete.php`
- `php -l module/task/functions/update.php`
- `php -l module/task/include/board_view.php`
- `php -l module/task/include/card_view.php`
- `php -l module/task/include/create_edit_view.php`
- `php -l module/task/include/details_view.php`


------
https://chatgpt.com/codex/tasks/task_e_689d728935248333b399e7ec0369ffb8