### PR TITLE
Include completed status in task list query

### DIFF
--- a/module/task/include/list_view.php
+++ b/module/task/include/list_view.php
@@ -30,7 +30,7 @@
             <div class="form-check mb-1 mb-md-0 d-flex align-items-center lh-1 position-relative" style="z-index:1;">
               <input class="form-check-input flex-shrink-0 form-check-line-through mt-0 me-2" type="checkbox" id="checkbox-todo-<?php echo (int)($task['id'] ?? 0); ?>" data-event-propagation-prevent="data-event-propagation-prevent" data-task-id="<?php echo (int)($task['id'] ?? 0); ?>" <?php echo (!empty($task['completed']) ? 'checked' : ''); ?> />
 
-              <label class="form-check-label mb-0 fs-8 me-2 line-clamp-1 flex-grow-1 flex-md-grow-0 cursor-pointer" for="checkbox-todo-<?php echo (int)($task['id'] ?? 0); ?>">
+              <label class="form-check-label mb-0 fs-8 me-2 line-clamp-1 flex-grow-1 flex-md-grow-0 cursor-pointer<?php echo (!empty($task['completed']) ? ' text-decoration-line-through' : ''); ?>" for="checkbox-todo-<?php echo (int)($task['id'] ?? 0); ?>">
                 <a href="index.php?action=details&amp;id=<?php echo (int)($task['id'] ?? 0); ?>" class="task-link text-reset" style="text-decoration:inherit;" data-event-propagation-prevent="data-event-propagation-prevent"><?php echo h($task['name'] ?? ''); ?></a>
               </label>
 
@@ -53,6 +53,7 @@ document.addEventListener('DOMContentLoaded', function () {
     checkbox.addEventListener('change', function () {
       const taskId = this.dataset.taskId;
       const newState = this.checked ? 1 : 0;
+      const label = this.nextElementSibling;
       fetch('functions/toggle_complete.php', {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -64,8 +65,10 @@ document.addEventListener('DOMContentLoaded', function () {
           } else {
             this.checked = !newState;
           }
+          label.classList.toggle('text-decoration-line-through', this.checked);
         }).catch(() => {
           this.checked = !newState;
+          label.classList.toggle('text-decoration-line-through', this.checked);
         });
     });
   });

--- a/module/task/index.php
+++ b/module/task/index.php
@@ -77,7 +77,7 @@ $action = $_GET['action'] ?? 'list';
 $statusMap = array_column(get_lookup_items($pdo, 'TASK_STATUS'), null, 'id');
 $priorityMap = array_column(get_lookup_items($pdo, 'TASK_PRIORITY'), null, 'id');
 
-$stmt = $pdo->query('SELECT id, name, status, priority FROM module_tasks ORDER BY name');
+$stmt = $pdo->query('SELECT id, name, status, priority, completed FROM module_tasks ORDER BY name');
 $tasks = $stmt->fetchAll(PDO::FETCH_ASSOC);
 foreach ($tasks as &$task) {
   $status = $statusMap[$task['status']] ?? null;
@@ -92,6 +92,7 @@ unset($task);
 if ($action === 'details') {
   $task_id = (int)($_GET['id'] ?? 0);
 
+  $stmt = $pdo->prepare(
     'SELECT t.id, t.name, t.description, t.status, t.priority,
             p.name AS project_name,
             d.name AS division_name,


### PR DESCRIPTION
## Summary
- Include `completed` flag in task list query so checkbox state reflects completion
- Add conditional strike-through styling for completed tasks and update JS to toggle it

## Testing
- `php -l module/task/index.php`
- `php -l module/task/include/list_view.php`


------
https://chatgpt.com/codex/tasks/task_e_689edf5ff83c833380c5de008548d5f4