### PR TITLE
Allow attaching files to task notes

### DIFF
--- a/_SQL/atlis.sql
+++ b/_SQL/atlis.sql
@@ -776,6 +776,7 @@ CREATE TABLE `module_tasks_files` (
   `date_updated` datetime DEFAULT current_timestamp() ON UPDATE current_timestamp(),
   `memo` text DEFAULT NULL,
   `task_id` int(11) NOT NULL,
+  `note_id` int(11) DEFAULT NULL,
   `file_name` varchar(255) DEFAULT NULL,
   `file_path` varchar(255) DEFAULT NULL,
   `file_size` int(11) DEFAULT NULL,
@@ -786,8 +787,8 @@ CREATE TABLE `module_tasks_files` (
 -- Dumping data for table `module_tasks_files`
 --
 
-INSERT INTO `module_tasks_files` (`id`, `user_id`, `user_updated`, `date_created`, `date_updated`, `memo`, `task_id`, `file_name`, `file_path`, `file_size`, `file_type`) VALUES
-(1, 1, 1, '2025-08-15 00:09:26', '2025-08-15 00:09:26', NULL, 6, 'Kratom-Colors-Chart-Final.png', '/module/task/uploads/task_6_1755238166_Kratom-Colors-Chart-Final.png', 939198, 'image/png');
+INSERT INTO `module_tasks_files` (`id`, `user_id`, `user_updated`, `date_created`, `date_updated`, `memo`, `task_id`, `note_id`, `file_name`, `file_path`, `file_size`, `file_type`) VALUES
+(1, 1, 1, '2025-08-15 00:09:26', '2025-08-15 00:09:26', NULL, 6, NULL, 'Kratom-Colors-Chart-Final.png', '/module/task/uploads/task_6_1755238166_Kratom-Colors-Chart-Final.png', 939198, 'image/png');
 
 -- --------------------------------------------------------
 
@@ -1155,7 +1156,8 @@ ALTER TABLE `module_tasks_files`
   ADD PRIMARY KEY (`id`),
   ADD KEY `fk_module_tasks_files_user_id` (`user_id`),
   ADD KEY `fk_module_tasks_files_user_updated` (`user_updated`),
-  ADD KEY `fk_module_tasks_files_task_id` (`task_id`);
+  ADD KEY `fk_module_tasks_files_task_id` (`task_id`),
+  ADD KEY `fk_module_tasks_files_note_id` (`note_id`);
 
 --
 -- Indexes for table `module_tasks_notes`
@@ -1445,7 +1447,8 @@ ALTER TABLE `module_tasks`
 -- Constraints for table `module_tasks_files`
 --
 ALTER TABLE `module_tasks_files`
-  ADD CONSTRAINT `fk_module_tasks_files_task_id` FOREIGN KEY (`task_id`) REFERENCES `module_tasks` (`id`);
+  ADD CONSTRAINT `fk_module_tasks_files_task_id` FOREIGN KEY (`task_id`) REFERENCES `module_tasks` (`id`),
+  ADD CONSTRAINT `fk_module_tasks_files_note_id` FOREIGN KEY (`note_id`) REFERENCES `module_tasks_notes` (`id`);
 
 --
 -- Constraints for table `module_tasks_notes`

--- a/module/task/functions/add_note.php
+++ b/module/task/functions/add_note.php
@@ -13,6 +13,36 @@ if($id && $note !== ''){
   ]);
   $noteId = $pdo->lastInsertId();
   admin_audit_log($pdo,$this_user_id,'module_tasks_notes',$noteId,'NOTE','', $note);
+
+  if(isset($_FILES['files'])){
+    $uploadDir = '../uploads/';
+    if(!is_dir($uploadDir)){
+      mkdir($uploadDir,0777,true);
+    }
+    foreach($_FILES['files']['name'] as $idx => $name){
+      if($_FILES['files']['error'][$idx] === UPLOAD_ERR_OK){
+        $baseName = basename($name);
+        $safeName = preg_replace('/[^A-Za-z0-9._-]/','_', $baseName);
+        $targetName = 'task_' . $id . '_' . time() . '_' . $safeName;
+        $targetPath = $uploadDir . $targetName;
+        if(move_uploaded_file($_FILES['files']['tmp_name'][$idx], $targetPath)){
+          $filePathDb = '/module/task/uploads/' . $targetName;
+          $stmtFile = $pdo->prepare('INSERT INTO module_tasks_files (user_id,user_updated,task_id,note_id,file_name,file_path,file_size,file_type) VALUES (:uid,:uid,:tid,:nid,:name,:path,:size,:type)');
+          $stmtFile->execute([
+            ':uid' => $this_user_id,
+            ':tid' => $id,
+            ':nid' => $noteId,
+            ':name' => $baseName,
+            ':path' => $filePathDb,
+            ':size' => $_FILES['files']['size'][$idx],
+            ':type' => $_FILES['files']['type'][$idx]
+          ]);
+          $fileId = $pdo->lastInsertId();
+          admin_audit_log($pdo,$this_user_id,'module_tasks_files',$fileId,'UPLOAD','',json_encode(['file'=>$baseName]));
+        }
+      }
+    }
+  }
 }
 header('Location: ../index.php?action=details&id=' . $id);
 exit;

--- a/module/task/functions/upload_file.php
+++ b/module/task/functions/upload_file.php
@@ -3,6 +3,7 @@ require '../../../includes/php_header.php';
 require_permission('task','update');
 
 $id = (int)($_POST['id'] ?? 0);
+$note_id = (int)($_POST['note_id'] ?? 0);
 if($id && isset($_FILES['file'])){
   $file = $_FILES['file'];
   $uploadDir = '../uploads/';
@@ -15,10 +16,11 @@ if($id && isset($_FILES['file'])){
   $targetPath = $uploadDir . $targetName;
   if(move_uploaded_file($file['tmp_name'],$targetPath)){
     $filePathDb = '/module/task/uploads/' . $targetName;
-    $stmt = $pdo->prepare('INSERT INTO module_tasks_files (user_id,user_updated,task_id,file_name,file_path,file_size,file_type) VALUES (:uid,:uid,:tid,:name,:path,:size,:type)');
+    $stmt = $pdo->prepare('INSERT INTO module_tasks_files (user_id,user_updated,task_id,note_id,file_name,file_path,file_size,file_type) VALUES (:uid,:uid,:tid,:nid,:name,:path,:size,:type)');
     $stmt->execute([
       ':uid' => $this_user_id,
       ':tid' => $id,
+      ':nid' => $note_id ?: null,
       ':name' => $baseName,
       ':path' => $filePathDb,
       ':size' => $file['size'],

--- a/module/task/include/details_view.php
+++ b/module/task/include/details_view.php
@@ -14,8 +14,8 @@ require_once __DIR__ . '/../../../includes/functions.php';
 
     // Merge notes and files into a single activity timeline
     $activities = [];
-    if (!empty($files)) {
-      foreach ($files as $f) {
+    if (!empty($taskFiles)) {
+      foreach ($taskFiles as $f) {
         $f['type'] = 'file';
         $activities[] = $f;
       }
@@ -110,9 +110,10 @@ require_once __DIR__ . '/../../../includes/functions.php';
       <div class="bg-light dark__bg-gray-1100 h-100">
         <div class="p-4 p-lg-6">
           <h3 class="text-body-highlight mb-4 fw-bold">Recent activity</h3>
-          <form action="functions/add_note.php" method="post" class="mb-3">
+          <form action="functions/add_note.php" method="post" enctype="multipart/form-data" class="mb-3">
             <input type="hidden" name="id" value="<?php echo (int)($current_task['id'] ?? 0); ?>">
             <div class="mb-2"><textarea class="form-control" name="note" rows="3" required></textarea></div>
+            <div class="mb-2"><input class="form-control form-control-sm" type="file" name="files[]" multiple></div>
             <button class="btn btn-success btn-sm" type="submit">Add Note</button>
           </form>
           <form action="functions/upload_file.php" method="post" enctype="multipart/form-data" class="mb-3">
@@ -149,6 +150,39 @@ require_once __DIR__ . '/../../../includes/functions.php';
                           <p class="fs-9 lh-sm mb-1"><?php echo nl2br(h($item['note_text'])); ?></p>
                           <?php if (!empty($item['user_name'])): ?>
                             <p class="fs-9 mb-0">by <a class="fw-semibold" href="#!"><?php echo h($item['user_name']); ?></a></p>
+                          <?php endif; ?>
+                          <?php if (!empty($item['files'])): ?>
+                            <div class="mt-2">
+                              <?php foreach ($item['files'] as $f): ?>
+                                <p class="mb-0">
+                                  <?php if (strpos($f['file_type'], 'image/') === 0): ?>
+                                    <a href="#" data-bs-toggle="modal" data-bs-target="#fileModal-<?php echo (int)$f['id']; ?>"><?php echo h($f['file_name']); ?></a>
+                                    <div class="modal fade" id="fileModal-<?php echo (int)$f['id']; ?>" tabindex="-1" aria-hidden="true">
+                                      <div class="modal-dialog modal-dialog-centered modal-lg">
+                                        <div class="modal-content">
+                                          <div class="modal-header">
+                                            <h5 class="modal-title"><?php echo h($f['file_name']); ?></h5>
+                                            <button class="btn-close" type="button" data-bs-dismiss="modal" aria-label="Close"></button>
+                                          </div>
+                                          <div class="modal-body text-center">
+                                            <img src="<?php echo getURLDir(); ?><?php echo h($f['file_path']); ?>" class="img-fluid" alt="<?php echo h($f['file_name']); ?>" />
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  <?php else: ?>
+                                    <a href="<?php echo getURLDir(); ?><?php echo h($f['file_path']); ?>"><?php echo h($f['file_name']); ?></a>
+                                  <?php endif; ?>
+                                </p>
+                                <p class="fs-9 text-body-secondary mb-0">
+                                  <?php echo h($f['file_size'] ?? ''); ?>
+                                  <?php if (!empty($f['file_type'])): ?>
+                                    <span class="text-body-quaternary mx-1">|</span>
+                                    <?php echo h($f['file_type']); ?>
+                                  <?php endif; ?>
+                                </p>
+                              <?php endforeach; ?>
+                            </div>
                           <?php endif; ?>
                         <?php else: ?>
                           <p class="mb-0">

--- a/module/task/index.php
+++ b/module/task/index.php
@@ -145,13 +145,27 @@ if ($action === 'details') {
       $availableUsers = $availableStmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
-    $filesStmt = $pdo->prepare('SELECT id,file_name,file_path,file_size,file_type,date_created FROM module_tasks_files WHERE task_id = :id ORDER BY date_created DESC');
+    $filesStmt = $pdo->prepare('SELECT f.id,f.user_id,f.note_id,f.file_name,f.file_path,f.file_size,f.file_type,f.date_created, CONCAT(p.first_name, " ", p.last_name) AS user_name FROM module_tasks_files f LEFT JOIN users u ON f.user_id = u.id LEFT JOIN person p ON u.id = p.user_id WHERE f.task_id = :id ORDER BY f.date_created DESC');
     $filesStmt->execute([':id' => $task_id]);
     $files = $filesStmt->fetchAll(PDO::FETCH_ASSOC);
 
-    $notesStmt = $pdo->prepare('SELECT id,note_text,date_created FROM module_tasks_notes WHERE task_id = :id ORDER BY date_created DESC');
+    $notesStmt = $pdo->prepare('SELECT n.id,n.user_id,n.note_text,n.date_created, CONCAT(p.first_name, " ", p.last_name) AS user_name FROM module_tasks_notes n LEFT JOIN users u ON n.user_id = u.id LEFT JOIN person p ON u.id = p.user_id WHERE n.task_id = :id ORDER BY n.date_created DESC');
     $notesStmt->execute([':id' => $task_id]);
     $notes = $notesStmt->fetchAll(PDO::FETCH_ASSOC);
+
+    $taskFiles = [];
+    $noteFilesMap = [];
+    foreach ($files as $f) {
+      if (!empty($f['note_id'])) {
+        $noteFilesMap[$f['note_id']][] = $f;
+      } else {
+        $taskFiles[] = $f;
+      }
+    }
+    foreach ($notes as &$n) {
+      $n['files'] = $noteFilesMap[$n['id']] ?? [];
+    }
+    unset($n);
   }
 } elseif ($action === 'create-edit' && isset($_GET['id'])) {
   $task_id = (int)($_GET['id'] ?? 0);


### PR DESCRIPTION
## Summary
- add nullable `note_id` to `module_tasks_files` and enforce FK to notes
- allow uploading multiple files with notes and optional note file links
- render note attachments in task detail timeline

## Testing
- `php -l module/task/functions/add_note.php`
- `php -l module/task/functions/upload_file.php`
- `php -l module/task/include/details_view.php`
- `php -l module/task/index.php`


------
https://chatgpt.com/codex/tasks/task_e_689f853d365c833384787c3ea8eb1280