### PR TITLE
Link lookup list names to items and track counts

### DIFF
--- a/admin/admin_header.php
+++ b/admin/admin_header.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/../includes/admin_guard.php';
+require_once __DIR__ . '/../includes/functions.php';
 require_once __DIR__ . '/../includes/helpers.php';
 require_once __DIR__ . '/../includes/html_header.php';
 ?>

--- a/admin/lookup-lists/index.php
+++ b/admin/lookup-lists/index.php
@@ -2,12 +2,12 @@
 require '../admin_header.php';
 
 $token = generate_csrf_token();
-$stmt = $pdo->query('SELECT id, name, description, memo FROM lookup_lists ORDER BY id DESC');
+$stmt = $pdo->query('SELECT l.id, l.name, l.description, l.memo, COUNT(li.id) AS item_count FROM lookup_lists l LEFT JOIN lookup_list_items li ON li.list_id = l.id GROUP BY l.id ORDER BY l.id DESC');
 $lists = $stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <h2 class="mb-4">Lookup Lists</h2>
 <button id="addListBtn" class="btn btn-sm btn-success mb-3">Add Lookup List</button>
-<div id="lookup-lists" data-list='{"valueNames":["id","name","description"],"page":50,"pagination":true}'>
+<div id="lookup-lists" data-list='{"valueNames":["id","name","description","item-count"],"page":50,"pagination":true}'>
   <div class="row justify-content-between g-2 mb-3">
     <div class="col-auto">
       <input class="form-control form-control-sm search" placeholder="Search" />
@@ -20,6 +20,7 @@ $lists = $stmt->fetchAll(PDO::FETCH_ASSOC);
           <th class="sort" data-sort="id">ID</th>
           <th class="sort" data-sort="name">Name</th>
           <th class="sort" data-sort="description">Description</th>
+          <th class="sort" data-sort="item-count">Item Count</th>
           <th>Actions</th>
         </tr>
       </thead>
@@ -27,11 +28,11 @@ $lists = $stmt->fetchAll(PDO::FETCH_ASSOC);
         <?php foreach($lists as $l): ?>
           <tr data-id="<?= htmlspecialchars($l['id']); ?>">
             <td class="id"><?= htmlspecialchars($l['id']); ?></td>
-            <td class="name"><?= htmlspecialchars($l['name']); ?></td>
+            <td class="name"><a href="items.php?list_id=<?= $l['id']; ?>"><?= htmlspecialchars($l['name']); ?></a></td>
             <td class="description"><?= htmlspecialchars($l['description']); ?></td>
+            <td class="item-count"><?= (int)$l['item_count']; ?></td>
             <td>
-              <button class="btn btn-sm btn-warning edit-list" data-id="<?= $l['id']; ?>" data-name="<?= htmlspecialchars($l['name'], ENT_QUOTES); ?>" data-description="<?= htmlspecialchars($l['description'], ENT_QUOTES); ?>" data-memo="<?= htmlspecialchars($l['memo'], ENT_QUOTES); ?>">Edit</button>
-              <a class="btn btn-sm btn-info" href="items.php?list_id=<?= $l['id']; ?>">Items</a>
+              <button class="btn btn-sm btn-warning edit-list" data-id="<?= $l['id']; ?>" data-name="<?= htmlspecialchars($l['name'], ENT_QUOTES); ?>" data-description="<?= htmlspecialchars($l['description'], ENT_QUOTES); ?>" data-memo="<?= h($l['memo']); ?>">Edit</button>
               <button class="btn btn-sm btn-danger delete-list" data-id="<?= $l['id']; ?>">Delete</button>
             </td>
           </tr>
@@ -117,17 +118,17 @@ $(function(){
           var l = res.list;
           var row = $('#lookup-lists tbody tr').filter(function(){ return $(this).data('id') == l.id; });
           if(row.length){
-            row.find('.name').text(l.name);
+            row.find('.name a').text(l.name);
             row.find('.description').text(l.description);
             row.find('.edit-list').data('name', l.name).data('description', l.description).data('memo', memoVal);
           }else{
             var html = '<tr data-id="'+l.id+'">'
               +'<td class="id">'+l.id+'</td>'
-              +'<td class="name">'+l.name+'</td>'
+              +'<td class="name"><a href="items.php?list_id='+l.id+'">'+l.name+'</a></td>'
               +'<td class="description">'+l.description+'</td>'
+              +'<td class="item-count">0</td>'
               +'<td>'
               +'<button class="btn btn-sm btn-warning edit-list" data-id="'+l.id+'" data-name="'+l.name+'" data-description="'+l.description+'">Edit</button> '
-              +'<a class="btn btn-sm btn-info" href="items.php?list_id='+l.id+'">Items</a> '
               +'<button class="btn btn-sm btn-danger delete-list" data-id="'+l.id+'">Delete</button>'
               +'</td></tr>';
             var $new = $(html);

--- a/admin/lookup-lists/items.php
+++ b/admin/lookup-lists/items.php
@@ -55,7 +55,7 @@ $items=$stmt->fetchAll(PDO::FETCH_ASSOC);
 
 <div class="row">
   <div class="col-12">
-    <h2 class="mb-4">Items for <?= htmlspecialchars($list['name']); ?>
+    <h2 class="mb-4">Items for <?= h($list['name']); ?>
       <br />
       <a class="btn btn-secondary" href="index.php">Back</a>
     </h2>
@@ -66,10 +66,10 @@ $items=$stmt->fetchAll(PDO::FETCH_ASSOC);
 <?= flash_message($message); ?>
 <form method="post" class="row g-2 mb-3">
   <input type="hidden" name="csrf_token" value="<?= $token; ?>">
-  <input type="hidden" name="id" value="<?= htmlspecialchars($_POST['id'] ?? ''); ?>">
+  <input type="hidden" name="id" value="<?= h($_POST['id'] ?? ''); ?>">
   <div class="col-md-2"><input class="form-control" name="code" placeholder="Code" required></div>
   <div class="col-md-3"><input class="form-control" name="label" placeholder="Label" required></div>
-  <div class="col-md-2"><input class="form-control" type="date" name="active_from" value="<?= htmlspecialchars($_POST['active_from'] ?? date('Y-m-d')); ?>" required></div>
+  <div class="col-md-2"><input class="form-control" type="date" name="active_from" value="<?= h($_POST['active_from'] ?? date('Y-m-d')); ?>" required></div>
   <div class="col-md-2"><input class="form-control" type="date" name="active_to"></div>
   <div class="col-md-2"><button class="btn btn-success w-100" type="submit" id="saveBtn">Save</button></div>
 </form>


### PR DESCRIPTION
## Summary
- Add reusable `h()` helper to admin header to ensure safe HTML escaping
- Link lookup list names directly to their item pages and show item counts
- Escape lookup list and item fields with `h()` for null-safe rendering

## Testing
- `php -l admin/lookup-lists/index.php admin/lookup-lists/items.php`


------
https://chatgpt.com/codex/tasks/task_e_689e6fa45e008333a88f20e45f067086