### PR TITLE
Add project creation form and handling

### DIFF
--- a/module/project/functions/create.php
+++ b/module/project/functions/create.php
@@ -1,5 +1,7 @@
 <?php
-require '../../../includes/php_header.php';
+if (!isset($pdo)) {
+  require '../../../includes/php_header.php';
+}
 require_permission('project', 'create');
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -15,9 +17,22 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     ':description' => $description
   ]);
   $id = $pdo->lastInsertId();
-  audit_log($pdo, $this_user_id, 'module_projects', $id, 'CREATE', 'Created project');
+
+  admin_audit_log(
+    $pdo,
+    $this_user_id,
+    'module_projects',
+    $id,
+    'CREATE',
+    null,
+    json_encode([
+      'name' => $name,
+      'status' => $status,
+      'description' => $description
+    ]),
+    'Created project'
+  );
 }
 
-header('Location: ../index.php');
+header('Location: index.php');
 exit;
-

--- a/module/project/include/card_view.php
+++ b/module/project/include/card_view.php
@@ -2,6 +2,11 @@
 // Card view of projects
 ?>
 <div class="container-fluid">
+  <?php if (user_has_permission('project','create')): ?>
+  <div class="mb-3">
+    <a href="index.php?action=create" class="btn btn-primary">Create Project</a>
+  </div>
+  <?php endif; ?>
   <div class="row g-3">
     <?php foreach ($projects as $project): ?>
       <div class="col-12 col-md-6 col-lg-4">

--- a/module/project/include/create_edit.php
+++ b/module/project/include/create_edit.php
@@ -1,0 +1,43 @@
+<?php
+// Form for creating a project
+?>
+<div class="container-fluid">
+  <div class="row">
+    <div class="col-xl-9">
+      <form class="row g-3 mb-6" method="post" action="index.php?action=create">
+        <div class="col-sm-6 col-md-8">
+          <div class="form-floating">
+            <input class="form-control" id="projectName" type="text" name="name" placeholder="Project title" />
+            <label for="projectName">Project title</label>
+          </div>
+        </div>
+        <div class="col-sm-6 col-md-4">
+          <div class="form-floating">
+            <select class="form-select" id="projectStatus" name="status">
+              <?php foreach ($statusMap as $s): ?>
+                <option value="<?php echo htmlspecialchars($s['id']); ?>"><?php echo htmlspecialchars($s['label']); ?></option>
+              <?php endforeach; ?>
+            </select>
+            <label for="projectStatus">Status</label>
+          </div>
+        </div>
+        <div class="col-12 gy-6">
+          <div class="form-floating">
+            <textarea class="form-control" id="projectDescription" name="description" placeholder="Description" style="height:100px"></textarea>
+            <label for="projectDescription">Project description</label>
+          </div>
+        </div>
+        <div class="col-12 gy-6">
+          <div class="row g-3 justify-content-end">
+            <div class="col-auto">
+              <a class="btn btn-phoenix-primary px-5" href="index.php">Cancel</a>
+            </div>
+            <div class="col-auto">
+              <button class="btn btn-primary px-5 px-sm-15" type="submit">Create Project</button>
+            </div>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>

--- a/module/project/include/list_view.php
+++ b/module/project/include/list_view.php
@@ -1,6 +1,11 @@
 <?php
 // List view of projects
 ?>
+<?php if (user_has_permission('project','create')): ?>
+<div class="mb-3">
+  <a href="index.php?action=create" class="btn btn-primary">Create Project</a>
+</div>
+<?php endif; ?>
 <div class="table-responsive">
   <table class="table table-striped">
     <thead>

--- a/module/project/index.php
+++ b/module/project/index.php
@@ -1,8 +1,32 @@
 <?php
 require '../../includes/php_header.php';
-require_permission('project','read');
 
 $action = $_GET['action'] ?? 'card';
+
+if ($action === 'create' && $_SERVER['REQUEST_METHOD'] === 'POST') {
+  require 'functions/create.php';
+  exit;
+}
+
+if ($action === 'create') {
+  require_permission('project', 'create');
+  $statusMap = get_lookup_items($pdo, 'PROJECT_STATUS');
+  require '../../includes/html_header.php';
+  ?>
+  <main class="main" id="top">
+    <?php require '../../includes/left_navigation.php'; ?>
+    <?php require '../../includes/navigation.php'; ?>
+    <div id="main_content" class="content">
+      <?php require 'include/create_edit.php'; ?>
+      <?php require '../../includes/html_footer.php'; ?>
+    </div>
+  </main>
+  <?php require '../../includes/js_footer.php'; ?>
+  <?php
+  exit;
+}
+
+require_permission('project','read');
 
 $statusMap = array_column(get_lookup_items($pdo, 'PROJECT_STATUS'), null, 'id');
 $stmt = $pdo->query('SELECT id, name, status FROM module_projects ORDER BY name');


### PR DESCRIPTION
## Summary
- add Bootstrap-based form for creating projects
- log project creation in admin audit log
- expose create action via index and card/list views

## Testing
- `php -l module/project/functions/create.php`
- `php -l module/project/include/card_view.php`
- `php -l module/project/include/list_view.php`
- `php -l module/project/index.php`
- `php -l module/project/include/create_edit.php`


------
https://chatgpt.com/codex/tasks/task_e_689d770796c48333a2972f908306a91d