### PR TITLE
Align task details files and notes with project styling

### DIFF
--- a/module/task/include/details_view.php
+++ b/module/task/include/details_view.php
@@ -87,94 +87,79 @@ require_once __DIR__ . '/../../../includes/functions.php';
         </div>
       </div>
 
-      <div class="card mb-4">
-        <div class="card-header"><h5 class="mb-0">Files</h5></div>
-        <div class="card-body">
+        <div class="px-4 px-lg-6"><h4 class="mb-3">Files</h4></div>
+        <div class="border-top px-4 px-lg-6 py-4">
           <form action="functions/upload_file.php" method="post" enctype="multipart/form-data" class="mb-3">
             <input type="hidden" name="id" value="<?php echo (int)($current_task['id'] ?? 0); ?>">
-            <div class="mb-2"><input class="form-control form-control-sm" type="file" name="file" required></div>
-            <button class="btn btn-sm btn-primary" type="submit">Upload</button>
+            <input class="form-control mb-2" type="file" name="file" required>
+            <button class="btn btn-outline-atlis" type="submit">Upload</button>
           </form>
-          <?php if (!empty($files)): ?>
-            <div class="timeline-vertical mt-3">
-              <?php foreach ($files as $f): ?>
-                <div class="timeline-item position-relative">
-                  <div class="row g-md-3">
-                    <div class="col-12 col-md-auto d-flex">
-                      <div class="timeline-item-date order-1 order-md-0 me-md-4">
-                        <p class="fs-10 fw-semibold text-body-tertiary text-opacity-85 text-end">
-                          <?php echo date('d M, Y', strtotime($f['date_created'])); ?><br class="d-none d-md-block" />
-                          <?php echo date('h:i A', strtotime($f['date_created'])); ?>
-                        </p>
-                      </div>
-                      <div class="timeline-item-bar position-md-relative me-3 me-md-0">
-                        <div class="icon-item icon-item-sm rounded-7 shadow-none bg-primary-subtle">
-                          <span class="fa-solid <?php echo strpos($f['file_type'], 'image/') === 0 ? 'fa-image' : 'fa-file'; ?> text-primary-dark fs-10"></span>
-                        </div>
-                        <span class="timeline-bar border-end border-dashed"></span>
-                      </div>
-                    </div>
-                    <div class="col">
-                      <div class="timeline-item-content ps-6 ps-md-3">
-                        <p class="mb-0"><a href="<? echo getURLDir(); ?><?php echo h($f['file_path']); ?>"><?php echo h($f['file_name']); ?></a></p>
-                        <p class="fs-9 text-body-secondary mb-0">
-                          <?php echo h($f['file_size']); ?>
-                          <span class="text-body-quaternary mx-1">|</span>
-                          <?php echo h($f['file_type']); ?>
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              <?php endforeach; ?>
-            </div>
-          <?php else: ?>
-            <p class="mb-0 text-700 small">No files</p>
-          <?php endif; ?>
         </div>
-      </div>
+        <?php if (!empty($files)): ?>
+          <?php foreach ($files as $f): ?>
+          <div class="border-top px-4 px-lg-6 py-4">
+            <div class="me-n3">
+              <div class="d-flex flex-between-center">
+                <div class="d-flex mb-1"><span class="fa-solid <?php echo strpos($f['file_type'], 'image/') === 0 ? 'fa-image' : 'fa-file'; ?> me-2 text-body-tertiary fs-9"></span>
+                  <p class="text-body-highlight mb-0 lh-1"><a class="text-body-highlight" href="<? echo getURLDir(); ?><?php echo h($f['file_path']); ?>"><?php echo h($f['file_name']); ?></a></p>
+                </div>
+              </div>
+              <div class="d-flex fs-9 text-body-tertiary mb-0 flex-wrap"><span><?php echo h($f['file_size']); ?></span><span class="text-body-quaternary mx-1">| </span><span class="text-nowrap"><?php echo h($f['file_type']); ?></span><span class="text-body-quaternary mx-1">| </span><span class="text-nowrap"><?php echo h($f['date_created']); ?></span></div>
+              <?php if (strpos($f['file_type'], 'image/') === 0): ?>
+                <img class="rounded-2 mt-2" src="<? echo getURLDir(); ?><?php echo h($f['file_path']); ?>" alt="" style="width:320px" />
+              <?php endif; ?>
+            </div>
+          </div>
+          <?php endforeach; ?>
+        <?php else: ?>
+          <div class="border-top px-4 px-lg-6 py-4">
+            <p class="fs-9 text-body-secondary mb-0">No files uploaded.</p>
+          </div>
+        <?php endif; ?>
     </div>
 
     <div class="col-lg-8">
-      <div class="card mb-4">
-        <div class="card-header"><h5 class="mb-0">Notes</h5></div>
-        <div class="card-body">
-          <form action="functions/add_note.php" method="post" class="mb-3">
-            <input type="hidden" name="id" value="<?php echo (int)($current_task['id'] ?? 0); ?>">
-            <div class="mb-2"><textarea class="form-control" name="note" rows="3" required></textarea></div>
-            <button class="btn btn-sm btn-primary" type="submit">Add Note</button>
-          </form>
-          <?php if (!empty($notes)): ?>
-            <div class="timeline-vertical mt-3">
+      <div class="bg-light dark__bg-gray-1100 h-100">
+        <div class="p-4 p-lg-6">
+          <h3 class="text-body-highlight mb-4 fw-bold">Recent activity</h3>
+          <div class="timeline-vertical timeline-with-details">
+            <?php if (!empty($notes)): ?>
               <?php foreach ($notes as $n): ?>
-                <div class="timeline-item position-relative">
-                  <div class="row g-md-3">
-                    <div class="col-12 col-md-auto d-flex">
-                      <div class="timeline-item-date order-1 order-md-0 me-md-4">
-                        <p class="fs-10 fw-semibold text-body-tertiary text-opacity-85 text-end">
-                          <?php echo date('d M, Y', strtotime($n['date_created'])); ?><br class="d-none d-md-block" />
-                          <?php echo date('h:i A', strtotime($n['date_created'])); ?>
-                        </p>
-                      </div>
-                      <div class="timeline-item-bar position-md-relative me-3 me-md-0">
-                        <div class="icon-item icon-item-sm rounded-7 shadow-none bg-success-subtle">
-                          <span class="fa-solid fa-note-sticky text-success fs-10"></span>
-                        </div>
-                        <span class="timeline-bar border-end border-dashed"></span>
-                      </div>
+              <div class="timeline-item position-relative">
+                <div class="row g-md-3">
+                  <div class="col-12 col-md-auto d-flex">
+                    <div class="timeline-item-date order-1 order-md-0 me-md-4">
+                      <p class="fs-10 fw-semibold text-body-tertiary text-opacity-85 text-end">
+                        <?php echo date('d M, Y', strtotime($n['date_created'])); ?><br class="d-none d-md-block" />
+                        <?php echo date('h:i A', strtotime($n['date_created'])); ?>
+                      </p>
                     </div>
-                    <div class="col">
-                      <div class="timeline-item-content ps-6 ps-md-3">
-                        <p class="mb-0"><?php echo nl2br(h($n['note_text'])); ?></p>
-                      </div>
+                    <div class="timeline-item-bar position-md-relative me-3 me-md-0">
+                      <div class="icon-item icon-item-sm rounded-7 shadow-none bg-primary-subtle"><span class="fa-solid fa-note-sticky text-primary-dark fs-10"></span></div><span class="timeline-bar border-end border-dashed"></span>
+                    </div>
+                  </div>
+                  <div class="col">
+                    <div class="timeline-item-content ps-6 ps-md-3">
+                      <p class="fs-9 lh-sm mb-1"><?php echo nl2br(h($n['note_text'])); ?></p>
+                      <p class="fs-9 mb-0">by <a class="fw-semibold" href="#!"><?php echo h($n['user_name'] ?? ''); ?></a></p>
                     </div>
                   </div>
                 </div>
+              </div>
               <?php endforeach; ?>
-            </div>
-          <?php else: ?>
-            <p class="mb-0 text-700 small">No notes</p>
-          <?php endif; ?>
+            <?php else: ?>
+              <p class="fs-9 text-body-secondary mb-0">No notes found.</p>
+            <?php endif; ?>
+          </div>
+          <div class="mt-4">
+            <form action="functions/add_note.php" method="post">
+              <input type="hidden" name="id" value="<?php echo (int)($current_task['id'] ?? 0); ?>">
+              <div class="mb-3">
+                <textarea class="form-control" name="note" rows="3" required></textarea>
+              </div>
+              <button class="btn btn-atlis" type="submit">Add Note</button>
+            </form>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Replace task files card with bordered list including upload form and file details
- Move task notes into a Recent activity timeline and form mirroring project details

## Testing
- `php -l module/task/include/details_view.php`


------
https://chatgpt.com/codex/tasks/task_e_689f5c56d5548333a3a5fcaa4a9d7985