### PR TITLE
Add edit and ID columns to task list view

### DIFF
--- a/module/task/include/list_view.php
+++ b/module/task/include/list_view.php
@@ -5,28 +5,30 @@
   <a href="index.php?action=create" class="btn btn-primary btn-sm">New Task</a>
  </div>
 <div class="table-responsive">
-  <table class="table table-striped">
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Status</th>
-        <th>Priority</th>
-        <th></th>
-      </tr>
-    </thead>
-    <tbody>
-      <?php foreach ($tasks as $task): ?>
+    <table class="table table-striped">
+      <thead>
         <tr>
-          <td><a href="index.php?action=details&amp;id=<?php echo (int)($task['id'] ?? 0); ?>"><?php echo h($task['name'] ?? ''); ?></a></td>
-          <td>
-            <span class="badge badge-phoenix fs-10 badge-phoenix-<?php echo h($task['status_color'] ?? ''); ?>">
-              <span class="badge-label"><?php echo h($task['status_label'] ?? ''); ?></span>
-            </span>
-          </td>
-          <td><?php echo h($task['priority_label'] ?? ''); ?></td>
-          <td><a href="index.php?action=edit&amp;id=<?php echo (int)($task['id'] ?? 0); ?>" class="btn btn-sm btn-link">Edit</a></td>
+          <th>Edit</th>
+          <th>ID</th>
+          <th>Name</th>
+          <th>Status</th>
+          <th>Priority</th>
         </tr>
-      <?php endforeach; ?>
-    </tbody>
-  </table>
+      </thead>
+      <tbody>
+        <?php foreach ($tasks as $task): ?>
+          <tr>
+            <td><a href="index.php?action=edit&amp;id=<?php echo (int)($task['id'] ?? 0); ?>" class="btn btn-warning btn-sm">Edit</a></td>
+            <td><?php echo (int)($task['id'] ?? 0); ?></td>
+            <td><a href="index.php?action=details&amp;id=<?php echo (int)($task['id'] ?? 0); ?>"><?php echo h($task['name'] ?? ''); ?></a></td>
+            <td>
+              <span class="badge badge-phoenix fs-10 badge-phoenix-<?php echo h($task['status_color'] ?? ''); ?>">
+                <span class="badge-label"><?php echo h($task['status_label'] ?? ''); ?></span>
+              </span>
+            </td>
+            <td><?php echo h($task['priority_label'] ?? ''); ?></td>
+          </tr>
+        <?php endforeach; ?>
+      </tbody>
+    </table>
 </div>


### PR DESCRIPTION
## Summary
- Reorder task list columns to show Edit, ID, Name, Status, and Priority
- Display task IDs and move the Edit action to a warning-styled button

## Testing
- `php -l module/task/include/list_view.php`


------
https://chatgpt.com/codex/tasks/task_e_689eb6d71be48333bc6da19891b69d1b