### PR TITLE
Add task completion endpoint and client-side interaction

### DIFF
--- a/module/task/functions/complete.php
+++ b/module/task/functions/complete.php
@@ -1,0 +1,21 @@
+<?php
+require '../../../includes/php_header.php';
+require_permission('task','update');
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  $id = (int)($_POST['id'] ?? 0);
+  if ($id > 0) {
+    $stmt = $pdo->prepare('UPDATE module_tasks SET completed = 1, complete_date = NOW(), progress_percent = 100, user_updated = :uid WHERE id = :id');
+    $stmt->execute([
+      ':uid' => $this_user_id,
+      ':id' => $id
+    ]);
+    audit_log($pdo, $this_user_id, 'module_tasks', $id, 'UPDATE', 'Completed task');
+    echo json_encode(['success' => true]);
+    exit;
+  }
+}
+
+echo json_encode(['success' => false]);

--- a/module/task/include/list_view.php
+++ b/module/task/include/list_view.php
@@ -28,7 +28,7 @@
         <div class="col-12 col-md-auto flex-1">
           <div>
             <div class="form-check mb-1 mb-md-0 d-flex align-items-center lh-1">
-              <input class="form-check-input flex-shrink-0 form-check-line-through mt-0 me-2" type="checkbox" id="checkbox-todo-<?php echo (int)($task['id'] ?? 0); ?>" data-event-propagation-prevent="data-event-propagation-prevent" />
+              <input class="form-check-input flex-shrink-0 form-check-line-through mt-0 me-2" type="checkbox" id="checkbox-todo-<?php echo (int)($task['id'] ?? 0); ?>" data-task-id="<?php echo (int)($task['id'] ?? 0); ?>" data-event-propagation-prevent="data-event-propagation-prevent" />
               <label class="form-check-label mb-0 fs-8 me-2 line-clamp-1 flex-grow-1 flex-md-grow-0 cursor-pointer" for="checkbox-todo-<?php echo (int)($task['id'] ?? 0); ?>"><?php echo h($task['name'] ?? ''); ?></label>
               <span class="badge badge-phoenix fs-10 badge-phoenix-<?php echo h($task['priority_color'] ?? 'primary'); ?>"><?php echo h($task['priority_label'] ?? ''); ?></span>
             </div>
@@ -60,3 +60,28 @@
   </div>
 
 </div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+  document.querySelectorAll('.todo-list input[type="checkbox"][data-task-id]').forEach(function (checkbox) {
+    checkbox.addEventListener('change', function () {
+      const taskId = this.dataset.taskId;
+      if (!this.checked) { return; }
+      fetch('functions/complete.php', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({ id: taskId })
+      }).then(response => response.json())
+        .then(data => {
+          if (data.success) {
+            this.disabled = true;
+          } else {
+            this.checked = false;
+          }
+        }).catch(() => {
+          this.checked = false;
+        });
+    });
+  });
+});
+</script>


### PR DESCRIPTION
## Summary
- Implement endpoint to mark a task complete and log the action
- Add data attributes and JavaScript to post completion and disable the checkbox

## Testing
- `php -l module/task/functions/complete.php`
- `php -l module/task/include/list_view.php`


------
https://chatgpt.com/codex/tasks/task_e_689ecd8825008333b7dea62376680e25