### PR TITLE
Track system property versions

### DIFF
--- a/admin/system-properties/version-history.php
+++ b/admin/system-properties/version-history.php
@@ -11,17 +11,18 @@ $name = $stmt->fetchColumn();
 
 $versions = [];
 if($id){
-  $stmt = $pdo->prepare('SELECT id, previous_value, user_id, date_created FROM system_properties_versions WHERE property_id=:id ORDER BY date_created DESC');
+  $stmt = $pdo->prepare('SELECT id, version_number, previous_value, user_id, date_created FROM system_properties_versions WHERE property_id=:id ORDER BY date_created DESC');
   $stmt->execute([':id'=>$id]);
   $versions = $stmt->fetchAll(PDO::FETCH_ASSOC);
 }
 ?>
 <h2 class="mb-4">Version History: <?= htmlspecialchars($name); ?></h2>
 <table class="table table-striped table-sm">
-  <thead><tr><th>Date</th><th>User</th><th>Value</th><th>Action</th></tr></thead>
+  <thead><tr><th>Version</th><th>Date</th><th>User</th><th>Previous Value</th><th>Action</th></tr></thead>
   <tbody>
   <?php foreach($versions as $v): ?>
     <tr data-id="<?= $v['id']; ?>">
+      <td><?= htmlspecialchars($v['version_number']); ?></td>
       <td><?= htmlspecialchars($v['date_created']); ?></td>
       <td><?= htmlspecialchars($v['user_id']); ?></td>
       <td><pre class="mb-0"><?= htmlspecialchars($v['previous_value']); ?></pre></td>


### PR DESCRIPTION
## Summary
- Track system property changes using `previous_value` and sequential `version_number`
- Restore system property values from version history
- Show version numbers and previous values in version history UI

## Testing
- `php -l admin/api/system-properties.php`
- `php -l admin/system-properties/version-history.php`


------
https://chatgpt.com/codex/tasks/task_e_689e73f70e888333a8025ae5254581c5