### PR TITLE
Add foreign key constraints for lookup lists

### DIFF
--- a/_SQL/atlis.sql
+++ b/_SQL/atlis.sql
@@ -1262,6 +1262,29 @@ ALTER TABLE `users_2fa`
 --
 
 --
+-- Constraints for table `lookup_lists`
+--
+ALTER TABLE `lookup_lists`
+  ADD CONSTRAINT `fk_module_lookup_lists_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  ADD CONSTRAINT `fk_module_lookup_lists_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`) ON DELETE SET NULL;
+
+--
+-- Constraints for table `lookup_list_items`
+--
+ALTER TABLE `lookup_list_items`
+  ADD CONSTRAINT `fk_module_lookup_list_items_list_id` FOREIGN KEY (`list_id`) REFERENCES `lookup_lists` (`id`) ON DELETE CASCADE,
+  ADD CONSTRAINT `fk_module_lookup_list_items_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  ADD CONSTRAINT `fk_module_lookup_list_items_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`) ON DELETE SET NULL;
+
+--
+-- Constraints for table `lookup_list_item_attributes`
+--
+ALTER TABLE `lookup_list_item_attributes`
+  ADD CONSTRAINT `fk_module_lookup_item_attributes_item_id` FOREIGN KEY (`item_id`) REFERENCES `lookup_list_items` (`id`) ON DELETE CASCADE,
+  ADD CONSTRAINT `fk_module_lookup_item_attributes_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  ADD CONSTRAINT `fk_module_lookup_item_attributes_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`) ON DELETE SET NULL;
+
+--
 -- Constraints for table `module_division`
 --
 ALTER TABLE `module_division`

--- a/admin/api/lookup-lists.php
+++ b/admin/api/lookup-lists.php
@@ -84,12 +84,6 @@ function handleList($action){
   }elseif($action==='delete'){
     $id=(int)($_POST['id']??0);
     if($id<=0){ echo json_encode(['success'=>false,'error'=>'Invalid ID']); return; }
-    $stmt=$pdo->prepare('SELECT COUNT(*) FROM lookup_list_items WHERE list_id=:id');
-    $stmt->execute([':id'=>$id]);
-    if($stmt->fetchColumn()>0){
-      echo json_encode(['success'=>false,'error'=>'Remove items before deleting this list']);
-      return;
-    }
     try{
       $pdo->prepare('DELETE FROM lookup_lists WHERE id=:id')->execute([':id'=>$id]);
       audit_log($pdo,$this_user_id,'lookup_lists',$id,'DELETE','Deleted lookup list');
@@ -177,15 +171,6 @@ function handleItem($action){
   }elseif($action==='delete'){
     $id=(int)($_POST['id']??0);
     if($id<=0){ echo json_encode(['success'=>false,'error'=>'Invalid ID']); return; }
-    $tables=['module_agency','module_division','module_organization','users'];
-    foreach($tables as $tbl){
-      $stmt=$pdo->prepare("SELECT COUNT(*) FROM {$tbl} WHERE status=:id");
-      $stmt->execute([':id'=>$id]);
-      if($stmt->fetchColumn()>0){
-        echo json_encode(['success'=>false,'error'=>'Item is referenced in '.$tbl]);
-        return;
-      }
-    }
     try{
       $pdo->prepare('DELETE FROM lookup_list_items WHERE id=:id')->execute([':id'=>$id]);
       audit_log($pdo,$this_user_id,'lookup_list_items',$id,'DELETE','Deleted lookup list item');


### PR DESCRIPTION
## Summary
- enforce lookup list relationships with cascading foreign keys and user references
- simplify lookup list API by trusting database constraints for deletions

## Testing
- `php -l admin/api/lookup-lists.php`


------
https://chatgpt.com/codex/tasks/task_e_689e9cbeefd8833394eaa0020293ded8