### PR TITLE
Sanitize login inputs and optimize 2FA cleanup

### DIFF
--- a/_SQL/atlis.sql
+++ b/_SQL/atlis.sql
@@ -987,7 +987,8 @@ ALTER TABLE `users`
 ALTER TABLE `users_2fa`
   ADD PRIMARY KEY (`id`),
   ADD KEY `fk_users_2fa_user_id` (`user_id`),
-  ADD KEY `fk_users_2fa_user_updated` (`user_updated`);
+  ADD KEY `fk_users_2fa_user_updated` (`user_updated`),
+  ADD KEY `idx_users_2fa_expires_at` (`expires_at`);
 
 -- Indexes for table `module_projects`
 ALTER TABLE `module_projects`

--- a/module/users/functions/login.php
+++ b/module/users/functions/login.php
@@ -5,8 +5,13 @@ if (session_status() !== PHP_SESSION_ACTIVE) {
 require_once '../../../includes/php_header.php';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-  $email = $_POST['email'] ?? '';
-  $password = $_POST['password'] ?? '';
+  $email = filter_var(trim($_POST['email'] ?? ''), FILTER_VALIDATE_EMAIL) ?: '';
+  $password = trim($_POST['password'] ?? '');
+
+  if ($email === '') {
+    header('Location: ../index.php?action=login&error=1');
+    exit;
+  }
 
   $sql = 'SELECT id, email, password, type FROM users WHERE email = :email';
   $stmt = $pdo->prepare($sql);
@@ -21,12 +26,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     $code = str_pad(random_int(0, 999999), 6, '0', STR_PAD_LEFT);
     $expires = date('Y-m-d H:i:s', time() + 600);
-    $insert = $pdo->prepare('INSERT INTO users_2fa (user_id, user_updated, code, expires_at) VALUES (:user_id, :user_id, :code, :expires)');
-    $insert->execute([
-      ':user_id' => $user['id'],
-      ':code' => $code,
-      ':expires' => $expires,
-    ]);
+      $insert = $pdo->prepare('INSERT INTO users_2fa (user_id, user_updated, code, expires_at) VALUES (:user_id, :user_id, :code, :expires)');
+      $insert->execute([
+        ':user_id' => $user['id'],
+        ':code' => $code,
+        ':expires' => $expires,
+      ]);
+
+      $pdo->prepare('DELETE FROM users_2fa WHERE used = 1 OR expires_at < NOW()')->execute();
 
     // DEACTIVATING THE EMAIL SEND BECUASE ITS NOT CURRENTLY WORKING IN XAMPP -- 8/5/2025 -- DAVE
     //@mail($user['email'], 'Your verification code', 'Your verification code is ' . $code);


### PR DESCRIPTION
## Summary
- Sanitize login form inputs and validate email before querying
- Purge used or expired 2FA codes after generating new code
- Add index on 2FA expiration timestamp for faster cleanups

## Testing
- `php -l module/users/functions/login.php`


------
https://chatgpt.com/codex/tasks/task_e_689d75e1c540833392400ae7fbd4cb21