### PR TITLE
Handle optional agency/division when creating tasks

### DIFF
--- a/module/project/details_view.php
+++ b/module/project/details_view.php
@@ -74,8 +74,12 @@ require '../../includes/html_header.php';
           <form method="post" action="../task/functions/create.php">
             <div class="modal-body">
               <input type="hidden" name="project_id" value="<?php echo (int)$id; ?>">
-              <input type="hidden" name="agency_id" value="<?php echo (int)($project['agency_id'] ?? 0); ?>">
-              <input type="hidden" name="division_id" value="<?php echo (int)($project['division_id'] ?? 0); ?>">
+              <?php if (!empty($project['agency_id'])): ?>
+              <input type="hidden" name="agency_id" value="<?php echo (int)$project['agency_id']; ?>">
+              <?php endif; ?>
+              <?php if (!empty($project['division_id'])): ?>
+              <input type="hidden" name="division_id" value="<?php echo (int)$project['division_id']; ?>">
+              <?php endif; ?>
               <input type="hidden" name="redirect" value="details_view.php?id=<?php echo (int)$id; ?>">
               <div class="mb-3">
                 <label class="form-label">Task Name</label>

--- a/module/task/functions/create.php
+++ b/module/task/functions/create.php
@@ -8,8 +8,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   $priority = $_POST['priority'] ?? null;
   $description = $_POST['description'] ?? null;
   $project_id = $_POST['project_id'] ?? null;
-  $agency_id = $_POST['agency_id'] ?? null;
-  $division_id = $_POST['division_id'] ?? null;
+  $agency_id = $_POST['agency_id'] ?: null;
+  $division_id = $_POST['division_id'] ?: null;
 
   // Default status to BACKLOG if not provided
   if (!$status) {
@@ -22,16 +22,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   }
 
   $stmt = $pdo->prepare('INSERT INTO module_tasks (user_id, user_updated, project_id, agency_id, division_id, name, status, priority, description) VALUES (:uid, :uid, :project_id, :agency_id, :division_id, :name, :status, :priority, :description)');
-  $stmt->execute([
-    ':uid' => $this_user_id,
-    ':project_id' => $project_id,
-    ':agency_id' => $agency_id,
-    ':division_id' => $division_id,
-    ':name' => $name,
-    ':status' => $status,
-    ':priority' => $priority,
-    ':description' => $description
-  ]);
+  $stmt->bindValue(':uid', $this_user_id, PDO::PARAM_INT);
+  $stmt->bindValue(':project_id', $project_id);
+  $stmt->bindValue(':agency_id', $agency_id, $agency_id !== null ? PDO::PARAM_INT : PDO::PARAM_NULL);
+  $stmt->bindValue(':division_id', $division_id, $division_id !== null ? PDO::PARAM_INT : PDO::PARAM_NULL);
+  $stmt->bindValue(':name', $name);
+  $stmt->bindValue(':status', $status);
+  $stmt->bindValue(':priority', $priority);
+  $stmt->bindValue(':description', $description);
+  $stmt->execute();
   $id = $pdo->lastInsertId();
   audit_log($pdo, $this_user_id, 'module_tasks', $id, 'CREATE', 'Created task');
 }


### PR DESCRIPTION
## Summary
- Coerce empty agency and division IDs to null before inserting tasks
- Bind task insert parameters to allow null agency/division IDs
- Only include agency/division fields in project task modal when project has valid IDs

## Testing
- `php -l module/task/functions/create.php`
- `php -l module/project/details_view.php`
- `php -r '$pdo=new PDO("sqlite::memory:");$pdo->exec("CREATE TABLE module_tasks (id INTEGER PRIMARY KEY AUTOINCREMENT,user_id INT,user_updated INT,project_id INT,agency_id INT,division_id INT,name TEXT,status INT,priority INT,description TEXT);");$agency_id=""?:null;$division_id="0"?:null;$stmt=$pdo->prepare("INSERT INTO module_tasks (user_id,user_updated,project_id,agency_id,division_id,name,status,priority,description) VALUES (:uid,:uid,:project_id,:agency_id,:division_id,:name,:status,:priority,:description)");$stmt->bindValue(":uid",1,PDO::PARAM_INT);$stmt->bindValue(":project_id",2);$stmt->bindValue(":agency_id",$agency_id,$agency_id!==null?PDO::PARAM_INT:PDO::PARAM_NULL);$stmt->bindValue(":division_id",$division_id,$division_id!==null?PDO::PARAM_INT:PDO::PARAM_NULL);$stmt->bindValue(":name","Test");$stmt->bindValue(":status",null);$stmt->bindValue(":priority",null);$stmt->bindValue(":description",null);$stmt->execute();$res=$pdo->query("SELECT agency_id,division_id FROM module_tasks")->fetch(PDO::FETCH_ASSOC);var_dump($res);'`


------
https://chatgpt.com/codex/tasks/task_e_689ea06f853c8333841f30bd58116aef