### PR TITLE
Add project list view with task progress and assignees

### DIFF
--- a/module/project/include/list_view.php
+++ b/module/project/include/list_view.php
@@ -1,0 +1,75 @@
+<?php
+?>
+<nav class="mb-3" aria-label="breadcrumb">
+  <ol class="breadcrumb mb-0">
+    <li class="breadcrumb-item"><a href="#">Projects</a></li>
+    <li class="breadcrumb-item active" aria-current="page">List View</li>
+  </ol>
+</nav>
+<div id="projectSummary" data-list='{"valueNames":["project","assignees","start","deadline","projectprogress","status","action"],"page":6,"pagination":true}'>
+  <div class="row align-items-end justify-content-between pb-4 g-3">
+    <div class="col-auto">
+      <h3>Projects</h3>
+      <p class="text-body-tertiary lh-sm mb-0">Brief summary of all projects</p>
+    </div>
+    <div class="col-12 col-md-auto">
+      <div class="search-box">
+        <form class="position-relative" data-bs-toggle="search">
+          <input class="form-control search-input search" type="search" placeholder="Search projects" aria-label="Search" />
+          <span class="fas fa-search search-box-icon"></span>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div class="table-responsive ms-n1 ps-1 scrollbar">
+    <table class="table fs-9 mb-0 border-top border-translucent">
+      <thead>
+        <tr>
+          <th class="sort white-space-nowrap align-middle ps-0" scope="col" data-sort="project" style="width:30%;">PROJECT NAME</th>
+          <th class="sort align-middle ps-3" scope="col" data-sort="assignees" style="width:10%;">Assignees</th>
+          <th class="sort align-middle ps-3" scope="col" data-sort="start" style="width:10%;">START DATE</th>
+          <th class="sort align-middle ps-3" scope="col" data-sort="deadline" style="width:15%;">DEADLINE</th>
+          <th class="sort align-middle ps-3" scope="col" data-sort="projectprogress" style="width:5%;">PROGRESS</th>
+          <th class="align-middle ps-8" scope="col" data-sort="status" style="width:10%;">STATUS</th>
+          <th class="sort align-middle text-end" scope="col" style="width:10%;"></th>
+        </tr>
+      </thead>
+      <tbody class="list" id="project-summary-table-body">
+        <?php foreach ($projects as $project): ?>
+        <tr class="position-static">
+          <td class="align-middle time white-space-nowrap ps-0 project"><a class="fw-bold fs-8" href="index.php?action=details&id=<?php echo $project['id']; ?>"><?php echo h($project['name']); ?></a></td>
+          <td class="align-middle white-space-nowrap assignees ps-3">
+            <div class="avatar-group avatar-group-dense">
+              <?php foreach ($project['assignees'] as $assignee): ?>
+                <?php $pic = !empty($assignee['profile_pic']) ? '../users/uploads/' . $assignee['profile_pic'] : '../../assets/img/team/avatar.webp'; ?>
+                <div class="avatar avatar-s rounded-circle">
+                  <img class="rounded-circle" src="<?php echo h($pic); ?>" alt="<?php echo h($assignee['name']); ?>" />
+                </div>
+              <?php endforeach; ?>
+            </div>
+          </td>
+          <td class="align-middle ps-3 start"><?php echo h($project['start_date']); ?></td>
+          <td class="align-middle ps-3 deadline"><?php echo h($project['complete_date']); ?></td>
+          <td class="align-middle ps-3 projectprogress"><?php echo h($project['in_progress']) . '/' . h($project['total_tasks']); ?></td>
+          <td class="align-middle ps-8 status"><span class="badge badge-phoenix fs-10 badge-phoenix-<?php echo h($project['status_color']); ?>"><?php echo h($project['status_label']); ?></span></td>
+          <td class="align-middle text-end">
+            <div class="btn-reveal-trigger position-static">
+              <a class="btn btn-sm dropdown-toggle dropdown-caret-none transition-none btn-reveal fs-10" href="index.php?action=details&id=<?php echo $project['id']; ?>"><span class="fas fa-chevron-right fs-10"></span></a>
+            </div>
+          </td>
+        </tr>
+        <?php endforeach; ?>
+      </tbody>
+    </table>
+  </div>
+  <div class="row align-items-center justify-content-between py-2 pe-0 fs-9">
+    <div class="col-auto d-flex">
+      <p class="mb-0 d-none d-sm-block me-3 fw-semibold text-body" data-list-info="data-list-info"></p><a class="fw-semibold" href="#!" data-list-view="*">View all<span class="fas fa-angle-right ms-1" data-fa-transform="down-1"></span></a><a class="fw-semibold d-none" href="#!" data-list-view="less">View Less<span class="fas fa-angle-right ms-1" data-fa-transform="down-1"></span></a>
+    </div>
+    <div class="col-auto d-flex">
+      <button class="page-link" data-list-pagination="prev"><span class="fas fa-chevron-left"></span></button>
+      <ul class="mb-0 pagination"></ul>
+      <button class="page-link pe-0" data-list-pagination="next"><span class="fas fa-chevron-right"></span></button>
+    </div>
+  </div>
+</div>

--- a/module/project/index.php
+++ b/module/project/index.php
@@ -1,7 +1,7 @@
 <?php
 require '../../includes/php_header.php';
 
-$action = $_GET['action'] ?? 'card';
+$action = $_GET['action'] ?? 'list';
 
 if ($action === 'create' && $_SERVER['REQUEST_METHOD'] === 'POST') {
   require 'functions/create.php';
@@ -30,13 +30,27 @@ if ($action === 'create') {
 
 require_permission('project','read');
 
-$statusMap = array_column(get_lookup_items($pdo, 'PROJECT_STATUS'), null, 'id');
-$stmt = $pdo->query('SELECT id, name, status FROM module_projects ORDER BY name');
-$projects = $stmt->fetchAll(PDO::FETCH_ASSOC);
+$sql = "SELECT p.id, p.name, p.description, p.start_date, p.complete_date,
+               li.label AS status_label,
+               COALESCE(attr.attr_value, 'secondary') AS status_color,
+               (SELECT COUNT(*) FROM module_tasks t WHERE t.project_id = p.id) AS total_tasks,
+               (SELECT COUNT(*) FROM module_tasks t WHERE t.project_id = p.id AND t.completed = 0) AS in_progress
+        FROM module_projects p
+        LEFT JOIN lookup_list_items li ON p.status = li.id
+        LEFT JOIN lookup_list_item_attributes attr ON li.id = attr.item_id AND attr.attr_code = 'COLOR-CLASS'
+        ORDER BY p.name";
+$projects = $pdo->query($sql)->fetchAll(PDO::FETCH_ASSOC);
+
+$assignStmt = $pdo->query("SELECT pa.project_id, u.profile_pic, CONCAT(per.first_name, ' ', per.last_name) AS name
+                           FROM module_projects_assignments pa
+                           LEFT JOIN users u ON pa.user_id = u.id
+                           LEFT JOIN person per ON u.id = per.user_id");
+$assignments = [];
+foreach ($assignStmt as $row) {
+  $assignments[$row['project_id']][] = $row;
+}
 foreach ($projects as &$project) {
-  $status = $statusMap[$project['status']] ?? null;
-  $project['status_label'] = $status['label'] ?? null;
-  $project['status_color'] = $status['color_class'] ?? 'secondary';
+  $project['assignees'] = $assignments[$project['id']] ?? [];
 }
 unset($project);
 


### PR DESCRIPTION
## Summary
- Default project module to list view instead of cards
- Add task counts, status data, and assignee avatars for projects
- Implement Phoenix-styled list table for projects with pagination

## Testing
- `php -l module/project/index.php`
- `php -l module/project/include/list_view.php`


------
https://chatgpt.com/codex/tasks/task_e_689eccd5d3788333819bf2e67021815f