### PR TITLE
Integrate task details view with assignments, files, and notes

### DIFF
--- a/module/task/functions/add_note.php
+++ b/module/task/functions/add_note.php
@@ -14,5 +14,5 @@ if($id && $note !== ''){
   $noteId = $pdo->lastInsertId();
   admin_audit_log($pdo,$this_user_id,'module_tasks_notes',$noteId,'NOTE','', $note);
 }
-header('Location: ../details_view.php?id=' . $id);
+header('Location: ../index.php?action=details&id=' . $id);
 exit;

--- a/module/task/functions/upload_file.php
+++ b/module/task/functions/upload_file.php
@@ -28,5 +28,5 @@ if($id && isset($_FILES['file'])){
     admin_audit_log($pdo,$this_user_id,'module_tasks_files',$fileId,'UPLOAD','',json_encode(['file'=>$baseName]));
   }
 }
-header('Location: ../details_view.php?id=' . $id);
+header('Location: ../index.php?action=details&id=' . $id);
 exit;

--- a/module/task/include/details_view.php
+++ b/module/task/include/details_view.php
@@ -2,7 +2,7 @@
 // Details view of a single task
 ?>
 <?php if (!empty($current_task)): ?>
-  <div class="card">
+  <div class="card mb-4">
     <div class="card-body">
       <h3 class="mb-3"><?php echo htmlspecialchars($current_task['name'] ?? ''); ?></h3>
       <p class="mb-3">
@@ -13,10 +13,75 @@
           <span class="badge-label"><?php echo htmlspecialchars($priorityMap[$current_task['priority']]['label'] ?? ''); ?></span>
         </span>
       </p>
-      <p><?php echo nl2br(htmlspecialchars($current_task['description'] ?? '')); ?></p>
+      <?php if (!empty($current_task['description'])): ?>
+      <p><?php echo nl2br(htmlspecialchars($current_task['description'])); ?></p>
+      <?php endif; ?>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-lg-4">
+      <div class="card mb-4">
+        <div class="card-header"><h5 class="mb-0">Assignments</h5></div>
+        <div class="card-body">
+          <?php if (!empty($assignments)): ?>
+            <ul class="list-unstyled mb-0">
+              <?php foreach ($assignments as $assign): ?>
+                <li class="mb-1"><span class="fas fa-user text-primary"></span> <?php echo htmlspecialchars($assign['email']); ?></li>
+              <?php endforeach; ?>
+            </ul>
+          <?php else: ?>
+            <p class="mb-0 text-700 small">No assignments</p>
+          <?php endif; ?>
+        </div>
+      </div>
+
+      <div class="card mb-4">
+        <div class="card-header"><h5 class="mb-0">Files</h5></div>
+        <div class="card-body">
+          <form action="functions/upload_file.php" method="post" enctype="multipart/form-data" class="mb-3">
+            <input type="hidden" name="id" value="<?php echo (int)($current_task['id'] ?? 0); ?>">
+            <div class="mb-2"><input class="form-control form-control-sm" type="file" name="file" required></div>
+            <button class="btn btn-sm btn-primary" type="submit">Upload</button>
+          </form>
+          <?php if (!empty($files)): ?>
+            <ul class="list-unstyled mb-0">
+              <?php foreach ($files as $f): ?>
+                <li class="mb-1"><a href="<?php echo htmlspecialchars($f['file_path']); ?>"><?php echo htmlspecialchars($f['file_name']); ?></a></li>
+              <?php endforeach; ?>
+            </ul>
+          <?php else: ?>
+            <p class="mb-0 text-700 small">No files</p>
+          <?php endif; ?>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-lg-8">
+      <div class="card mb-4">
+        <div class="card-header"><h5 class="mb-0">Notes</h5></div>
+        <div class="card-body">
+          <form action="functions/add_note.php" method="post" class="mb-3">
+            <input type="hidden" name="id" value="<?php echo (int)($current_task['id'] ?? 0); ?>">
+            <div class="mb-2"><textarea class="form-control" name="note" rows="3" required></textarea></div>
+            <button class="btn btn-sm btn-primary" type="submit">Add Note</button>
+          </form>
+          <?php if (!empty($notes)): ?>
+            <ul class="list-group">
+              <?php foreach ($notes as $n): ?>
+                <li class="list-group-item d-flex justify-content-between align-items-start">
+                  <div><?php echo nl2br(htmlspecialchars($n['note_text'])); ?></div>
+                  <small class="text-muted ms-2"><?php echo htmlspecialchars($n['date_created']); ?></small>
+                </li>
+              <?php endforeach; ?>
+            </ul>
+          <?php else: ?>
+            <p class="mb-0 text-700 small">No notes</p>
+          <?php endif; ?>
+        </div>
+      </div>
     </div>
   </div>
 <?php else: ?>
   <p>No task found.</p>
 <?php endif; ?>
-

--- a/module/task/include/list_view.php
+++ b/module/task/include/list_view.php
@@ -17,7 +17,7 @@
     <tbody>
       <?php foreach ($tasks as $task): ?>
         <tr>
-          <td><?php echo htmlspecialchars($task['name'] ?? ''); ?></td>
+          <td><a href="index.php?action=details&amp;id=<?php echo (int)($task['id'] ?? 0); ?>"><?php echo htmlspecialchars($task['name'] ?? ''); ?></a></td>
           <td>
             <span class="badge badge-phoenix fs-10 badge-phoenix-<?php echo htmlspecialchars($task['status_color'] ?? ''); ?>">
               <span class="badge-label"><?php echo htmlspecialchars($task['status_label'] ?? ''); ?></span>

--- a/module/task/index.php
+++ b/module/task/index.php
@@ -88,7 +88,26 @@ foreach ($tasks as &$task) {
 }
 unset($task);
 
-if ($action === 'details' || ($action === 'create-edit' && isset($_GET['id']))) {
+if ($action === 'details') {
+  $task_id = (int)($_GET['id'] ?? 0);
+  $stmt = $pdo->prepare('SELECT id, name, description, status, priority FROM module_tasks WHERE id = :id');
+  $stmt->execute([':id' => $task_id]);
+  $current_task = $stmt->fetch(PDO::FETCH_ASSOC);
+
+  if ($current_task) {
+    $assignStmt = $pdo->prepare('SELECT u.id, u.email FROM module_task_assignments ta JOIN users u ON ta.assigned_user_id = u.id WHERE ta.task_id = :id');
+    $assignStmt->execute([':id' => $task_id]);
+    $assignments = $assignStmt->fetchAll(PDO::FETCH_ASSOC);
+
+    $filesStmt = $pdo->prepare('SELECT id,file_name,file_path,file_size,file_type,date_created FROM module_tasks_files WHERE task_id = :id ORDER BY date_created DESC');
+    $filesStmt->execute([':id' => $task_id]);
+    $files = $filesStmt->fetchAll(PDO::FETCH_ASSOC);
+
+    $notesStmt = $pdo->prepare('SELECT id,note_text,date_created FROM module_tasks_notes WHERE task_id = :id ORDER BY date_created DESC');
+    $notesStmt->execute([':id' => $task_id]);
+    $notes = $notesStmt->fetchAll(PDO::FETCH_ASSOC);
+  }
+} elseif ($action === 'create-edit' && isset($_GET['id'])) {
   $task_id = (int)($_GET['id'] ?? 0);
   $stmt = $pdo->prepare('SELECT id, name, description, status, priority FROM module_tasks WHERE id = :id');
   $stmt->execute([':id' => $task_id]);


### PR DESCRIPTION
## Summary
- Implement detailed task view leveraging theme styles, showing assignments, files, and notes
- Fetch task metadata, assignments, attachments, and notes when viewing task details
- Link task names to new details view and update file/note actions to return to it

## Testing
- `php -l module/task/index.php`
- `php -l module/task/include/details_view.php`
- `php -l module/task/include/list_view.php`
- `php -l module/task/functions/upload_file.php`
- `php -l module/task/functions/add_note.php`


------
https://chatgpt.com/codex/tasks/task_e_689d770d0b208333be1e10c1c4fd74bc