### PR TITLE
Add priority color badges to task list

### DIFF
--- a/module/task/include/list_view.php
+++ b/module/task/include/list_view.php
@@ -23,7 +23,11 @@
               <span class="badge-label"><?php echo h($task['status_label'] ?? ''); ?></span>
             </span>
           </td>
-          <td><?php echo h($task['priority_label'] ?? ''); ?></td>
+          <td>
+            <span class="badge badge-phoenix fs-10 badge-phoenix-<?php echo h($task['priority_color'] ?? ''); ?>">
+              <span class="badge-label"><?php echo h($task['priority_label'] ?? ''); ?></span>
+            </span>
+          </td>
           <td><a href="index.php?action=edit&amp;id=<?php echo (int)($task['id'] ?? 0); ?>" class="btn btn-sm btn-link">Edit</a></td>
         </tr>
       <?php endforeach; ?>

--- a/module/task/index.php
+++ b/module/task/index.php
@@ -85,6 +85,7 @@ foreach ($tasks as &$task) {
   $task['status_color'] = $status['color_class'] ?? 'secondary';
   $priority = $priorityMap[$task['priority']] ?? null;
   $task['priority_label'] = $priority['label'] ?? null;
+  $task['priority_color'] = $priority['color_class'] ?? 'secondary';
 }
 unset($task);
 


### PR DESCRIPTION
## Summary
- Include priority color metadata when listing tasks
- Display priority using Phoenix badge styling in task list

## Testing
- `php -l module/task/index.php`
- `php -l module/task/include/list_view.php`


------
https://chatgpt.com/codex/tasks/task_e_689eb6d5fcac83338e2be0d0efa00fb5