### PR TITLE
Align project management views with Phoenix templates

### DIFF
--- a/module/project/include/card_view.php
+++ b/module/project/include/card_view.php
@@ -68,6 +68,15 @@ foreach ($projects as $proj) {
           <p class="mb-0 fw-bold fs-9">Deadline : <span class="fw-semibold text-body-tertiary text-opactity-85 ms-1"><?php echo h(date('F jS, Y', strtotime($project['complete_date']))); ?></span></p>
         </div>
         <?php endif; ?>
+        <?php if (!empty($project['assignees'])): ?>
+        <div class="avatar-group mt-3">
+          <?php foreach ($project['assignees'] as $assignee): ?>
+          <div class="avatar avatar-s rounded-circle">
+            <img class="rounded-circle" src="<?php echo getURLDir(); ?>module/users/uploads/<?= h($assignee['profile_pic'] ?? ''); ?>" alt="<?= h($assignee['name'] ?? ''); ?>" />
+          </div>
+          <?php endforeach; ?>
+        </div>
+        <?php endif; ?>
         <a class="stretched-link" href="index.php?action=details&id=<?php echo $project['id']; ?>"></a>
       </div>
     </div>

--- a/module/project/include/create_edit.php
+++ b/module/project/include/create_edit.php
@@ -1,27 +1,35 @@
 <?php
 require_once __DIR__ . '/../../../includes/functions.php';
+
+$editing    = !empty($current_project);
+$actionUrl  = $editing ? 'functions/update.php' : 'functions/create.php';
+$permAction = $editing ? 'update' : 'create';
+require_permission('project', $permAction);
 ?>
 <nav class="mb-3" aria-label="breadcrumb">
   <ol class="breadcrumb mb-0">
     <li class="breadcrumb-item"><a href="index.php">Projects</a></li>
-    <li class="breadcrumb-item active" aria-current="page">Create</li>
+    <li class="breadcrumb-item active" aria-current="page"><?php echo $editing ? 'Edit' : 'Create'; ?></li>
   </ol>
 </nav>
-<h2 class="mb-4">Create a project</h2>
+<h2 class="mb-4"><?php echo $editing ? 'Edit project' : 'Create a project'; ?></h2>
 <div class="row">
   <div class="col-xl-9">
-    <form class="row g-3 mb-6" method="post" action="index.php?action=create">
+    <form class="row g-3 mb-6" method="post" action="<?php echo $actionUrl; ?>">
+      <?php if ($editing): ?>
+      <input type="hidden" name="id" value="<?php echo h($current_project['id']); ?>">
+      <?php endif; ?>
       <div class="col-sm-6 col-md-8">
         <div class="form-floating">
-          <input class="form-control" id="projectName" type="text" name="name" placeholder="Project title" required />
+          <input class="form-control" id="projectName" type="text" name="name" placeholder="Project title" value="<?php echo h($current_project['name'] ?? ''); ?>" required />
           <label for="projectName">Project title</label>
         </div>
       </div>
       <div class="col-sm-6 col-md-4">
         <div class="form-floating">
           <select class="form-select" id="projectStatus" name="status" required>
-            <?php foreach ($statusMap as $s): ?>
-              <option value="<?= h($s['id']); ?>"><?= h($s['label']); ?></option>
+            <?php foreach ($statusMap as $id => $s): ?>
+              <option value="<?php echo h($s['id'] ?? $id); ?>" <?php if (($current_project['status'] ?? '') == ($s['id'] ?? $id)) echo 'selected'; ?>><?php echo h($s['label']); ?></option>
             <?php endforeach; ?>
           </select>
           <label for="projectStatus">Status</label>
@@ -30,7 +38,7 @@ require_once __DIR__ . '/../../../includes/functions.php';
       <div class="col-sm-6 col-md-4">
         <div class="flatpickr-input-container">
           <div class="form-floating">
-            <input class="form-control datetimepicker" id="startDate" type="text" name="start_date" placeholder="start date" data-options='{"disableMobile":true}' />
+            <input class="form-control datetimepicker" id="startDate" type="text" name="start_date" placeholder="start date" data-options='{"disableMobile":true}' value="<?php echo h($current_project['start_date'] ?? ''); ?>" />
             <label class="ps-6" for="startDate">Start date</label><span class="uil uil-calendar-alt flatpickr-icon text-body-tertiary"></span>
           </div>
         </div>
@@ -40,7 +48,7 @@ require_once __DIR__ . '/../../../includes/functions.php';
           <select class="form-select" id="agencySelect" name="agency_id">
             <option value="">Select agency</option>
             <?php foreach ($agencies as $agency): ?>
-              <option value="<?= h($agency['id']); ?>"><?= h($agency['name']); ?></option>
+              <option value="<?php echo h($agency['id']); ?>" <?php if (($current_project['agency_id'] ?? '') == $agency['id']) echo 'selected'; ?>><?php echo h($agency['name']); ?></option>
             <?php endforeach; ?>
           </select>
           <label for="agencySelect">Agency</label>
@@ -51,7 +59,7 @@ require_once __DIR__ . '/../../../includes/functions.php';
           <select class="form-select" id="divisionSelect" name="division_id">
             <option value="">Select division</option>
             <?php foreach ($divisions as $division): ?>
-              <option value="<?= h($division['id']); ?>"><?= h($division['name']); ?></option>
+              <option value="<?php echo h($division['id']); ?>" <?php if (($current_project['division_id'] ?? '') == $division['id']) echo 'selected'; ?>><?php echo h($division['name']); ?></option>
             <?php endforeach; ?>
           </select>
           <label for="divisionSelect">Division</label>
@@ -59,29 +67,29 @@ require_once __DIR__ . '/../../../includes/functions.php';
       </div>
       <div class="col-12 gy-6">
         <div class="form-floating">
-          <textarea class="form-control" id="projectDescription" name="description" placeholder="Leave a description here" style="height:100px"></textarea>
+          <textarea class="form-control" id="projectDescription" name="description" placeholder="Leave a description here" style="height:100px"><?php echo h($current_project['description'] ?? ''); ?></textarea>
           <label for="projectDescription">Project description</label>
         </div>
       </div>
       <div class="col-12 gy-6">
         <div class="form-floating">
-          <textarea class="form-control" id="projectRequirements" name="requirements" placeholder="Requirements" style="height:100px"></textarea>
+          <textarea class="form-control" id="projectRequirements" name="requirements" placeholder="Requirements" style="height:100px"><?php echo h($current_project['requirements'] ?? ''); ?></textarea>
           <label for="projectRequirements">Requirements</label>
         </div>
       </div>
       <div class="col-12 gy-6">
         <div class="form-floating">
-          <textarea class="form-control" id="projectSpecifications" name="specifications" placeholder="Specifications" style="height:100px"></textarea>
+          <textarea class="form-control" id="projectSpecifications" name="specifications" placeholder="Specifications" style="height:100px"><?php echo h($current_project['specifications'] ?? ''); ?></textarea>
           <label for="projectSpecifications">Specifications</label>
         </div>
       </div>
       <div class="col-12 gy-6">
         <div class="row g-3 justify-content-end">
           <div class="col-auto">
-            <a class="btn btn-phoenix-primary px-5" href="index.php">Cancel</a>
+            <a class="btn btn-warning px-5" href="<?php echo $editing ? 'index.php?action=details&id=' . (int)$current_project['id'] : 'index.php'; ?>">Cancel</a>
           </div>
           <div class="col-auto">
-            <button class="btn btn-primary px-5 px-sm-15" type="submit">Create Project</button>
+            <button class="btn atlis px-5 px-sm-15" type="submit"><?php echo $editing ? 'Update Project' : 'Create Project'; ?></button>
           </div>
         </div>
       </div>

--- a/module/project/include/details_view.php
+++ b/module/project/include/details_view.php
@@ -1,327 +1,203 @@
 <?php
-// Project details view built from the Phoenix theme project-details template
 require_once __DIR__ . '/../../../includes/functions.php';
 
-if (!empty($current_project)) {
-    $totalTasks = count($tasks ?? []);
-    $completedTasks = 0;
-    $chartData = [];
-    if (!empty($tasks)) {
-        foreach ($tasks as $t) {
-            if (!empty($t['completed'])) {
-                $completedTasks++;
-            }
-            if (!empty($t['due_date'])) {
-                $date = date('Y-m-d', strtotime($t['due_date']));
-                if (!isset($chartData[$date])) {
-                    $chartData[$date] = 0;
-                }
-                if (!empty($t['completed'])) {
-                    $chartData[$date]++;
-                }
-            }
-        }
-    }
-    ksort($chartData);
-    $chartDates = array_keys($chartData);
-    $chartValues = array_values($chartData);
-    $progress = $totalTasks > 0 ? round(($completedTasks / $totalTasks) * 100) : 0;
+if (empty($current_project)) {
+    echo '<p class="text-danger">Project not found.</p>';
+    return;
 }
+
+$totalTasks     = count($tasks ?? []);
+$completedTasks = 0;
+foreach ($tasks as $t) {
+    if (!empty($t['completed'])) {
+        $completedTasks++;
+    }
+}
+$progress = $totalTasks > 0 ? round(($completedTasks / $totalTasks) * 100) : 0;
 ?>
-<?php if (!empty($current_project)): ?>
 <div class="row g-0">
   <div class="col-12 col-xxl-8 px-0 bg-body">
-    <div class="px-4 px-lg-6 pt-6 pb-9">
-      <div class="mb-5">
-        <div class="d-flex justify-content-between">
-          <h2 class="text-body-emphasis fw-bolder mb-2"><?= h($current_project['name'] ?? '') ?></h2>
-          <div class="btn-reveal-trigger">
-            <button class="btn btn-sm dropdown-toggle dropdown-caret-none transition-none btn-reveal" type="button" data-bs-toggle="dropdown" data-boundary="window" aria-haspopup="true" aria-expanded="false" data-bs-reference="parent"><span class="fas fa-ellipsis-h"></span></button>
-            <div class="dropdown-menu dropdown-menu-end py-2"><a class="dropdown-item" href="#!">Edit</a><a class="dropdown-item text-danger" href="#!">Delete</a><a class="dropdown-item" href="#!">Download</a><a class="dropdown-item" href="#!">Report abuse</a></div>
-          </div>
+    <div class="px-4 px-lg-6 pt-6 pb-6">
+      <div class="d-flex justify-content-between mb-3">
+        <h2 class="text-body-emphasis fw-bolder mb-0"><?= h($current_project['name']); ?></h2>
+        <?php if (user_has_permission('project','update')): ?>
+        <div class="d-flex gap-2">
+          <a class="btn btn-warning btn-sm" href="index.php?action=create-edit&id=<?= (int)$current_project['id']; ?>">Edit</a>
+          <form method="post" action="functions/delete.php" onsubmit="return confirm('Delete this project?');">
+            <input type="hidden" name="id" value="<?= (int)$current_project['id']; ?>">
+            <button class="btn btn-danger btn-sm" type="submit">Delete</button>
+          </form>
         </div>
-        <span class="badge badge-phoenix badge-phoenix-<?= h($statusMap[$current_project['status']]['color_class'] ?? 'secondary') ?>">
-          <?= h($statusMap[$current_project['status']]['label'] ?? '') ?>
-        </span>
-        <span class="badge badge-phoenix badge-phoenix-<?= h($priorityMap[$current_project['priority']]['color_class'] ?? 'secondary') ?>">
-          <?= h($priorityMap[$current_project['priority']]['label'] ?? '') ?>
-        </span>
+        <?php endif; ?>
       </div>
-      <div class="row gx-0 gx-sm-5 gy-8 mb-8">
-        <div class="col-12 col-xl-3 col-xxl-4 pe-xl-0">
-          <div class="mb-4 mb-xl-7">
-            <div class="row gx-0 gx-sm-7">
-              <div class="col-12 col-sm-auto">
-                <table class="lh-sm mb-4 mb-sm-0 mb-xl-4">
-                  <tbody>
-                    <tr>
-                      <td class="py-1" colspan="2">
-                        <div class="d-flex"><span class="fa-solid fa-earth-americas me-2 text-body-tertiary fs-9"></span>
-                          <h5 class="text-body">Public project</h5>
-                        </div>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td class="align-top py-1">
-                        <div class="d-flex"><span class="fa-solid fa-user me-2 text-body-tertiary fs-9"></span>
-                          <h5 class="text-body mb-0 text-nowrap">Client :</h5>
-                        </div>
-                      </td>
-                      <td class="ps-1 py-1"><a class="fw-semibold d-block lh-sm" href="#!"><?= h($current_project['agency_id'] ?? '') ?></a></td>
-                    </tr>
-                    <tr>
-                      <td class="align-top py-1">
-                        <div class="d-flex"><span class="fa-regular fa-credit-card me-2 text-body-tertiary fs-9"></span>
-                          <h5 class="text-body mb-0 text-nowrap">Budget : </h5>
-                        </div>
-                      </td>
-                      <td class="fw-bold ps-1 py-1 text-body-highlight"><?= h($current_project['budget'] ?? '') ?></td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
-              <div class="col-12 col-sm-auto">
-                <table class="lh-sm">
-                  <tbody>
-                    <tr>
-                      <td class="align-top py-1 text-body text-nowrap fw-bold">Started : </td>
-                      <td class="text-body-tertiary text-opacity-85 fw-semibold ps-3"><?= !empty($current_project['start_date']) ? h(date('jS M, Y', strtotime($current_project['start_date']))) : '' ?></td>
-                    </tr>
-                    <tr>
-                      <td class="align-top py-1 text-body text-nowrap fw-bold">Deadline :</td>
-                      <td class="text-body-tertiary text-opacity-85 fw-semibold ps-3"><?= !empty($current_project['complete_date']) ? h(date('jS M, Y', strtotime($current_project['complete_date']))) : '' ?></td>
-                    </tr>
-                    <tr>
-                      <td class="align-top py-1 text-body text-nowrap fw-bold">Progress :</td>
-                      <td class="text-warning fw-semibold ps-3"><?= $progress ?>%</td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
-            </div>
-          </div>
-          <div>
-            <div class="d-flex align-items-center"><span class="fa-solid fa-list-check me-2 text-body-tertiary fs-9"></span>
-              <h5 class="text-body-emphasis mb-0 me-2"><?= $totalTasks ?><span class="text-body fw-normal ms-2">tasks</span></h5><a class="fw-bold fs-9 mt-1" href="../task/index.php?action=list&project_id=<?= (int)$current_project['id'] ?>">See tasks <span class="fa-solid fa-chevron-right me-2 fs-10"></span></a>
-            </div>
-          </div>
-        </div>
-        <div class="col-12 col-xl-9 col-xxl-8">
-          <div class="row flex-between-center mb-3 g-3">
-            <div class="col-auto">
-              <h4 class="text-body-emphasis">Task completed over time</h4>
-              <p class="text-body-tertiary mb-0">Hard works done across all tasks</p>
-            </div>
-          </div>
-            <div class="echart-completed-task-chart" style="min-height:200px;width:100%"></div>
-        </div>
+      <div class="mb-4">
+        <span class="badge badge-phoenix badge-phoenix-<?= h($statusMap[$current_project['status']]['color_class'] ?? 'secondary'); ?>"><?= h($statusMap[$current_project['status']]['label'] ?? ''); ?></span>
+        <span class="badge badge-phoenix badge-phoenix-<?= h($priorityMap[$current_project['priority']]['color_class'] ?? 'secondary'); ?>"><?= h($priorityMap[$current_project['priority']]['label'] ?? ''); ?></span>
       </div>
-      <h3 class="text-body-emphasis mb-4">Project overview</h3>
-      <p class="text-body-secondary mb-4"><?= nl2br(h($current_project['description'] ?? '')) ?></p>
+      <table class="table table-sm">
+        <tbody>
+          <tr>
+            <th scope="row">Start date</th>
+            <td><?= !empty($current_project['start_date']) ? h(date('jS M, Y', strtotime($current_project['start_date']))) : ''; ?></td>
+          </tr>
+          <tr>
+            <th scope="row">Deadline</th>
+            <td><?= !empty($current_project['complete_date']) ? h(date('jS M, Y', strtotime($current_project['complete_date']))) : ''; ?></td>
+          </tr>
+          <tr>
+            <th scope="row">Progress</th>
+            <td><?= $progress; ?>%</td>
+          </tr>
+        </tbody>
+      </table>
+      <h3 class="text-body-emphasis mt-5 mb-3">Project overview</h3>
+      <p class="text-body-secondary mb-4"><?= nl2br(h($current_project['description'] ?? '')); ?></p>
       <?php if (!empty($current_project['requirements']) || !empty($current_project['specifications'])): ?>
-      <div class="row mb-5">
+      <div class="row mb-4">
         <div class="col-md-6">
-          <h4 class="mb-2 fs-8 text-body-emphasis">Requirements</h4>
-          <p class="text-body-secondary mb-4"><?= nl2br(h($current_project['requirements'] ?? '')) ?></p>
+          <h4 class="fs-8">Requirements</h4>
+          <p class="text-body-secondary mb-3"><?= nl2br(h($current_project['requirements'] ?? '')); ?></p>
         </div>
         <div class="col-md-6">
-          <h4 class="mb-2 fs-8 text-body-emphasis">Specifications</h4>
-          <p class="text-body-secondary mb-4"><?= nl2br(h($current_project['specifications'] ?? '')) ?></p>
+          <h4 class="fs-8">Specifications</h4>
+          <p class="text-body-secondary mb-3"><?= nl2br(h($current_project['specifications'] ?? '')); ?></p>
         </div>
       </div>
       <?php endif; ?>
     </div>
-    <div class="row">
-      <div class="col-4">
-        <div class="d-flex align-items-center mb-4">
-          <h4 class="text-body-emphasis mb-0 me-2">Team members</h4>
-          <button class="btn btn-sm btn-outline-atlis" type="button" data-bs-toggle="modal" data-bs-target="#assignUserModal">+</button>
-        </div>
-        <?php if (!empty($assignedUsers)): ?>
-          <ul class="list-unstyled mb-4">
-            <?php foreach ($assignedUsers as $au): ?>
-              <li class="d-flex align-items-center mb-2">
-                <div class="avatar avatar-xl me-2">
-                  <img class="rounded-circle" src="<?php echo getURLDir(); ?>module/users/uploads/<?= h($au['profile_pic'] ?? '') ?>" alt="<?= h($au['name']) ?>" />
-                </div>
-                <div class="d-flex align-items-center flex-grow-1">
-                  <h6 class="mb-0"><?= h($au['name']) ?></h6>
-                  <form method="post" action="functions/remove_user.php" class="ms-2" onclick="return confirm('Remove this user?')">
-                    <input type="hidden" name="project_id" value="<?= (int)$current_project['id'] ?>">
-                    <input type="hidden" name="user_id" value="<?= (int)$au['user_id'] ?>">
-                    <button class="btn btn-sm btn-outline-danger" type="submit">-</button>
-                  </form>
-                </div>
-                <form method="post" action="functions/remove_user.php" class="ms-2" onclick="return confirm('Remove this user?')">
-                  <input type="hidden" name="project_id" value="<?= (int)$current_project['id'] ?>">
-                  <input type="hidden" name="user_id" value="<?= (int)$au['user_id'] ?>">
-                </form>
-              </li>
-            <?php endforeach; ?>
-          </ul>
-        <?php else: ?>
-          <p class="fs-9 text-body-secondary mb-4">No team members assigned.</p>
-        <?php endif; ?>
-      </div>
-      <div class="col-8">
-        <div class="mt-6">
-          <h2 class="mb-4">Todo list<span class="text-body-tertiary fw-normal">(<?= count($tasks) ?>)</span></h2>
-          <div class="row align-items-center g-3 mb-3">
-            <div class="col-sm-auto">
-              <div class="search-box">
-                <form class="position-relative">
-                  <input class="form-control search-input search" type="search" placeholder="Search tasks" aria-label="Search" />
-                  <span class="fas fa-search search-box-icon"></span>
-                </form>
-              </div>
-            </div>
-            <div class="col-sm-auto">
-              <div class="d-flex"><a class="btn btn-link p-0 ms-sm-3 fs-9 text-body-tertiary fw-bold" href="#!"><span class="fas fa-filter me-1 fw-extra-bold fs-10"></span><?= count($tasks) ?> tasks</a><a class="btn btn-link p-0 ms-3 fs-9 text-body-tertiary fw-bold" href="#!"><span class="fas fa-sort me-1 fw-extra-bold fs-10"></span>Sorting</a></div>
-            </div>
+    <div class="px-4 px-lg-6 pb-6">
+      <h4 class="mb-3">Tasks <span class="text-body-tertiary fw-normal">(<?= $totalTasks; ?>)</span></h4>
+      <?php if (user_has_permission('task','create')): ?>
+      <a class="btn btn-success mb-3" href="../task/index.php?action=create&project_id=<?= (int)$current_project['id']; ?>">Add Task</a>
+      <?php endif; ?>
+      <div class="mb-4">
+        <?php foreach ($tasks as $t): ?>
+        <div class="d-flex justify-content-between align-items-center border-top py-2">
+          <div>
+            <span class="badge badge-phoenix fs-10 badge-phoenix-<?= h($t['status_color']); ?>"><?= h($t['status_label']); ?></span>
+            <span class="ms-2"><?= h($t['name']); ?></span>
           </div>
-          <div class="mb-4 todo-list">
-            <?php if (!empty($tasks)): ?>
-              <?php foreach ($tasks as $t): ?>
-                <div class="row justify-content-between align-items-md-center hover-actions-trigger btn-reveal-trigger border-translucent py-3 gx-0 cursor-pointer border-top">
-                  <div class="col-12 col-md-auto flex-1">
-                    <div>
-                      <div class="form-check mb-1 mb-md-0 d-flex align-items-center lh-1">
-                        <input class="form-check-input flex-shrink-0 form-check-line-through mt-0 me-2" type="checkbox" <?= !empty($t['completed']) ? 'checked' : '' ?> />
-                        <label class="form-check-label mb-0 fs-8 me-2 line-clamp-1 flex-grow-1 flex-md-grow-0 cursor-pointer"><?= h($t['name']) ?></label><span class="badge badge-phoenix fs-10 badge-phoenix-<?= h($t['status_color']) ?>"><?= h($t['status_label']) ?></span>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="col-12 col-md-auto">
-                    <div class="d-flex ms-4 lh-1 align-items-center">
-                      <button class="btn btn-link p-0 text-body-tertiary fs-10 me-2"><span class="fas fa-paperclip me-1"></span><?= (int)($t['attachment_count'] ?? 0) ?></button>
-                      <p class="text-body-tertiary fs-10 mb-md-0 me-2 me-md-3 mb-0"><?= !empty($t['due_date']) ? h(date('d M, Y', strtotime($t['due_date']))) : '' ?></p>
-                    </div>
-                  </div>
-                </div>
-              <?php endforeach; ?>
-            <?php else: ?>
-              <p class="fs-9 text-body-secondary mb-0">No tasks found.</p>
+          <div class="d-flex align-items-center gap-1">
+            <span class="text-body-tertiary fs-10 me-2"><?= !empty($t['due_date']) ? h(date('d M, Y', strtotime($t['due_date']))) : ''; ?></span>
+            <?php if (user_has_permission('task','update')): ?>
+            <a class="btn btn-warning btn-sm" href="../task/index.php?action=create-edit&id=<?= (int)$t['id']; ?>">Edit</a>
             <?php endif; ?>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <div class="col-12 col-xxl-4 px-0 border-start-xxl border-top-sm">
-    <div class="bg-light dark__bg-gray-1100 h-100">
-      <div class="p-4 p-lg-6">
-        <h3 class="text-body-highlight mb-4 fw-bold">Recent activity</h3>
-        <div class="timeline-vertical timeline-with-details">
-          <?php if (!empty($notes)): ?>
-            <?php foreach ($notes as $n): ?>
-            <div class="timeline-item position-relative">
-              <div class="row g-md-3">
-                <div class="col-12 col-md-auto d-flex">
-                  <div class="timeline-item-date order-1 order-md-0 me-md-4">
-                    <p class="fs-10 fw-semibold text-body-tertiary text-opacity-85 text-end">
-                      <?= h(date('d M, Y', strtotime($n['date_created']))) ?><br class="d-none d-md-block" />
-                      <?= h(date('h:i A', strtotime($n['date_created']))) ?>
-                    </p>
-                  </div>
-                  <div class="timeline-item-bar position-md-relative me-3 me-md-0">
-                    <div class="icon-item icon-item-sm rounded-7 shadow-none bg-primary-subtle"><span class="fa-solid fa-note-sticky text-primary-dark fs-10"></span></div><span class="timeline-bar border-end border-dashed"></span>
-                  </div>
-                </div>
-                <div class="col">
-                  <div class="timeline-item-content ps-6 ps-md-3">
-                    <p class="fs-9 lh-sm mb-1"><?= nl2br(h($n['note_text'])) ?></p>
-                    <p class="fs-9 mb-0">by <a class="fw-semibold" href="#!"><?= h($n['user_name'] ?? '') ?></a></p>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <?php endforeach; ?>
-          <?php else: ?>
-            <p class="fs-9 text-body-secondary mb-0">No notes found.</p>
-          <?php endif; ?>
-        </div>
-        <div class="mt-4">
-          <form action="functions/add_note.php" method="post">
-            <input type="hidden" name="id" value="<?= (int)$current_project['id'] ?>">
-            <div class="mb-3">
-              <textarea class="form-control" name="note" rows="3" required></textarea>
-            </div>
-            <button class="btn btn-atlis" type="submit">Add Note</button>
-          </form>
-        </div>
-      </div>
-      <div class="px-4 px-lg-6">
-        <h4 class="mb-3">Files</h4>
-      </div>
-      <div class="border-top px-4 px-lg-6 py-4">
-        <form action="functions/upload_file.php" method="post" enctype="multipart/form-data" class="mb-3">
-          <input type="hidden" name="id" value="<?= (int)$current_project['id'] ?>">
-          <input class="form-control mb-2" type="file" name="file" required>
-          <button class="btn btn-outline-atlis" type="submit">Upload</button>
-        </form>
-      </div>
-      <?php if (!empty($files)): ?>
-        <?php foreach ($files as $f): ?>
-        <div class="border-top px-4 px-lg-6 py-4">
-          <div class="me-n3">
-            <div class="d-flex flex-between-center">
-              <div class="d-flex mb-1"><span class="fa-solid <?= strpos($f['file_type'], 'image/') === 0 ? 'fa-image' : 'fa-file' ?> me-2 text-body-tertiary fs-9"></span>
-                <p class="text-body-highlight mb-0 lh-1"><a class="text-body-highlight" href="<? echo getURLDir(); ?><?= h($f['file_path']) ?>"><?= h($f['file_name']) ?></a></p>
-              </div>
-            </div>
-            <div class="d-flex fs-9 text-body-tertiary mb-0 flex-wrap"><span><?= h($f['file_size']) ?></span><span class="text-body-quaternary mx-1">| </span><span class="text-nowrap"><?= h($f['file_type']) ?></span><span class="text-body-quaternary mx-1">| </span><span class="text-nowrap"><?= h($f['date_created']) ?></span></div>
-            <?php if (strpos($f['file_type'], 'image/') === 0): ?>
-              <img class="rounded-2 mt-2" src="<? echo getURLDir(); ?><?= h($f['file_path']) ?>" alt="" style="width:320px" />
+            <?php if (user_has_permission('task','delete')): ?>
+            <form method="post" action="../task/functions/delete.php" onsubmit="return confirm('Delete task?');" class="d-inline">
+              <input type="hidden" name="id" value="<?= (int)$t['id']; ?>">
+              <button class="btn btn-danger btn-sm" type="submit">Delete</button>
+            </form>
             <?php endif; ?>
           </div>
         </div>
         <?php endforeach; ?>
-      <?php else: ?>
-        <div class="border-top px-4 px-lg-6 py-4">
-          <p class="fs-9 text-body-secondary mb-0">No files uploaded.</p>
-        </div>
+        <?php if ($totalTasks === 0): ?><p class="text-body-secondary fs-9 mb-0">No tasks found.</p><?php endif; ?>
+      </div>
+    </div>
+    <div class="px-4 px-lg-6 pb-6">
+      <h4 class="mb-3">Files</h4>
+      <?php if (user_has_permission('project','update')): ?>
+      <button class="btn btn-success mb-3" data-bs-toggle="collapse" data-bs-target="#fileUpload">Add file</button>
+      <div id="fileUpload" class="collapse mb-3">
+        <form method="post" action="functions/upload_file.php" enctype="multipart/form-data" class="d-flex gap-2">
+          <input type="hidden" name="project_id" value="<?= (int)$current_project['id']; ?>">
+          <input class="form-control" type="file" name="file">
+          <button class="btn atlis" type="submit">Upload</button>
+        </form>
+      </div>
       <?php endif; ?>
+      <div class="row g-2">
+        <?php foreach ($files as $f): ?>
+        <div class="col-6 col-md-3">
+          <a href="<?php echo getURLDir(); ?><?= h($f['file_path']); ?>" data-bs-toggle="modal" data-bs-target="#fileModal<?= (int)$f['id']; ?>">
+            <img class="img-fluid rounded" src="<?php echo getURLDir(); ?><?= h($f['file_path']); ?>" alt="<?= h($f['file_name']); ?>">
+          </a>
+          <div class="modal fade" id="fileModal<?= (int)$f['id']; ?>" tabindex="-1" aria-hidden="true">
+            <div class="modal-dialog modal-dialog-centered">
+              <div class="modal-content">
+                <div class="modal-body">
+                  <img class="img-fluid" src="<?php echo getURLDir(); ?><?= h($f['file_path']); ?>" alt="<?= h($f['file_name']); ?>">
+                </div>
+              </div>
+            </div>
+          </div>
+          <?php if (user_has_permission('project','delete')): ?>
+          <form method="post" action="functions/delete_file.php" onsubmit="return confirm('Delete file?');" class="mt-1">
+            <input type="hidden" name="id" value="<?= (int)$f['id']; ?>">
+            <button class="btn btn-danger btn-sm" type="submit">Delete</button>
+          </form>
+          <?php endif; ?>
+        </div>
+        <?php endforeach; ?>
+        <?php if (empty($files)): ?><p class="text-body-secondary fs-9 mb-0">No files uploaded.</p><?php endif; ?>
+      </div>
+    </div>
+    <div class="px-4 px-lg-6 pb-6">
+      <h4 class="mb-3">Notes</h4>
+      <?php if (user_has_permission('project','update')): ?>
+      <button class="btn btn-success mb-3" data-bs-toggle="collapse" data-bs-target="#addNote">Add note</button>
+      <div id="addNote" class="collapse mb-3">
+        <form method="post" action="functions/add_note.php">
+          <input type="hidden" name="project_id" value="<?= (int)$current_project['id']; ?>">
+          <textarea class="form-control mb-2" name="note_text" rows="3"></textarea>
+          <button class="btn atlis" type="submit">Save Note</button>
+        </form>
+      </div>
+      <?php endif; ?>
+      <ul class="list-unstyled mb-0">
+        <?php foreach ($notes as $n): ?>
+        <li class="mb-3">
+          <div class="d-flex justify-content-between">
+            <span><?= nl2br(h($n['note_text'])); ?></span>
+            <small class="text-body-secondary ms-2">by <?= h($n['user_name'] ?? ''); ?></small>
+          </div>
+          <?php if (user_has_permission('project','delete')): ?>
+          <form method="post" action="functions/delete_note.php" onsubmit="return confirm('Delete note?');" class="mt-1">
+            <input type="hidden" name="id" value="<?= (int)$n['id']; ?>">
+            <button class="btn btn-danger btn-sm" type="submit">Delete</button>
+          </form>
+          <?php endif; ?>
+        </li>
+        <?php endforeach; ?>
+        <?php if (empty($notes)): ?><li><p class="text-body-secondary fs-9 mb-0">No notes yet.</p></li><?php endif; ?>
+      </ul>
     </div>
   </div>
-</div>
-<script>
-document.addEventListener('DOMContentLoaded', function () {
-  var chartEl = document.querySelector('.echart-completed-task-chart');
-  if (chartEl && window.echarts) {
-    var chart = window.echarts.init(chartEl);
-    var option = {
-      tooltip: { trigger: 'axis' },
-      xAxis: { type: 'category', data: <?= json_encode($chartDates ?? []) ?> },
-      yAxis: { type: 'value' },
-      series: [{ type: 'line', data: <?= json_encode($chartValues ?? []) ?>, smooth: true }]
-    };
-    chart.setOption(option);
-  }
-});
-</script>
-<?php else: ?>
-<p>No project found.</p>
-<?php endif; ?>
-
-<div class="modal fade" id="assignUserModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog">
-    <form class="modal-content" method="post" action="functions/assign_user.php">
-      <div class="modal-header">
-        <h5 class="modal-title">Assign User</h5>
-        <button class="btn-close" type="button" data-bs-dismiss="modal" aria-label="Close"></button>
+  <div class="col-12 col-xxl-4 bg-body-tertiary px-0">
+    <div class="p-4">
+      <h4 class="mb-3">Team members</h4>
+      <?php if (user_has_permission('project','update')): ?>
+      <button class="btn btn-success mb-3" data-bs-toggle="collapse" data-bs-target="#assignUser">Add member</button>
+      <div id="assignUser" class="collapse mb-3">
+        <form method="post" action="functions/assign_user.php" class="d-flex gap-2">
+          <input type="hidden" name="project_id" value="<?= (int)$current_project['id']; ?>">
+          <select class="form-select" name="user_id">
+            <?php foreach ($availableUsers as $u): ?>
+            <option value="<?= (int)$u['user_id']; ?>"><?= h($u['name']); ?></option>
+            <?php endforeach; ?>
+          </select>
+          <button class="btn atlis" type="submit">Assign</button>
+        </form>
       </div>
-      <div class="modal-body">
-        <input type="hidden" name="project_id" value="<?= (int)$current_project['id'] ?>">
-        <select class="form-select" name="user_id">
-          <?php foreach ($availableUsers as $au): ?>
-            <option value="<?= (int)$au['user_id'] ?>"><?= h($au['name']) ?></option>
-          <?php endforeach; ?>
-        </select>
-      </div>
-      <div class="modal-footer">
-        <button class="btn btn-atlis" type="submit">Assign</button>
-      </div>
-    </form>
+      <?php endif; ?>
+      <ul class="list-unstyled mb-0">
+        <?php foreach ($assignedUsers as $au): ?>
+        <li class="d-flex align-items-center mb-2">
+          <div class="avatar avatar-xl me-2">
+            <img class="rounded-circle" src="<?php echo getURLDir(); ?>module/users/uploads/<?= h($au['profile_pic'] ?? ''); ?>" alt="<?= h($au['name']); ?>" />
+          </div>
+          <span class="flex-grow-1"><?= h($au['name']); ?></span>
+          <?php if (user_has_permission('project','update')): ?>
+          <form method="post" action="functions/remove_user.php" onsubmit="return confirm('Remove this user?');">
+            <input type="hidden" name="project_id" value="<?= (int)$current_project['id']; ?>">
+            <input type="hidden" name="user_id" value="<?= (int)$au['user_id']; ?>">
+            <button class="btn btn-danger btn-sm" type="submit">Remove</button>
+          </form>
+          <?php endif; ?>
+        </li>
+        <?php endforeach; ?>
+        <?php if (empty($assignedUsers)): ?><li><p class="text-body-secondary fs-9 mb-0">No team members assigned.</p></li><?php endif; ?>
+      </ul>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Rebuild project card view using Phoenix markup, permission-aware add button, and avatar images
- Implement themed create/edit form with lookup-backed fields and role-based protection
- Replace project details page with RBAC-gated tasks, files, notes, and assignments using consistent button styles and modal previews

## Testing
- `php -l Atlis/module/project/include/card_view.php`
- `php -l Atlis/module/project/include/create_edit.php`
- `php -l Atlis/module/project/include/details_view.php`


------
https://chatgpt.com/codex/tasks/task_e_689f74a429c88333a0e605ec0dce985c