### PR TITLE
Add helper for HTML escaping and sanitize project views

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -4,6 +4,10 @@ function getURLDir(){
   return '/_atlis/';
 }
 
+function h(?string $value): string {
+  return htmlspecialchars($value ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+}
+
 /**
  * Writes an entry to the audit_log table using a stored procedure.
  *

--- a/module/project/details_view.php
+++ b/module/project/details_view.php
@@ -30,7 +30,7 @@ require '../../includes/html_header.php';
   <?php require '../../includes/left_navigation.php'; ?>
   <?php require '../../includes/navigation.php'; ?>
   <div id="main_content" class="content">
-    <h2 class="mb-4">Project: <?php echo htmlspecialchars($project['name'] ?? ''); ?></h2>
+    <h2 class="mb-4">Project: <?php echo h($project['name'] ?? ''); ?></h2>
 
     <div class="card mb-4">
       <div class="card-header"><h5 class="mb-0">Upload Files</h5></div>
@@ -51,9 +51,9 @@ require '../../includes/html_header.php';
             <tbody>
               <?php foreach ($files as $f): ?>
               <tr>
-                <td><a href="<?php echo htmlspecialchars($f['file_path']); ?>"><?php echo htmlspecialchars($f['file_name']); ?></a></td>
-                <td><?php echo htmlspecialchars($f['file_size']); ?></td>
-                <td><?php echo htmlspecialchars($f['file_type']); ?></td>
+                <td><a href="<?php echo h($f['file_path']); ?>"><?php echo h($f['file_name']); ?></a></td>
+                <td><?php echo h($f['file_size']); ?></td>
+                <td><?php echo h($f['file_type']); ?></td>
               </tr>
               <?php endforeach; ?>
             </tbody>
@@ -77,8 +77,8 @@ require '../../includes/html_header.php';
         <ul class="list-group mt-3">
           <?php foreach ($notes as $n): ?>
           <li class="list-group-item d-flex justify-content-between align-items-start">
-            <div><?php echo nl2br(htmlspecialchars($n['note_text'])); ?></div>
-            <small class="text-muted ms-2"><?php echo htmlspecialchars($n['date_created']); ?></small>
+            <div><?php echo nl2br(h($n['note_text'])); ?></div>
+            <small class="text-muted ms-2"><?php echo h($n['date_created']); ?></small>
           </li>
           <?php endforeach; ?>
         </ul>

--- a/module/project/include/board_view.php
+++ b/module/project/include/board_view.php
@@ -4,11 +4,11 @@
 <div class="row g-3">
   <?php foreach ($statusMap as $id => $status): ?>
     <div class="col-12 col-md-6 col-lg-4">
-      <h5 class="mb-3"><?php echo htmlspecialchars($status['label'] ?? ''); ?></h5>
+      <h5 class="mb-3"><?php echo h($status['label'] ?? ''); ?></h5>
       <?php foreach ($projects as $proj): if (($proj['status'] ?? '') == $id): ?>
         <div class="card mb-2">
           <div class="card-body p-2">
-            <?php echo htmlspecialchars($proj['name'] ?? ''); ?>
+            <?php echo h($proj['name'] ?? ''); ?>
           </div>
         </div>
       <?php endif; endforeach; ?>

--- a/module/project/include/card_view.php
+++ b/module/project/include/card_view.php
@@ -72,24 +72,24 @@ foreach ($projects as $proj) {
       <div class="card-body">
         <div class="d-flex align-items-center">
           <h4 class="mb-2 line-clamp-1 lh-sm flex-1 me-5">
-            <a href="index.php?action=details&id=<?php echo $project['id']; ?>"><?php echo htmlspecialchars($project['name']); ?></a>
+            <a href="index.php?action=details&id=<?php echo $project['id']; ?>"><?php echo h($project['name']); ?></a>
           </h4>
           <div class="hover-actions top-0 end-0 mt-4 me-4">
             <a class="btn btn-primary btn-icon flex-shrink-0" href="index.php?action=details&id=<?php echo $project['id']; ?>"><span class="fa-solid fa-chevron-right"></span></a>
           </div>
         </div>
-        <span class="badge badge-phoenix fs-10 mb-4 badge-phoenix-<?php echo htmlspecialchars($project['status_color']); ?>"><?php echo htmlspecialchars($project['status_label']); ?></span>
+        <span class="badge badge-phoenix fs-10 mb-4 badge-phoenix-<?php echo h($project['status_color'] ?? 'secondary'); ?>"><?php echo h($project['status_label'] ?? ''); ?></span>
         <?php if (!empty($project['description'])): ?>
-        <p class="text-body-secondary line-clamp-2 mb-4"><?php echo htmlspecialchars($project['description']); ?></p>
+        <p class="text-body-secondary line-clamp-2 mb-4"><?php echo h($project['description']); ?></p>
         <?php endif; ?>
         <?php if (!empty($project['start_date'])): ?>
         <div class="d-flex align-items-center mt-4">
-          <p class="mb-0 fw-bold fs-9">Started :<span class="fw-semibold text-body-tertiary text-opactity-85 ms-1"><?php echo htmlspecialchars($project['start_date']); ?></span></p>
+          <p class="mb-0 fw-bold fs-9">Started :<span class="fw-semibold text-body-tertiary text-opactity-85 ms-1"><?php echo h($project['start_date']); ?></span></p>
         </div>
         <?php endif; ?>
         <?php if (!empty($project['complete_date'])): ?>
         <div class="d-flex align-items-center mt-2">
-          <p class="mb-0 fw-bold fs-9">Deadline : <span class="fw-semibold text-body-tertiary text-opactity-85 ms-1"><?php echo htmlspecialchars($project['complete_date']); ?></span></p>
+          <p class="mb-0 fw-bold fs-9">Deadline : <span class="fw-semibold text-body-tertiary text-opactity-85 ms-1"><?php echo h($project['complete_date']); ?></span></p>
         </div>
         <?php endif; ?>
       </div>

--- a/module/project/include/create_edit.php
+++ b/module/project/include/create_edit.php
@@ -16,7 +16,7 @@
           <div class="form-floating">
             <select class="form-select" id="projectStatus" name="status">
               <?php foreach ($statusMap as $s): ?>
-                <option value="<?= htmlspecialchars($s['id']); ?>"><?= htmlspecialchars($s['label']); ?></option>
+                <option value="<?= h($s['id']); ?>"><?= h($s['label']); ?></option>
               <?php endforeach; ?>
             </select>
             <label for="projectStatus">Status</label>
@@ -35,7 +35,7 @@
             <select class="form-select" id="agencySelect" name="agency_id">
               <option value="">Select agency</option>
               <?php foreach ($agencies as $agency): ?>
-                <option value="<?= htmlspecialchars($agency['id']); ?>"><?= htmlspecialchars($agency['name']); ?></option>
+                <option value="<?= h($agency['id']); ?>"><?= h($agency['name']); ?></option>
               <?php endforeach; ?>
             </select>
             <label for="agencySelect">Agency</label>
@@ -46,7 +46,7 @@
             <select class="form-select" id="divisionSelect" name="division_id">
               <option value="">Select division</option>
               <?php foreach ($divisions as $division): ?>
-                <option value="<?= htmlspecialchars($division['id']); ?>"><?= htmlspecialchars($division['name']); ?></option>
+                <option value="<?= h($division['id']); ?>"><?= h($division['name']); ?></option>
               <?php endforeach; ?>
             </select>
             <label for="divisionSelect">Division</label>

--- a/module/project/include/create_edit_view.php
+++ b/module/project/include/create_edit_view.php
@@ -5,23 +5,23 @@ $actionUrl = $editing ? 'functions/update.php' : 'functions/create.php';
 ?>
 <form method="post" action="<?php echo $actionUrl; ?>">
   <?php if ($editing): ?>
-    <input type="hidden" name="id" value="<?php echo htmlspecialchars($current_project['id']); ?>">
+    <input type="hidden" name="id" value="<?php echo h($current_project['id'] ?? ''); ?>">
   <?php endif; ?>
   <div class="mb-3">
     <label class="form-label">Name</label>
-    <input type="text" name="name" class="form-control" value="<?php echo htmlspecialchars($current_project['name'] ?? ''); ?>">
+    <input type="text" name="name" class="form-control" value="<?php echo h($current_project['name'] ?? ''); ?>">
   </div>
   <div class="mb-3">
     <label class="form-label">Status</label>
     <select name="status" class="form-select">
       <?php foreach ($statusMap as $id => $status): ?>
-        <option value="<?php echo htmlspecialchars($id); ?>" <?php if (($current_project['status'] ?? '') == $id) echo 'selected'; ?>><?php echo htmlspecialchars($status['label']); ?></option>
+        <option value="<?php echo h($id); ?>" <?php if (($current_project['status'] ?? '') == $id) echo 'selected'; ?>><?php echo h($status['label']); ?></option>
       <?php endforeach; ?>
     </select>
   </div>
   <div class="mb-3">
     <label class="form-label">Description</label>
-    <textarea name="description" class="form-control" rows="4"><?php echo htmlspecialchars($current_project['description'] ?? ''); ?></textarea>
+    <textarea name="description" class="form-control" rows="4"><?php echo h($current_project['description'] ?? ''); ?></textarea>
   </div>
   <button type="submit" class="btn btn-primary"><?php echo $editing ? 'Update' : 'Create'; ?></button>
 </form>

--- a/module/project/include/details_view.php
+++ b/module/project/include/details_view.php
@@ -8,14 +8,14 @@
       <div class="px-4 px-lg-6 pt-6 pb-9">
         <div class="mb-5">
           <div class="d-flex justify-content-between">
-            <h2 class="text-body-emphasis fw-bolder mb-2"><?php echo htmlspecialchars($current_project['name'] ?? ''); ?></h2>
+            <h2 class="text-body-emphasis fw-bolder mb-2"><?php echo h($current_project['name'] ?? ''); ?></h2>
           </div>
-          <span class="badge badge-phoenix badge-phoenix-<?php echo htmlspecialchars($statusMap[$current_project['status']]['color_class'] ?? 'secondary'); ?>">
-            <?php echo htmlspecialchars($statusMap[$current_project['status']]['label'] ?? ''); ?>
+          <span class="badge badge-phoenix badge-phoenix-<?php echo h($statusMap[$current_project['status']]['color_class'] ?? 'secondary'); ?>">
+            <?php echo h($statusMap[$current_project['status']]['label'] ?? ''); ?>
           </span>
         </div>
           <h3 class="text-body-emphasis mb-4">Project overview</h3>
-          <p class="text-body-secondary mb-4"><?php echo nl2br(htmlspecialchars($current_project['description'] ?? '')); ?></p>
+          <p class="text-body-secondary mb-4"><?php echo nl2br(h($current_project['description'] ?? '')); ?></p>
 
           <h3 class="text-body-emphasis mb-4">Tasks</h3>
           <div class="row align-items-center g-0 justify-content-start mb-3">
@@ -38,14 +38,14 @@
                 <div>
                   <div class="form-check mb-1 mb-md-0 d-flex align-items-center lh-1">
                     <input class="form-check-input flex-shrink-0 form-check-line-through mt-0 me-2" type="checkbox" id="checkbox-task-<?php echo (int)$t['id']; ?>" <?php echo !empty($t['completed']) ? 'checked' : ''; ?> />
-                    <label class="form-check-label mb-0 fs-8 me-2 line-clamp-1" for="checkbox-task-<?php echo (int)$t['id']; ?>"><?php echo htmlspecialchars($t['name']); ?></label>
-                    <span class="badge badge-phoenix fs-10 badge-phoenix-<?php echo htmlspecialchars($t['status_color']); ?> ms-2"><span class="badge-label"><?php echo htmlspecialchars($t['status_label']); ?></span></span>
+                    <label class="form-check-label mb-0 fs-8 me-2 line-clamp-1" for="checkbox-task-<?php echo (int)$t['id']; ?>"><?php echo h($t['name']); ?></label>
+                    <span class="badge badge-phoenix fs-10 badge-phoenix-<?php echo h($t['status_color'] ?? 'secondary'); ?> ms-2"><span class="badge-label"><?php echo h($t['status_label'] ?? ''); ?></span></span>
                   </div>
                 </div>
               </div>
               <div class="col-12 col-lg-auto">
                 <div class="d-flex ms-4 lh-1 align-items-center">
-                  <p class="text-body-tertiary fs-10 mb-md-0 me-2 me-lg-3 mb-0"><?php echo !empty($t['due_date']) ? htmlspecialchars(date('d M, Y', strtotime($t['due_date']))) : ''; ?></p>
+                  <p class="text-body-tertiary fs-10 mb-md-0 me-2 me-lg-3 mb-0"><?php echo !empty($t['due_date']) ? h(date('d M, Y', strtotime($t['due_date']))) : ''; ?></p>
                 </div>
               </div>
             </div>
@@ -67,8 +67,8 @@
                   <div class="col-12 col-md-auto d-flex">
                     <div class="timeline-item-date order-1 order-md-0 me-md-4">
                       <p class="fs-10 fw-semibold text-body-tertiary text-opacity-85 text-end">
-                        <?php echo htmlspecialchars(date('d M, Y', strtotime($n['date_created']))); ?><br class="d-none d-md-block" />
-                        <?php echo htmlspecialchars(date('h:i A', strtotime($n['date_created']))); ?>
+                        <?php echo h(date('d M, Y', strtotime($n['date_created']))); ?><br class="d-none d-md-block" />
+                        <?php echo h(date('h:i A', strtotime($n['date_created']))); ?>
                       </p>
                     </div>
                     <div class="timeline-item-bar position-md-relative me-3 me-md-0">
@@ -80,8 +80,8 @@
                   </div>
                     <div class="col">
                       <div class="timeline-item-content ps-6 ps-md-3">
-                        <p class="fs-9 text-body-secondary mb-1"><?php echo nl2br(htmlspecialchars($n['note_text'])); ?></p>
-                        <p class="fs-9 mb-0">by <a class="fw-semibold" href="#!"><?php echo htmlspecialchars($n['user_name'] ?? ''); ?></a></p>
+                        <p class="fs-9 text-body-secondary mb-1"><?php echo nl2br(h($n['note_text'])); ?></p>
+                        <p class="fs-9 mb-0">by <a class="fw-semibold" href="#!"><?php echo h($n['user_name'] ?? ''); ?></a></p>
                       </div>
                     </div>
                 </div>
@@ -117,14 +117,14 @@
               <div class="d-flex flex-between-center">
                 <div class="d-flex mb-1">
                   <span class="fa-solid <?php echo strpos($f['file_type'], 'image/') === 0 ? 'fa-image' : 'fa-file'; ?> me-2 text-body-tertiary fs-9"></span>
-                  <a class="text-body-highlight mb-0 lh-1" href="<?php echo htmlspecialchars($f['file_path']); ?>"><?php echo htmlspecialchars($f['file_name']); ?></a>
+                  <a class="text-body-highlight mb-0 lh-1" href="<?php echo h($f['file_path']); ?>"><?php echo h($f['file_name']); ?></a>
                 </div>
               </div>
               <div class="d-flex fs-9 text-body-tertiary mb-0 flex-wrap">
-                <span><?php echo htmlspecialchars($f['file_size']); ?></span><span class="text-body-quaternary mx-1">| </span><span class="text-nowrap"><?php echo htmlspecialchars($f['file_type']); ?></span><span class="text-body-quaternary mx-1">| </span><span class="text-nowrap"><?php echo htmlspecialchars($f['date_created']); ?></span>
+                <span><?php echo h($f['file_size']); ?></span><span class="text-body-quaternary mx-1">| </span><span class="text-nowrap"><?php echo h($f['file_type']); ?></span><span class="text-body-quaternary mx-1">| </span><span class="text-nowrap"><?php echo h($f['date_created']); ?></span>
               </div>
               <?php if (strpos($f['file_type'], 'image/') === 0): ?>
-                <img class="rounded-2 mt-2" src="<?php echo htmlspecialchars($f['file_path']); ?>" alt="" style="width:320px" />
+                <img class="rounded-2 mt-2" src="<?php echo h($f['file_path']); ?>" alt="" style="width:320px" />
               <?php endif; ?>
             </div>
             <?php endforeach; ?>

--- a/module/project/include/list_view.php
+++ b/module/project/include/list_view.php
@@ -17,10 +17,10 @@
     <tbody>
       <?php foreach ($projects as $proj): ?>
         <tr>
-          <td><?php echo htmlspecialchars($proj['name'] ?? ''); ?></td>
+          <td><?php echo h($proj['name'] ?? ''); ?></td>
           <td>
-            <span class="badge badge-phoenix fs-10 badge-phoenix-<?php echo htmlspecialchars($proj['status_color'] ?? ''); ?>">
-              <span class="badge-label"><?php echo htmlspecialchars($proj['status_label'] ?? ''); ?></span>
+            <span class="badge badge-phoenix fs-10 badge-phoenix-<?php echo h($proj['status_color'] ?? 'secondary'); ?>">
+              <span class="badge-label"><?php echo h($proj['status_label'] ?? ''); ?></span>
             </span>
           </td>
         </tr>


### PR DESCRIPTION
## Summary
- add `h()` HTML escaping helper
- replace direct `htmlspecialchars` calls across project views and forms
- ensure status badges default to `secondary` when color missing

## Testing
- `php -l includes/functions.php && php -l module/project/details_view.php && php -l module/project/include/board_view.php && php -l module/project/include/card_view.php && php -l module/project/include/create_edit.php && php -l module/project/include/create_edit_view.php && php -l module/project/include/details_view.php && php -l module/project/include/list_view.php`


------
https://chatgpt.com/codex/tasks/task_e_689e69a1c380833389c2a4a02ca1e079