### PR TITLE
Handle hidden required select fields for system properties

### DIFF
--- a/admin/system-properties/edit.php
+++ b/admin/system-properties/edit.php
@@ -65,6 +65,10 @@ if($id){
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 <script>
 $(function(){
+  // Choices.js hides the original select elements, so ensure
+  // they're not marked as required to avoid browser validation
+  // errors when the hidden inputs are unfocusable.
+  $('select[name="category_id"],select[name="type_id"]').prop('required', false);
   $('#propertyForm').on('submit', function(e){
     e.preventDefault();
     var category = $('select[name="category_id"]').val();


### PR DESCRIPTION
## Summary
- Prevent Choices.js from marking hidden category/type selects as required

## Testing
- `php -l admin/system-properties/edit.php admin/system-properties/index.php admin/system-properties/version-history.php admin/api/system-properties.php`


------
https://chatgpt.com/codex/tasks/task_e_689e73191d4083338b5bf0e078c804c6