### PR TITLE
feat: apply Phoenix project details layout

### DIFF
--- a/includes/js_footer.php
+++ b/includes/js_footer.php
@@ -21,6 +21,7 @@
 
     <!-- Project-specific JS (if any) -->
     <script src="<?php echo getURLDir(); ?>assets/js/projectmanagement-dashboard.js"></script>
+    <script src="<?php echo getURLDir(); ?>assets/js/project-details.js"></script>
 
     <!-- FontAwesome (for dynamic icon loading) -->
     <script src="<?php echo getURLDir(); ?>vendors/fontawesome/all.min.js"></script>

--- a/module/project/include/details_view.php
+++ b/module/project/include/details_view.php
@@ -2,76 +2,98 @@
 // Project details view built from the Phoenix theme project-details template
 ?>
 <?php if (!empty($current_project)): ?>
-  <div class="container-fluid py-4">
-    <div class="row mb-4">
-      <div class="col-12 col-lg-8">
-        <h2 class="mb-2"><?php echo htmlspecialchars($current_project['name'] ?? ''); ?></h2>
-        <div class="mb-2">
-          <span class="badge badge-phoenix fs-10 badge-phoenix-<?php echo htmlspecialchars($statusMap[$current_project['status']]['color_class'] ?? 'secondary'); ?>">
-            <span class="badge-label"><?php echo htmlspecialchars($statusMap[$current_project['status']]['label'] ?? ''); ?></span>
+<div class="content px-0 pt-navbar">
+  <div class="row g-0">
+    <div class="col-12 col-xxl-8 px-0 bg-body">
+      <div class="px-4 px-lg-6 pt-6 pb-9">
+        <div class="mb-5">
+          <div class="d-flex justify-content-between">
+            <h2 class="text-body-emphasis fw-bolder mb-2"><?php echo htmlspecialchars($current_project['name'] ?? ''); ?></h2>
+          </div>
+          <span class="badge badge-phoenix badge-phoenix-<?php echo htmlspecialchars($statusMap[$current_project['status']]['color_class'] ?? 'secondary'); ?>">
+            <?php echo htmlspecialchars($statusMap[$current_project['status']]['label'] ?? ''); ?>
           </span>
         </div>
-        <p class="text-body-secondary"><?php echo nl2br(htmlspecialchars($current_project['description'] ?? '')); ?></p>
+        <h3 class="text-body-emphasis mb-4">Project overview</h3>
+        <p class="text-body-secondary mb-0"><?php echo nl2br(htmlspecialchars($current_project['description'] ?? '')); ?></p>
       </div>
     </div>
-
-    <div class="row g-4">
-      <div class="col-12 col-xl-6">
-        <div class="card mb-4">
-          <div class="card-header"><h5 class="mb-0">Files</h5></div>
-          <div class="card-body">
-            <form action="functions/upload_file.php" method="post" enctype="multipart/form-data" class="mb-3">
-              <input type="hidden" name="id" value="<?php echo (int)$current_project['id']; ?>">
-              <input class="form-control mb-2" type="file" name="file" required>
-              <button class="btn btn-primary" type="submit">Upload</button>
-            </form>
-            <?php if (!empty($files)): ?>
-              <div class="table-responsive">
-                <table class="table table-sm">
-                  <thead>
-                    <tr><th>File</th><th>Size</th><th>Type</th></tr>
-                  </thead>
-                  <tbody>
-                    <?php foreach ($files as $f): ?>
-                      <tr>
-                        <td><a href="<?php echo htmlspecialchars($f['file_path']); ?>"><?php echo htmlspecialchars($f['file_name']); ?></a></td>
-                        <td><?php echo htmlspecialchars($f['file_size']); ?></td>
-                        <td><?php echo htmlspecialchars($f['file_type']); ?></td>
-                      </tr>
-                    <?php endforeach; ?>
-                  </tbody>
-                </table>
+    <div class="col-12 col-xxl-4 px-0 border-start-xxl border-top-sm">
+      <div class="bg-light dark__bg-gray-1100 h-100">
+        <div class="p-4 p-lg-6">
+          <h3 class="text-body-highlight mb-4 fw-bold">Notes</h3>
+          <div class="timeline-vertical timeline-with-details">
+            <?php if (!empty($notes)): ?>
+              <?php foreach ($notes as $n): ?>
+              <div class="timeline-item position-relative">
+                <div class="row g-md-3">
+                  <div class="col-12 col-md-auto d-flex">
+                    <div class="timeline-item-date order-1 order-md-0 me-md-4">
+                      <p class="fs-10 fw-semibold text-body-tertiary text-opacity-85 text-end">
+                        <?php echo htmlspecialchars(date('d M, Y', strtotime($n['date_created']))); ?><br class="d-none d-md-block" />
+                        <?php echo htmlspecialchars(date('h:i A', strtotime($n['date_created']))); ?>
+                      </p>
+                    </div>
+                    <div class="timeline-item-bar position-md-relative me-3 me-md-0">
+                      <div class="icon-item icon-item-sm rounded-7 shadow-none bg-primary-subtle">
+                        <span class="fa-solid fa-note-sticky text-primary-dark fs-10"></span>
+                      </div>
+                      <span class="timeline-bar border-end border-dashed"></span>
+                    </div>
+                  </div>
+                  <div class="col">
+                    <div class="timeline-item-content ps-6 ps-md-3">
+                      <p class="fs-9 text-body-secondary mb-0"><?php echo nl2br(htmlspecialchars($n['note_text'])); ?></p>
+                    </div>
+                  </div>
+                </div>
               </div>
+              <?php endforeach; ?>
+            <?php else: ?>
+              <p class="fs-9 text-body-secondary mb-0">No notes found.</p>
             <?php endif; ?>
           </div>
-        </div>
-      </div>
-
-      <div class="col-12 col-xl-6">
-        <div class="card mb-4">
-          <div class="card-header"><h5 class="mb-0">Notes</h5></div>
-          <div class="card-body">
-            <form action="functions/add_note.php" method="post" class="mb-3">
+          <div class="mt-4">
+            <form action="functions/add_note.php" method="post">
               <input type="hidden" name="id" value="<?php echo (int)$current_project['id']; ?>">
-              <textarea class="form-control mb-2" name="note" rows="3" required></textarea>
+              <div class="mb-3">
+                <textarea class="form-control" name="note" rows="3" required></textarea>
+              </div>
               <button class="btn btn-primary" type="submit">Add Note</button>
             </form>
-            <?php if (!empty($notes)): ?>
-              <ul class="list-group">
-                <?php foreach ($notes as $n): ?>
-                  <li class="list-group-item d-flex justify-content-between align-items-start">
-                    <div><?php echo nl2br(htmlspecialchars($n['note_text'])); ?></div>
-                    <small class="text-muted ms-2"><?php echo htmlspecialchars($n['date_created']); ?></small>
-                  </li>
-                <?php endforeach; ?>
-              </ul>
-            <?php endif; ?>
           </div>
+        </div>
+        <div class="px-4 px-lg-6">
+          <h4 class="mb-3">Files</h4>
+        </div>
+        <div class="border-top px-4 px-lg-6 py-4">
+          <form action="functions/upload_file.php" method="post" enctype="multipart/form-data" class="mb-3">
+            <input type="hidden" name="id" value="<?php echo (int)$current_project['id']; ?>">
+            <input class="form-control mb-2" type="file" name="file" required>
+            <button class="btn btn-primary" type="submit">Upload</button>
+          </form>
+          <?php if (!empty($files)): ?>
+            <?php foreach ($files as $f): ?>
+            <div class="border-top pt-3 mt-3">
+              <div class="d-flex flex-between-center">
+                <div class="d-flex mb-1">
+                  <span class="fa-solid fa-file me-2 text-body-tertiary fs-9"></span>
+                  <a class="text-body-highlight mb-0 lh-1" href="<?php echo htmlspecialchars($f['file_path']); ?>"><?php echo htmlspecialchars($f['file_name']); ?></a>
+                </div>
+              </div>
+              <div class="d-flex fs-9 text-body-tertiary mb-0 flex-wrap">
+                <span><?php echo htmlspecialchars($f['file_size']); ?></span><span class="text-body-quaternary mx-1">| </span><span class="text-nowrap"><?php echo htmlspecialchars($f['file_type']); ?></span><span class="text-body-quaternary mx-1">| </span><span class="text-nowrap"><?php echo htmlspecialchars($f['date_created']); ?></span>
+              </div>
+            </div>
+            <?php endforeach; ?>
+          <?php else: ?>
+            <p class="fs-9 text-body-secondary mb-0">No files uploaded.</p>
+          <?php endif; ?>
         </div>
       </div>
     </div>
   </div>
+</div>
 <?php else: ?>
-  <p>No project found.</p>
+<p>No project found.</p>
 <?php endif; ?>
-


### PR DESCRIPTION
## Summary
- migrate project details view to Phoenix theme structure
- display project status, notes timeline, and file management in new layout
- load Phoenix project-details script assets

## Testing
- `php -l module/project/include/details_view.php`
- `php -l includes/js_footer.php`


------
https://chatgpt.com/codex/tasks/task_e_689e0e14748083339d6e00aa2ca7beaa