### PR TITLE
Enable task completion toggling via new endpoint

### DIFF
--- a/module/task/functions/toggle_complete.php
+++ b/module/task/functions/toggle_complete.php
@@ -1,0 +1,26 @@
+<?php
+require '../../../includes/php_header.php';
+require_permission('task','update');
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  $id = (int)($_POST['id'] ?? 0);
+  $completed = isset($_POST['completed']) ? (int)$_POST['completed'] : 0;
+  if ($id > 0) {
+    if ($completed === 1) {
+      $stmt = $pdo->prepare('UPDATE module_tasks SET completed = 1, complete_date = NOW(), progress_percent = 100, user_updated = :uid WHERE id = :id');
+    } else {
+      $stmt = $pdo->prepare('UPDATE module_tasks SET completed = 0, complete_date = NULL, progress_percent = 0, user_updated = :uid WHERE id = :id');
+    }
+    $stmt->execute([
+      ':uid' => $this_user_id,
+      ':id' => $id
+    ]);
+    audit_log($pdo, $this_user_id, 'module_tasks', $id, 'UPDATE', $completed ? 'Completed task' : 'Marked task incomplete');
+    echo json_encode(['success' => true, 'completed' => $completed]);
+    exit;
+  }
+}
+
+echo json_encode(['success' => false]);

--- a/module/task/include/list_view.php
+++ b/module/task/include/list_view.php
@@ -28,7 +28,7 @@
         <div class="col-12 col-md-auto flex-1 position-relative" style="z-index:1;">
           <div>
             <div class="form-check mb-1 mb-md-0 d-flex align-items-center lh-1 position-relative" style="z-index:1;">
-              <input class="form-check-input flex-shrink-0 form-check-line-through mt-0 me-2" type="checkbox" id="checkbox-todo-<?php echo (int)($task['id'] ?? 0); ?>" data-event-propagation-prevent="data-event-propagation-prevent" />
+              <input class="form-check-input flex-shrink-0 form-check-line-through mt-0 me-2" type="checkbox" id="checkbox-todo-<?php echo (int)($task['id'] ?? 0); ?>" data-event-propagation-prevent="data-event-propagation-prevent" data-task-id="<?php echo (int)($task['id'] ?? 0); ?>" <?php echo (!empty($task['completed']) ? 'checked' : ''); ?> />
               <label class="form-check-label mb-0 fs-8 me-2 line-clamp-1 flex-grow-1 flex-md-grow-0 cursor-pointer" for="checkbox-todo-<?php echo (int)($task['id'] ?? 0); ?>"><?php echo h($task['name'] ?? ''); ?></label>
               <span class="badge badge-phoenix fs-10 badge-phoenix-<?php echo h($task['priority_color'] ?? 'primary'); ?>"><?php echo h($task['priority_label'] ?? ''); ?></span>
             </div>
@@ -54,22 +54,25 @@
 <script>
 document.addEventListener('DOMContentLoaded', function () {
   document.querySelectorAll('.todo-list input[type="checkbox"][data-task-id]').forEach(function (checkbox) {
+    checkbox.addEventListener('click', function (event) {
+      event.stopPropagation();
+    });
     checkbox.addEventListener('change', function () {
       const taskId = this.dataset.taskId;
-      if (!this.checked) { return; }
-      fetch('functions/complete.php', {
+      const newState = this.checked ? 1 : 0;
+      fetch('functions/toggle_complete.php', {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: new URLSearchParams({ id: taskId })
+        body: new URLSearchParams({ id: taskId, completed: newState })
       }).then(response => response.json())
         .then(data => {
           if (data.success) {
-            this.disabled = true;
+            this.checked = data.completed == 1;
           } else {
-            this.checked = false;
+            this.checked = !newState;
           }
         }).catch(() => {
-          this.checked = false;
+          this.checked = !newState;
         });
     });
   });


### PR DESCRIPTION
## Summary
- add task id data attribute and JS handlers to stop propagation and toggle completion
- create `functions/toggle_complete.php` to update task completion state and progress

## Testing
- `php -l module/task/include/list_view.php`
- `php -l module/task/functions/toggle_complete.php`


------
https://chatgpt.com/codex/tasks/task_e_689ed5ca23ac8333a13bbc65ce3d5197