### PR TITLE
Enforce unique lookup list item codes

### DIFF
--- a/_SQL/atlis.sql
+++ b/_SQL/atlis.sql
@@ -950,7 +950,9 @@ ALTER TABLE `lookup_list_items`
   ADD KEY `fk_module_lookup_list_items_list_id` (`list_id`),
   ADD KEY `fk_module_lookup_list_items_user_id` (`user_id`),
   ADD KEY `fk_module_lookup_list_items_user_updated` (`user_updated`),
-  ADD KEY `idx_module_lookup_list_items_label` (`label`);
+  ADD KEY `idx_module_lookup_list_items_label` (`label`),
+  ADD UNIQUE KEY `uq_lookup_list_items_label` (`list_id`,`label`),
+  ADD UNIQUE KEY `uq_lookup_list_items_code` (`list_id`,`code`);
 
 --
 -- Indexes for table `lookup_list_item_attributes`

--- a/admin/api/lookup-lists.php
+++ b/admin/api/lookup-lists.php
@@ -124,11 +124,17 @@ function handleItem($action){
     if($active_to==='' || $active_to==='0000-00-00'){
        $active_to=null;
      }
-    if($list_id<=0||$label===''){ echo json_encode(['success'=>false,'error'=>'Invalid data']); return; }
+    if($list_id<=0||$label===''||$code===''){ echo json_encode(['success'=>false,'error'=>'Invalid data']); return; }
     $stmt=$pdo->prepare('SELECT id FROM lookup_list_items WHERE list_id=:list_id AND label=:label');
     $stmt->execute([':list_id'=>$list_id,':label'=>$label]);
     if($stmt->fetch()){
       echo json_encode(['success'=>false,'error'=>'Label already exists']);
+      return;
+    }
+    $stmt=$pdo->prepare('SELECT id FROM lookup_list_items WHERE list_id=:list_id AND code=:code');
+    $stmt->execute([':list_id'=>$list_id,':code'=>$code]);
+    if($stmt->fetch()){
+      echo json_encode(['success'=>false,'error'=>'Code already exists']);
       return;
     }
     try{
@@ -139,7 +145,7 @@ function handleItem($action){
       echo json_encode(['success'=>true,'message'=>'Item created','item'=>['id'=>$id,'label'=>$label,'code'=>$code,'active_from'=>$active_from,'active_to'=>$active_to]]);
     }catch(PDOException $e){
       if($e->getCode()==='23000'){
-        echo json_encode(['success'=>false,'error'=>'Label already exists']);
+        echo json_encode(['success'=>false,'error'=>'Label or code already exists']);
       }else{
         echo json_encode(['success'=>false,'error'=>'Database error']);
       }
@@ -151,7 +157,7 @@ function handleItem($action){
     $active_from=$_POST['active_from']??date('Y-m-d');
     $active_to=$_POST['active_to']??null;
     if($active_to===''){ $active_to=null; }
-    if($id<=0||$label===''){ echo json_encode(['success'=>false,'error'=>'Invalid data']); return; }
+    if($id<=0||$label===''||$code===''){ echo json_encode(['success'=>false,'error'=>'Invalid data']); return; }
     $stmt=$pdo->prepare('SELECT list_id FROM lookup_list_items WHERE id=:id');
     $stmt->execute([':id'=>$id]);
     $list_id=$stmt->fetchColumn();
@@ -162,6 +168,12 @@ function handleItem($action){
       echo json_encode(['success'=>false,'error'=>'Label already exists']);
       return;
     }
+    $stmt=$pdo->prepare('SELECT id FROM lookup_list_items WHERE list_id=:list_id AND code=:code AND id<>:id');
+    $stmt->execute([':list_id'=>$list_id,':code'=>$code,':id'=>$id]);
+    if($stmt->fetch()){
+      echo json_encode(['success'=>false,'error'=>'Code already exists']);
+      return;
+    }
     try{
       $stmt=$pdo->prepare('UPDATE lookup_list_items SET label=:label,code=:code,active_from=:active_from,active_to=:active_to,user_updated=:uid WHERE id=:id');
       $stmt->execute([':label'=>$label,':code'=>$code,':active_from'=>$active_from,':active_to'=>$active_to,':uid'=>$this_user_id,':id'=>$id]);
@@ -169,7 +181,7 @@ function handleItem($action){
       echo json_encode(['success'=>true,'message'=>'Item updated','item'=>['id'=>$id,'label'=>$label,'code'=>$code,'active_from'=>$active_from,'active_to'=>$active_to]]);
     }catch(PDOException $e){
       if($e->getCode()==='23000'){
-        echo json_encode(['success'=>false,'error'=>'Label already exists']);
+        echo json_encode(['success'=>false,'error'=>'Label or code already exists']);
       }else{
         echo json_encode(['success'=>false,'error'=>'Database error']);
       }

--- a/admin/lookup-lists/items.php
+++ b/admin/lookup-lists/items.php
@@ -30,7 +30,23 @@ if($_SERVER['REQUEST_METHOD']==='POST'){
     if($active_to==='' || $active_to==='0000-00-00'){
       $active_to=null;
     }
-    if($label===''){$error='Label is required.';}
+    if($code===''){
+      $error='Code is required.';
+    }elseif($label===''){
+      $error='Label is required.';
+    }
+    if(!$error){
+      if($item_id){
+        $stmt=$pdo->prepare('SELECT id FROM lookup_list_items WHERE list_id=:list_id AND (label=:label OR code=:code) AND id<>:id');
+        $stmt->execute([':list_id'=>$list_id,':label'=>$label,':code'=>$code,':id'=>$item_id]);
+      }else{
+        $stmt=$pdo->prepare('SELECT id FROM lookup_list_items WHERE list_id=:list_id AND (label=:label OR code=:code)');
+        $stmt->execute([':list_id'=>$list_id,':label'=>$label,':code'=>$code]);
+      }
+      if($stmt->fetch()){
+        $error='Label or code already exists.';
+      }
+    }
     if(!$error){
       if($item_id){
         $stmt=$pdo->prepare('UPDATE lookup_list_items SET label=:label, code=:code, active_from=:active_from, active_to=:active_to, user_updated=:uid WHERE id=:id');
@@ -67,10 +83,10 @@ $items=$stmt->fetchAll(PDO::FETCH_ASSOC);
 <form method="post" class="row g-2 mb-3">
   <input type="hidden" name="csrf_token" value="<?= $token; ?>">
   <input type="hidden" name="id" value="<?= h($_POST['id'] ?? ''); ?>">
-  <div class="col-md-2"><input class="form-control" name="code" placeholder="Code" required></div>
-  <div class="col-md-3"><input class="form-control" name="label" placeholder="Label" required></div>
+  <div class="col-md-2"><input class="form-control" name="code" placeholder="Code" value="<?= h($_POST['code'] ?? ''); ?>" required></div>
+  <div class="col-md-3"><input class="form-control" name="label" placeholder="Label" value="<?= h($_POST['label'] ?? ''); ?>" required></div>
   <div class="col-md-2"><input class="form-control" type="date" name="active_from" value="<?= h($_POST['active_from'] ?? date('Y-m-d')); ?>" required></div>
-  <div class="col-md-2"><input class="form-control" type="date" name="active_to"></div>
+  <div class="col-md-2"><input class="form-control" type="date" name="active_to" value="<?= h($_POST['active_to'] ?? ''); ?>"></div>
   <div class="col-md-2"><button class="btn btn-success w-100" type="submit" id="saveBtn">Save</button></div>
 </form>
 <div id="items" data-list='{"valueNames":["code","label"],"page":25,"pagination":true}'>


### PR DESCRIPTION
## Summary
- add unique indexes on lookup list item label and code
- require unique non-empty code in API for creating/updating lookup list items
- validate and require code field in admin item form

## Testing
- `php -l admin/api/lookup-lists.php`
- `php -l admin/lookup-lists/items.php`


------
https://chatgpt.com/codex/tasks/task_e_689e9cc078b883339927bfc85bf3c908