### PR TITLE
Fix project assignments and task progress metrics

### DIFF
--- a/module/project/include/card_view.php
+++ b/module/project/include/card_view.php
@@ -60,12 +60,12 @@ foreach ($projects as $proj) {
         <?php endif; ?>
         <?php if (!empty($project['start_date'])): ?>
         <div class="d-flex align-items-center mt-4">
-          <p class="mb-0 fw-bold fs-9">Started :<span class="fw-semibold text-body-tertiary text-opactity-85 ms-1"><?php echo h($project['start_date']); ?></span></p>
+          <p class="mb-0 fw-bold fs-9">Started :<span class="fw-semibold text-body-tertiary text-opactity-85 ms-1"><?php echo h(date('F jS, Y', strtotime($project['start_date']))); ?></span></p>
         </div>
         <?php endif; ?>
         <?php if (!empty($project['complete_date'])): ?>
         <div class="d-flex align-items-center mt-2">
-          <p class="mb-0 fw-bold fs-9">Deadline : <span class="fw-semibold text-body-tertiary text-opactity-85 ms-1"><?php echo h($project['complete_date']); ?></span></p>
+          <p class="mb-0 fw-bold fs-9">Deadline : <span class="fw-semibold text-body-tertiary text-opactity-85 ms-1"><?php echo h(date('F jS, Y', strtotime($project['complete_date']))); ?></span></p>
         </div>
         <?php endif; ?>
         <a class="stretched-link" href="index.php?action=details&id=<?php echo $project['id']; ?>"></a>

--- a/module/project/include/list_view.php
+++ b/module/project/include/list_view.php
@@ -48,9 +48,9 @@
               <?php endforeach; ?>
             </div>
           </td>
-          <td class="align-middle ps-3 start"><?php echo h($project['start_date']); ?></td>
-          <td class="align-middle ps-3 deadline"><?php echo h($project['complete_date']); ?></td>
-          <td class="align-middle ps-3 projectprogress"><?php echo h($project['in_progress']) . '/' . h($project['total_tasks']); ?></td>
+          <td class="align-middle ps-3 start"><?php echo !empty($project['start_date']) ? h(date('F jS, Y', strtotime($project['start_date']))) : ''; ?></td>
+          <td class="align-middle ps-3 deadline"><?php echo !empty($project['complete_date']) ? h(date('F jS, Y', strtotime($project['complete_date']))) : ''; ?></td>
+          <td class="align-middle ps-3 projectprogress"><?php echo h($project['completed_tasks']) . '/' . h($project['total_tasks']); ?></td>
           <td class="align-middle ps-8 status"><span class="badge badge-phoenix fs-10 badge-phoenix-<?php echo h($project['status_color']); ?>"><?php echo h($project['status_label']); ?></span></td>
           <td class="align-middle text-end">
             <div class="btn-reveal-trigger position-static">

--- a/module/project/index.php
+++ b/module/project/index.php
@@ -34,16 +34,16 @@ $sql = "SELECT p.id, p.name, p.description, p.start_date, p.complete_date,
                li.label AS status_label,
                COALESCE(attr.attr_value, 'secondary') AS status_color,
                (SELECT COUNT(*) FROM module_tasks t WHERE t.project_id = p.id) AS total_tasks,
-               (SELECT COUNT(*) FROM module_tasks t WHERE t.project_id = p.id AND t.completed = 0) AS in_progress
+               (SELECT COUNT(*) FROM module_tasks t WHERE t.project_id = p.id AND t.completed = 1) AS completed_tasks
         FROM module_projects p
         LEFT JOIN lookup_list_items li ON p.status = li.id
         LEFT JOIN lookup_list_item_attributes attr ON li.id = attr.item_id AND attr.attr_code = 'COLOR-CLASS'
         ORDER BY p.name";
 $projects = $pdo->query($sql)->fetchAll(PDO::FETCH_ASSOC);
 
-$assignStmt = $pdo->query("SELECT pa.project_id, u.profile_pic, CONCAT(per.first_name, ' ', per.last_name) AS name
+$assignStmt = $pdo->query("SELECT pa.project_id, pa.assigned_user_id, u.profile_pic, CONCAT(per.first_name, ' ', per.last_name) AS name
                            FROM module_projects_assignments pa
-                           LEFT JOIN users u ON pa.user_id = u.id
+                           LEFT JOIN users u ON pa.assigned_user_id = u.id
                            LEFT JOIN person per ON u.id = per.user_id");
 $assignments = [];
 foreach ($assignStmt as $row) {


### PR DESCRIPTION
## Summary
- count completed project tasks and use in progress display
- show each project's assignees using assigned_user_id
- format project dates for readability

## Testing
- `php -l module/project/index.php`
- `php -l module/project/include/list_view.php`
- `php -l module/project/include/card_view.php`


------
https://chatgpt.com/codex/tasks/task_e_689ed412aeac8333a329b6d9817cc14e