### PR TITLE
Add team member management for tasks

### DIFF
--- a/module/task/functions/assign_user.php
+++ b/module/task/functions/assign_user.php
@@ -1,0 +1,36 @@
+<?php
+require '../../../includes/php_header.php';
+require_permission('task','update');
+
+$task_id = (int)($_POST['task_id'] ?? 0);
+$user_id = (int)($_POST['user_id'] ?? 0);
+
+if ($task_id && $user_id) {
+$stmt = $pdo->prepare('SELECT user_id, project_id FROM module_tasks WHERE id = :id');
+$stmt->execute([':id' => $task_id]);
+$task = $stmt->fetch(PDO::FETCH_ASSOC);
+$owner_id = $task['user_id'] ?? null;
+$project_id = $task['project_id'] ?? null;
+if ($owner_id && ($is_admin || $owner_id == $this_user_id)) {
+  if ($project_id) {
+    $projCheck = $pdo->prepare('SELECT id FROM module_projects_assignments WHERE project_id = :pid AND assigned_user_id = :uid');
+    $projCheck->execute([':pid' => $project_id, ':uid' => $user_id]);
+    if (!$projCheck->fetchColumn()) {
+      header('Location: ../index.php?action=details&id=' . $task_id);
+      exit;
+    }
+  }
+
+  $check = $pdo->prepare('SELECT id FROM module_task_assignments WHERE task_id = :tid AND assigned_user_id = :uid');
+  $check->execute([':tid' => $task_id, ':uid' => $user_id]);
+  if (!$check->fetchColumn()) {
+    $ins = $pdo->prepare('INSERT INTO module_task_assignments (user_id,user_updated,task_id,assigned_user_id) VALUES (:uid,:uid,:tid,:aid)');
+    $ins->execute([':uid' => $this_user_id, ':tid' => $task_id, ':aid' => $user_id]);
+    $assignId = $pdo->lastInsertId();
+    audit_log($pdo, $this_user_id, 'module_task_assignments', $assignId, 'ASSIGN', 'Assigned user');
+  }
+}
+}
+
+header('Location: ../index.php?action=details&id=' . $task_id);
+exit;

--- a/module/task/functions/remove_user.php
+++ b/module/task/functions/remove_user.php
@@ -1,0 +1,25 @@
+<?php
+require '../../../includes/php_header.php';
+require_permission('task','update');
+
+$task_id = (int)($_POST['task_id'] ?? 0);
+$user_id = (int)($_POST['user_id'] ?? 0);
+
+if ($task_id && $user_id) {
+  $stmt = $pdo->prepare('SELECT user_id FROM module_tasks WHERE id = :id');
+  $stmt->execute([':id' => $task_id]);
+  $owner_id = $stmt->fetchColumn();
+  if ($owner_id && ($is_admin || $owner_id == $this_user_id)) {
+    $sel = $pdo->prepare('SELECT id FROM module_task_assignments WHERE task_id = :tid AND assigned_user_id = :uid');
+    $sel->execute([':tid' => $task_id, ':uid' => $user_id]);
+    $assignId = $sel->fetchColumn();
+    if ($assignId) {
+      $del = $pdo->prepare('DELETE FROM module_task_assignments WHERE id = :id');
+      $del->execute([':id' => $assignId]);
+      audit_log($pdo, $this_user_id, 'module_task_assignments', $assignId, 'DELETE', 'Removed user assignment');
+    }
+  }
+}
+
+header('Location: ../index.php?action=details&id=' . $task_id);
+exit;

--- a/module/task/include/details_view.php
+++ b/module/task/include/details_view.php
@@ -1,5 +1,6 @@
 <?php
 // Details view of a single task
+require_once __DIR__ . '/../../../includes/functions.php';
 ?>
 <?php if (!empty($current_task)): ?>
   <div class="card mb-4">
@@ -22,17 +23,54 @@
   <div class="row">
     <div class="col-lg-4">
       <div class="card mb-4">
-        <div class="card-header"><h5 class="mb-0">Assignments</h5></div>
+        <div class="card-header d-flex justify-content-between align-items-center">
+          <h5 class="mb-0">Team members</h5>
+          <button class="btn btn-sm btn-outline-atlis" type="button" data-bs-toggle="modal" data-bs-target="#assignUserModal">Assign User</button>
+        </div>
         <div class="card-body">
-          <?php if (!empty($assignments)): ?>
+          <?php if (!empty($assignedUsers)): ?>
             <ul class="list-unstyled mb-0">
-              <?php foreach ($assignments as $assign): ?>
-                <li class="mb-1"><span class="fas fa-user text-primary"></span> <?php echo h($assign['email']); ?></li>
+              <?php foreach ($assignedUsers as $au): ?>
+                <li class="d-flex align-items-center mb-2">
+                  <div class="avatar avatar-xl me-2">
+                    <img class="rounded-circle" src="<?php echo getURLDir(); ?>module/users/uploads/<?= h($au['profile_pic'] ?? '') ?>" alt="<?= h($au['name']) ?>" />
+                  </div>
+                  <div class="flex-grow-1">
+                    <h6 class="mb-0"><?= h($au['name']) ?></h6>
+                  </div>
+                  <form method="post" action="functions/remove_user.php" class="ms-2" onclick="return confirm('Remove this user?')">
+                    <input type="hidden" name="task_id" value="<?= (int)$current_task['id'] ?>">
+                    <input type="hidden" name="user_id" value="<?= (int)$au['user_id'] ?>">
+                    <button class="btn btn-link p-0 text-decoration-none text-danger" type="submit"><span class="fa-solid fa-minus"></span></button>
+                  </form>
+                </li>
               <?php endforeach; ?>
             </ul>
           <?php else: ?>
-            <p class="mb-0 text-700 small">No assignments</p>
+            <p class="mb-0 text-700 small">No team members assigned.</p>
           <?php endif; ?>
+        </div>
+      </div>
+
+      <div class="modal fade" id="assignUserModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+          <form class="modal-content" method="post" action="functions/assign_user.php">
+            <div class="modal-header">
+              <h5 class="modal-title">Assign User</h5>
+              <button class="btn-close" type="button" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+              <input type="hidden" name="task_id" value="<?= (int)$current_task['id'] ?>">
+              <select class="form-select" name="user_id">
+                <?php foreach ($availableUsers as $au): ?>
+                  <option value="<?= (int)$au['user_id'] ?>"><?= h($au['name']) ?></option>
+                <?php endforeach; ?>
+              </select>
+            </div>
+            <div class="modal-footer">
+              <button class="btn btn-atlis" type="submit">Assign</button>
+            </div>
+          </form>
         </div>
       </div>
 

--- a/module/task/index.php
+++ b/module/task/index.php
@@ -91,14 +91,40 @@ unset($task);
 
 if ($action === 'details') {
   $task_id = (int)($_GET['id'] ?? 0);
-  $stmt = $pdo->prepare('SELECT id, name, description, status, priority FROM module_tasks WHERE id = :id');
+  $stmt = $pdo->prepare('SELECT id, name, description, status, priority, project_id FROM module_tasks WHERE id = :id');
   $stmt->execute([':id' => $task_id]);
   $current_task = $stmt->fetch(PDO::FETCH_ASSOC);
 
+  $availableUsers = [];
   if ($current_task) {
-    $assignStmt = $pdo->prepare('SELECT u.id, u.email FROM module_task_assignments ta JOIN users u ON ta.assigned_user_id = u.id WHERE ta.task_id = :id');
-    $assignStmt->execute([':id' => $task_id]);
-    $assignments = $assignStmt->fetchAll(PDO::FETCH_ASSOC);
+    $assignedStmt = $pdo->prepare('SELECT mta.assigned_user_id AS user_id, u.profile_pic, CONCAT(p.first_name, " ", p.last_name) AS name FROM module_task_assignments mta JOIN users u ON mta.assigned_user_id = u.id LEFT JOIN person p ON u.id = p.user_id WHERE mta.task_id = :id');
+    $assignedStmt->execute([':id' => $task_id]);
+    $assignedUsers = $assignedStmt->fetchAll(PDO::FETCH_ASSOC);
+
+    $assignedIds = array_column($assignedUsers, 'user_id');
+    if (!empty($current_task['project_id'])) {
+      $params = [$current_task['project_id']];
+      $query = "SELECT u.id AS user_id, CONCAT(p.first_name, ' ', p.last_name) AS name FROM module_projects_assignments mpa JOIN users u ON mpa.assigned_user_id = u.id LEFT JOIN person p ON u.id = p.user_id WHERE mpa.project_id = ?";
+      if ($assignedIds) {
+        $placeholders = implode(',', array_fill(0, count($assignedIds), '?'));
+        $query .= " AND u.id NOT IN ($placeholders)";
+        $params = array_merge($params, $assignedIds);
+      }
+      $query .= ' ORDER BY name';
+      $availableStmt = $pdo->prepare($query);
+      $availableStmt->execute($params);
+    } else {
+      if ($assignedIds) {
+        $placeholders = implode(',', array_fill(0, count($assignedIds), '?'));
+        $availableStmt = $pdo->prepare("SELECT u.id AS user_id, CONCAT(p.first_name, ' ', p.last_name) AS name FROM users u LEFT JOIN person p ON u.id = p.user_id WHERE u.id NOT IN ($placeholders) ORDER BY name");
+        $availableStmt->execute($assignedIds);
+      } else {
+        $availableStmt = $pdo->query("SELECT u.id AS user_id, CONCAT(p.first_name, ' ', p.last_name) AS name FROM users u LEFT JOIN person p ON u.id = p.user_id ORDER BY name");
+      }
+    }
+    if (isset($availableStmt)) {
+      $availableUsers = $availableStmt->fetchAll(PDO::FETCH_ASSOC);
+    }
 
     $filesStmt = $pdo->prepare('SELECT id,file_name,file_path,file_size,file_type,date_created FROM module_tasks_files WHERE task_id = :id ORDER BY date_created DESC');
     $filesStmt->execute([':id' => $task_id]);


### PR DESCRIPTION
## Summary
- Allow assigning and removing users from tasks with permission and ownership checks
- Add team member list and assignment modal to task detail view
- Load available users for assigning in task details
- Restrict task user options to parent project's team when applicable and clarify assign button label

## Testing
- `php -l module/task/functions/assign_user.php`
- `php -l module/task/index.php`
- `php -l module/task/include/details_view.php`


------
https://chatgpt.com/codex/tasks/task_e_689ed5c946548333acda809185e41ad6