### PR TITLE
Fix task details query and heading

### DIFF
--- a/module/task/include/details_view.php
+++ b/module/task/include/details_view.php
@@ -5,33 +5,30 @@ require_once __DIR__ . '/../../../includes/functions.php';
 <?php if (!empty($current_task)): ?>
   <?php
     $hierarchyParts = array_filter([
-      $project_name ?? null,
-      $division_name ?? null,
-      $agency_name ?? null,
-      $organization_name ?? null
+      $current_task['project_name'] ?? null,
+      $current_task['division_name'] ?? null,
+      $current_task['agency_name'] ?? null,
+      $current_task['organization_name'] ?? null
     ]);
-    $hierarchyString = implode(' / ', array_map('h', $hierarchyParts));
   ?>
-  <div class="card mb-4">
-    <div class="card-body">
-      <h3 class="mb-3">
-        <?php echo h($current_task['name'] ?? ''); ?>
-        <?php if ($hierarchyString !== ''): ?>
-          &ndash; <?php echo $hierarchyString; ?>
-        <?php endif; ?>
-      </h3>
-      <p class="mb-3">
-        <span class="badge badge-phoenix fs-10 badge-phoenix-<?php echo h($statusMap[$current_task['status']]['color_class'] ?? 'secondary'); ?>">
-          <span class="badge-label"><?php echo h($statusMap[$current_task['status']]['label'] ?? ''); ?></span>
-        </span>
-        <span class="badge badge-phoenix fs-10 badge-phoenix-secondary ms-1">
-          <span class="badge-label"><?php echo h($priorityMap[$current_task['priority']]['label'] ?? ''); ?></span>
-        </span>
-      </p>
-      <?php if (!empty($current_task['description'])): ?>
-      <p><?php echo nl2br(h($current_task['description'])); ?></p>
-      <?php endif; ?>
+  <div class="mb-5">
+    <div class="d-flex justify-content-between">
+      <h2 class="text-body-emphasis fw-bolder mb-2"><?php echo h($current_task['name'] ?? ''); ?></h2>
     </div>
+    <?php if ($hierarchyParts): ?>
+      <p class="text-body-secondary mb-0"><?php echo implode(' / ', array_map('h', $hierarchyParts)); ?></p>
+    <?php endif; ?>
+    <p class="mb-3 mt-3">
+      <span class="badge badge-phoenix fs-10 badge-phoenix-<?php echo h($statusMap[$current_task['status']]['color_class'] ?? 'secondary'); ?>">
+        <span class="badge-label"><?php echo h($statusMap[$current_task['status']]['label'] ?? ''); ?></span>
+      </span>
+      <span class="badge badge-phoenix fs-10 badge-phoenix-secondary ms-1">
+        <span class="badge-label"><?php echo h($priorityMap[$current_task['priority']]['label'] ?? ''); ?></span>
+      </span>
+    </p>
+    <?php if (!empty($current_task['description'])): ?>
+    <p><?php echo nl2br(h($current_task['description'])); ?></p>
+    <?php endif; ?>
   </div>
 
   <div class="row">

--- a/module/task/index.php
+++ b/module/task/index.php
@@ -92,7 +92,9 @@ unset($task);
 if ($action === 'details') {
   $task_id = (int)($_GET['id'] ?? 0);
 
+  $stmt = $pdo->prepare(
     'SELECT t.id, t.name, t.description, t.status, t.priority,
+            t.project_id, t.division_id, t.agency_id,
             p.name AS project_name,
             d.name AS division_name,
             a.name AS agency_name,
@@ -147,8 +149,6 @@ if ($action === 'details') {
     $notesStmt = $pdo->prepare('SELECT id,note_text,date_created FROM module_tasks_notes WHERE task_id = :id ORDER BY date_created DESC');
     $notesStmt->execute([':id' => $task_id]);
     $notes = $notesStmt->fetchAll(PDO::FETCH_ASSOC);
-  } else {
-    $project_name = $division_name = $agency_name = $organization_name = null;
   }
 } elseif ($action === 'create-edit' && isset($_GET['id'])) {
   $task_id = (int)($_GET['id'] ?? 0);


### PR DESCRIPTION
## Summary
- use prepared statement to load task details with related names
- render task hierarchy using fetched names in details view

## Testing
- php -l module/task/index.php
- php -l module/task/include/details_view.php

------
https://chatgpt.com/codex/tasks/task_e_689edf6133288333ae101955343ba70f