### PR TITLE
Refactor project creation form

### DIFF
--- a/module/project/functions/create.php
+++ b/module/project/functions/create.php
@@ -8,13 +8,23 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   $name = $_POST['name'] ?? '';
   $status = $_POST['status'] ?? null;
   $description = $_POST['description'] ?? null;
+  $requirements = $_POST['requirements'] ?? null;
+  $specifications = $_POST['specifications'] ?? null;
+  $start_date = $_POST['start_date'] ?? null;
+  $agency_id = $_POST['agency_id'] ?? null;
+  $division_id = $_POST['division_id'] ?? null;
 
-  $stmt = $pdo->prepare('INSERT INTO module_projects (user_id, user_updated, name, status, description) VALUES (:uid, :uid, :name, :status, :description)');
+  $stmt = $pdo->prepare('INSERT INTO module_projects (user_id, user_updated, agency_id, division_id, name, description, requirements, specifications, status, start_date) VALUES (:uid, :uid, :agency_id, :division_id, :name, :description, :requirements, :specifications, :status, :start_date)');
   $stmt->execute([
     ':uid' => $this_user_id,
+    ':agency_id' => $agency_id,
+    ':division_id' => $division_id,
     ':name' => $name,
+    ':description' => $description,
+    ':requirements' => $requirements,
+    ':specifications' => $specifications,
     ':status' => $status,
-    ':description' => $description
+    ':start_date' => $start_date
   ]);
   $id = $pdo->lastInsertId();
 
@@ -26,9 +36,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     'CREATE',
     null,
     json_encode([
+      'agency_id' => $agency_id,
+      'division_id' => $division_id,
       'name' => $name,
+      'description' => $description,
+      'requirements' => $requirements,
+      'specifications' => $specifications,
       'status' => $status,
-      'description' => $description
+      'start_date' => $start_date
     ]),
     'Created project'
   );

--- a/module/project/include/create_edit.php
+++ b/module/project/include/create_edit.php
@@ -16,65 +16,10 @@
           <div class="form-floating">
             <select class="form-select" id="projectStatus" name="status">
               <?php foreach ($statusMap as $s): ?>
-                <option value="<?php echo htmlspecialchars($s['id']); ?>"><?php echo htmlspecialchars($s['label']); ?></option>
+                <option value="<?= htmlspecialchars($s['id']); ?>"><?= htmlspecialchars($s['label']); ?></option>
               <?php endforeach; ?>
             </select>
             <label for="projectStatus">Status</label>
-          </div>
-        </div>
-        <div class="col-sm-6 col-md-4">
-          <div class="form-floating">
-            <select class="form-select" id="defaultTaskView" name="task_view">
-              <option selected="selected">Select task view</option>
-              <option value="technical">technical</option>
-              <option value="external">external</option>
-              <option value="organizational">organizational</option>
-            </select>
-            <label for="defaultTaskView">Default task view</label>
-          </div>
-        </div>
-        <div class="col-sm-6 col-md-4">
-          <div class="form-floating">
-            <select class="form-select" id="projectPrivacy" name="privacy">
-              <option selected="selected">Select privacy</option>
-              <option value="1">Data Privacy One</option>
-              <option value="2">Data Privacy Two</option>
-              <option value="3">Data Privacy Three</option>
-            </select>
-            <label for="projectPrivacy">Project privacy</label>
-          </div>
-        </div>
-        <div class="col-sm-6 col-md-4">
-          <div class="form-floating">
-            <select class="form-select" id="projectTeam" name="team">
-              <option selected="selected">Select team</option>
-              <option value="1">Team One</option>
-              <option value="2">Team Two</option>
-              <option value="3">Team Three</option>
-            </select>
-            <label for="projectTeam">Team</label>
-          </div>
-        </div>
-        <div class="col-sm-6 col-md-4">
-          <div class="form-floating">
-            <select class="form-select" id="projectAssignees" name="assignees">
-              <option selected="selected">Select assignees</option>
-              <option value="1">One</option>
-              <option value="2">Two</option>
-              <option value="3">Three</option>
-            </select>
-            <label for="projectAssignees">People</label>
-          </div>
-        </div>
-        <div class="col-sm-6 col-md-4">
-          <div class="form-floating">
-            <select class="form-select" id="projectLead" name="admin">
-              <option selected="selected">Select admin</option>
-              <option value="1">Data Privacy One</option>
-              <option value="2">Data Privacy Two</option>
-              <option value="3">Data Privacy Three</option>
-            </select>
-            <label for="projectLead">Project Lead</label>
           </div>
         </div>
         <div class="col-sm-6 col-md-4">
@@ -86,48 +31,43 @@
           </div>
         </div>
         <div class="col-sm-6 col-md-4">
-          <div class="flatpickr-input-container">
-            <div class="form-floating">
-              <input class="form-control datetimepicker" id="deadline" type="text" name="deadline" placeholder="deadline" data-options='{"disableMobile":true}' />
-              <label class="ps-6" for="deadline">Deadline</label><span class="uil uil-calendar-alt flatpickr-icon text-body-tertiary"></span>
-            </div>
+          <div class="form-floating">
+            <select class="form-select" id="agencySelect" name="agency_id">
+              <option value="">Select agency</option>
+              <?php foreach ($agencies as $agency): ?>
+                <option value="<?= htmlspecialchars($agency['id']); ?>"><?= htmlspecialchars($agency['name']); ?></option>
+              <?php endforeach; ?>
+            </select>
+            <label for="agencySelect">Agency</label>
+          </div>
+        </div>
+        <div class="col-sm-6 col-md-4">
+          <div class="form-floating">
+            <select class="form-select" id="divisionSelect" name="division_id">
+              <option value="">Select division</option>
+              <?php foreach ($divisions as $division): ?>
+                <option value="<?= htmlspecialchars($division['id']); ?>"><?= htmlspecialchars($division['name']); ?></option>
+              <?php endforeach; ?>
+            </select>
+            <label for="divisionSelect">Division</label>
           </div>
         </div>
         <div class="col-12 gy-6">
           <div class="form-floating">
-            <textarea class="form-control" id="projectDescription" name="description" placeholder="Leave a comment here" style="height:100px"></textarea>
-            <label for="projectDescription">project overview</label>
-          </div>
-        </div>
-        <div class="col-md-6 gy-6">
-          <div class="form-floating">
-            <select class="form-select" id="projectClient" name="client">
-              <option selected="selected">Select client</option>
-              <option value="1">Client One</option>
-              <option value="2">Client Two</option>
-              <option value="3">Client Three</option>
-            </select>
-            <label for="projectClient">client</label>
-          </div>
-        </div>
-        <div class="col-md-6 gy-md-6">
-          <div class="form-floating">
-            <input class="form-control" id="projectBudget" type="text" name="budget" placeholder="Budget" />
-            <label for="projectBudget">Budget</label>
+            <textarea class="form-control" id="projectDescription" name="description" placeholder="Leave a description here" style="height:100px"></textarea>
+            <label for="projectDescription">Project description</label>
           </div>
         </div>
         <div class="col-12 gy-6">
-          <div class="form-floating form-floating-advance-select">
-            <label for="projectTags">Add tags</label>
-            <select class="form-select" id="projectTags" name="tags[]" data-choices="data-choices" multiple="multiple" data-options='{"removeItemButton":true,"placeholder":true}'>
-              <option value="Stupidity" selected="selected">Stupidity</option>
-              <option value="Jerry">Jerry</option>
-              <option value="Not_the_mouse">Not_the_mouse</option>
-              <option value="Rick">Rick</option>
-              <option value="Biology">Biology</option>
-              <option value="Neurology">Neurology</option>
-              <option value="Brainlessness">Brainlessness</option>
-            </select>
+          <div class="form-floating">
+            <textarea class="form-control" id="projectRequirements" name="requirements" placeholder="Requirements" style="height:100px"></textarea>
+            <label for="projectRequirements">Requirements</label>
+          </div>
+        </div>
+        <div class="col-12 gy-6">
+          <div class="form-floating">
+            <textarea class="form-control" id="projectSpecifications" name="specifications" placeholder="Specifications" style="height:100px"></textarea>
+            <label for="projectSpecifications">Specifications</label>
           </div>
         </div>
         <div class="col-12 gy-6">

--- a/module/project/index.php
+++ b/module/project/index.php
@@ -11,6 +11,8 @@ if ($action === 'create' && $_SERVER['REQUEST_METHOD'] === 'POST') {
 if ($action === 'create') {
   require_permission('project', 'create');
   $statusMap = get_lookup_items($pdo, 'PROJECT_STATUS');
+  $agencies = $pdo->query('SELECT id, name FROM module_agency ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
+  $divisions = $pdo->query('SELECT id, name FROM module_division ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
   require '../../includes/html_header.php';
   ?>
   <main class="main" id="top">


### PR DESCRIPTION
## Summary
- Replace project creation form markup with Phoenix theme layout and required fields
- Load agencies and divisions for form selections
- Save requirements, specifications, start date, agency and division on create

## Testing
- `php -l module/project/include/create_edit.php`
- `php -l module/project/index.php`
- `php -l module/project/functions/create.php`


------
https://chatgpt.com/codex/tasks/task_e_689e6369f5ec8333949435096460784c