### PR TITLE
Add note and file deletion with ownership checks

### DIFF
--- a/module/task/functions/delete_file.php
+++ b/module/task/functions/delete_file.php
@@ -1,0 +1,20 @@
+<?php
+require '../../../includes/php_header.php';
+
+$file_id = (int)($_POST['id'] ?? 0);
+$task_id = (int)($_POST['task_id'] ?? 0);
+if ($file_id && $task_id) {
+  $stmt = $pdo->prepare('SELECT user_id, file_path, file_name FROM module_tasks_files WHERE id = :id AND task_id = :tid');
+  $stmt->execute([':id' => $file_id, ':tid' => $task_id]);
+  $file = $stmt->fetch(PDO::FETCH_ASSOC);
+  if ($file && (int)$file['user_id'] === (int)$this_user_id) {
+    $pdo->prepare('DELETE FROM module_tasks_files WHERE id = :id')->execute([':id' => $file_id]);
+    $fullPath = __DIR__ . '/../../..' . $file['file_path'];
+    if (is_file($fullPath)) {
+      unlink($fullPath);
+    }
+    admin_audit_log($pdo, $this_user_id, 'module_tasks_files', $file_id, 'DELETE', '', json_encode(['file' => $file['file_name']]));
+  }
+}
+header('Location: ../index.php?action=details&id=' . $task_id);
+exit;

--- a/module/task/functions/delete_note.php
+++ b/module/task/functions/delete_note.php
@@ -1,0 +1,16 @@
+<?php
+require '../../../includes/php_header.php';
+
+$note_id = (int)($_POST['id'] ?? 0);
+$task_id = (int)($_POST['task_id'] ?? 0);
+if ($note_id && $task_id) {
+  $stmt = $pdo->prepare('SELECT user_id, note_text FROM module_tasks_notes WHERE id = :id AND task_id = :tid');
+  $stmt->execute([':id' => $note_id, ':tid' => $task_id]);
+  $note = $stmt->fetch(PDO::FETCH_ASSOC);
+  if ($note && (int)$note['user_id'] === (int)$this_user_id) {
+    $pdo->prepare('DELETE FROM module_tasks_notes WHERE id = :id')->execute([':id' => $note_id]);
+    admin_audit_log($pdo, $this_user_id, 'module_tasks_notes', $note_id, 'DELETE', '', $note['note_text']);
+  }
+}
+header('Location: ../index.php?action=details&id=' . $task_id);
+exit;

--- a/module/task/include/details_view.php
+++ b/module/task/include/details_view.php
@@ -150,6 +150,13 @@ require_once __DIR__ . '/../../../includes/functions.php';
                           <?php if (!empty($item['user_name'])): ?>
                             <p class="fs-9 mb-0">by <a class="fw-semibold" href="#!"><?php echo h($item['user_name']); ?></a></p>
                           <?php endif; ?>
+                          <?php if ((int)($item['user_id'] ?? 0) === (int)$this_user_id): ?>
+                            <form method="post" action="functions/delete_note.php" class="mt-2" onsubmit="return confirm('Delete this note?');">
+                              <input type="hidden" name="id" value="<?php echo (int)$item['id']; ?>">
+                              <input type="hidden" name="task_id" value="<?php echo (int)($current_task['id'] ?? 0); ?>">
+                              <button class="btn btn-danger btn-sm" type="submit">Delete</button>
+                            </form>
+                          <?php endif; ?>
                         <?php else: ?>
                           <p class="mb-0">
                             <?php if (strpos($item['file_type'], 'image/') === 0): ?>
@@ -178,6 +185,13 @@ require_once __DIR__ . '/../../../includes/functions.php';
                               <?php echo h($item['file_type']); ?>
                             <?php endif; ?>
                           </p>
+                          <?php if ((int)($item['user_id'] ?? 0) === (int)$this_user_id): ?>
+                            <form method="post" action="functions/delete_file.php" class="mt-2" onsubmit="return confirm('Delete this file?');">
+                              <input type="hidden" name="id" value="<?php echo (int)$item['id']; ?>">
+                              <input type="hidden" name="task_id" value="<?php echo (int)($current_task['id'] ?? 0); ?>">
+                              <button class="btn btn-danger btn-sm" type="submit">Delete</button>
+                            </form>
+                          <?php endif; ?>
                         <?php endif; ?>
                       </div>
                     </div>

--- a/module/task/index.php
+++ b/module/task/index.php
@@ -145,11 +145,11 @@ if ($action === 'details') {
       $availableUsers = $availableStmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
-    $filesStmt = $pdo->prepare('SELECT id,file_name,file_path,file_size,file_type,date_created FROM module_tasks_files WHERE task_id = :id ORDER BY date_created DESC');
+    $filesStmt = $pdo->prepare('SELECT f.id, f.user_id, CONCAT(p.first_name, " ", p.last_name) AS user_name, f.file_name, f.file_path, f.file_size, f.file_type, f.date_created FROM module_tasks_files f LEFT JOIN users u ON f.user_id = u.id LEFT JOIN person p ON u.id = p.user_id WHERE f.task_id = :id ORDER BY f.date_created DESC');
     $filesStmt->execute([':id' => $task_id]);
     $files = $filesStmt->fetchAll(PDO::FETCH_ASSOC);
 
-    $notesStmt = $pdo->prepare('SELECT id,note_text,date_created FROM module_tasks_notes WHERE task_id = :id ORDER BY date_created DESC');
+    $notesStmt = $pdo->prepare('SELECT n.id, n.user_id, CONCAT(p.first_name, " ", p.last_name) AS user_name, n.note_text, n.date_created FROM module_tasks_notes n LEFT JOIN users u ON n.user_id = u.id LEFT JOIN person p ON u.id = p.user_id WHERE n.task_id = :id ORDER BY n.date_created DESC');
     $notesStmt->execute([':id' => $task_id]);
     $notes = $notesStmt->fetchAll(PDO::FETCH_ASSOC);
   }


### PR DESCRIPTION
## Summary
- Add endpoints to delete task notes and files after validating ownership
- Display delete controls for user-owned notes and files in task details
- Fetch note and file owners for permission-aware UI

## Testing
- `php -l module/task/functions/delete_note.php`
- `php -l module/task/functions/delete_file.php`
- `php -l module/task/include/details_view.php`
- `php -l module/task/index.php`


------
https://chatgpt.com/codex/tasks/task_e_689f853b7de08333a2796fccbe2f97e5