### PR TITLE
Streamline project details view team management

### DIFF
--- a/module/project/include/details_view.php
+++ b/module/project/include/details_view.php
@@ -112,53 +112,9 @@ if (!empty($current_project)) {
           </div>
           <div class="echart-completed-task-chart" style="min-height:200px;width:100%"></div>
         </div>
-        <div class="col-12 col-sm-5 col-lg-4 col-xl-3 col-xxl-4">
-          <div class="mb-5">
-            <h4 class="text-body-emphasis">Work loads</h4>
-            <h6 class="text-body-tertiary">Last 7 days</h6>
-          </div>
-          <div class="echart-top-coupons mb-5" style="height:115px;width:100%;"></div>
-          <div class="row justify-content-center">
-            <div class="col-auto col-sm-12">
-              <div class="row justify-content-center justify-content-sm-between g-5 g-sm-0 mb-2">
-                <div class="col">
-                  <div class="d-flex align-items-center">
-                    <div class="bullet-item me-2 bg-primary"></div>
-                    <h6 class="text-body fw-semibold flex-1 mb-0">Shantinan Mekalan</h6>
-                  </div>
-                </div>
-                <div class="col-auto">
-                  <h6 class="text-body fw-semibold mb-0">72%</h6>
-                </div>
-              </div>
-              <div class="row justify-content-center justify-content-sm-between g-5 g-sm-0 mb-2">
-                <div class="col">
-                  <div class="d-flex align-items-center">
-                    <div class="bullet-item me-2 bg-primary-lighter"></div>
-                    <h6 class="text-body fw-semibold flex-1 mb-0">Makena Zikonn</h6>
-                  </div>
-                </div>
-                <div class="col-auto">
-                  <h6 class="text-body fw-semibold mb-0">18%</h6>
-                </div>
-              </div>
-              <div class="row justify-content-center justify-content-sm-between g-5 g-sm-0 mb-2">
-                <div class="col">
-                  <div class="d-flex align-items-center">
-                    <div class="bullet-item me-2 bg-info"></div>
-                    <h6 class="text-body fw-semibold flex-1 mb-0">Meena Kumari</h6>
-                  </div>
-                </div>
-                <div class="col-auto">
-                  <h6 class="text-body fw-semibold mb-0">10%</h6>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-          <div class="col-12 col-sm-7 col-lg-8 col-xl-5">
-          <div class="d-flex justify-content-between align-items-center mb-4">
-            <h4 class="text-body-emphasis mb-0">Team members</h4>
+        <div class="col-12 col-lg-8 col-xl-5">
+          <div class="d-flex align-items-center mb-4">
+            <h4 class="text-body-emphasis mb-0 me-2">Team members</h4>
             <button class="btn btn-sm btn-outline-atlis" type="button" data-bs-toggle="modal" data-bs-target="#assignUserModal">+</button>
           </div>
           <?php if (!empty($assignedUsers)): ?>
@@ -171,10 +127,10 @@ if (!empty($current_project)) {
                   <div class="flex-grow-1">
                     <h6 class="mb-0"><?= h($au['name']) ?></h6>
                   </div>
-                  <form method="post" action="functions/remove_user.php" class="ms-2">
+                  <form method="post" action="functions/remove_user.php" class="ms-2" onclick="return confirm('Remove this user?')">
                     <input type="hidden" name="project_id" value="<?= (int)$current_project['id'] ?>">
                     <input type="hidden" name="user_id" value="<?= (int)$au['user_id'] ?>">
-                    <button class="btn btn-link p-0 text-decoration-none text-danger" type="submit">Unassign</button>
+                    <button class="btn btn-link p-0 text-decoration-none text-danger" type="submit"><span class="fa-solid fa-minus"></span></button>
                   </form>
                 </li>
               <?php endforeach; ?>
@@ -204,8 +160,6 @@ if (!empty($current_project)) {
               </form>
             </div>
           </div>
-
-          <h4 class="text-body-emphasis mb-4">Tags</h4><span class="badge badge-tag me-2 mb-1">Unused_brain</span><span class="badge badge-tag me-2 mb-1">Machine</span><span class="badge badge-tag me-2 mb-1">Coding</span>
         </div>
       </div>
       <h3 class="text-body-emphasis mb-4">Project overview</h3>


### PR DESCRIPTION
## Summary
- Align "Team members" header with add button using a shared flex container.
- Replace text-based unassign link with minus icon and confirmation dialog.
- Remove unused demo "Work loads" chart and "Tags" section from project details.

## Testing
- `php -l module/project/include/details_view.php`


------
https://chatgpt.com/codex/tasks/task_e_689ed41519ec8333b6de986026315ccc