### PR TITLE
Support file attachments on project notes

### DIFF
--- a/_SQL/atlis.sql
+++ b/_SQL/atlis.sql
@@ -675,6 +675,7 @@ CREATE TABLE `module_projects_files` (
   `date_updated` datetime DEFAULT current_timestamp() ON UPDATE current_timestamp(),
   `memo` text DEFAULT NULL,
   `project_id` int(11) NOT NULL,
+  `note_id` int(11) DEFAULT NULL,
   `file_name` varchar(255) DEFAULT NULL,
   `file_path` varchar(255) DEFAULT NULL,
   `file_size` int(11) DEFAULT NULL,
@@ -685,8 +686,8 @@ CREATE TABLE `module_projects_files` (
 -- Dumping data for table `module_projects_files`
 --
 
-INSERT INTO `module_projects_files` (`id`, `user_id`, `user_updated`, `date_created`, `date_updated`, `memo`, `project_id`, `file_name`, `file_path`, `file_size`, `file_type`) VALUES
-(3, 1, 1, '2025-08-14 22:27:08', '2025-08-14 22:27:08', NULL, 5, 'Image from iOS.jpg', '/module/project/uploads/project_5_1755232028_Image_from_iOS.jpg', 278679, 'image/jpeg');
+INSERT INTO `module_projects_files` (`id`, `user_id`, `user_updated`, `date_created`, `date_updated`, `memo`, `project_id`, `note_id`, `file_name`, `file_path`, `file_size`, `file_type`) VALUES
+(3, 1, 1, '2025-08-14 22:27:08', '2025-08-14 22:27:08', NULL, 5, NULL, 'Image from iOS.jpg', '/module/project/uploads/project_5_1755232028_Image_from_iOS.jpg', 278679, 'image/jpeg');
 
 -- --------------------------------------------------------
 
@@ -1124,7 +1125,8 @@ ALTER TABLE `module_projects_files`
   ADD PRIMARY KEY (`id`),
   ADD KEY `fk_module_projects_files_user_id` (`user_id`),
   ADD KEY `fk_module_projects_files_user_updated` (`user_updated`),
-  ADD KEY `fk_module_projects_files_project_id` (`project_id`);
+  ADD KEY `fk_module_projects_files_project_id` (`project_id`),
+  ADD KEY `fk_module_projects_files_note_id` (`note_id`);
 
 --
 -- Indexes for table `module_projects_notes`
@@ -1425,7 +1427,8 @@ ALTER TABLE `module_projects_assignments`
 -- Constraints for table `module_projects_files`
 --
 ALTER TABLE `module_projects_files`
-  ADD CONSTRAINT `fk_module_projects_files_project_id` FOREIGN KEY (`project_id`) REFERENCES `module_projects` (`id`);
+  ADD CONSTRAINT `fk_module_projects_files_project_id` FOREIGN KEY (`project_id`) REFERENCES `module_projects` (`id`),
+  ADD CONSTRAINT `fk_module_projects_files_note_id` FOREIGN KEY (`note_id`) REFERENCES `module_projects_notes` (`id`);
 
 --
 -- Constraints for table `module_projects_notes`

--- a/module/project/include/details_view.php
+++ b/module/project/include/details_view.php
@@ -231,6 +231,22 @@ if (!empty($current_project)) {
                 <div class="col">
                   <div class="timeline-item-content ps-6 ps-md-3">
                     <p class="fs-9 lh-sm mb-1"><?= nl2br(h($n['note_text'])) ?></p>
+                    <?php if (!empty($noteFiles[$n['id']])): ?>
+                      <ul class="list-unstyled mt-2">
+                        <?php foreach ($noteFiles[$n['id']] as $f): ?>
+                          <li class="mb-1">
+                            <?php if (strpos($f['file_type'], 'image/') === 0): ?>
+                              <a class="fw-semibold" href="#" data-bs-toggle="modal" data-bs-target="#imageModal" data-img-src="<? echo getURLDir(); ?><?= h($f['file_path']) ?>"><?= h($f['file_name']) ?></a>
+                              <div class="mt-1">
+                                <img class="rounded-2" src="<? echo getURLDir(); ?><?= h($f['file_path']) ?>" alt="" style="width:160px" />
+                              </div>
+                            <?php else: ?>
+                              <a class="fw-semibold" href="<? echo getURLDir(); ?><?= h($f['file_path']) ?>"><?= h($f['file_name']) ?></a>
+                            <?php endif; ?>
+                          </li>
+                        <?php endforeach; ?>
+                      </ul>
+                    <?php endif; ?>
                     <p class="fs-9 mb-0">by <a class="fw-semibold" href="#!"><?= h($n['user_name'] ?? '') ?></a></p>
                   </div>
                 </div>
@@ -243,10 +259,13 @@ if (!empty($current_project)) {
         </div>
         <?php if (user_has_permission('project','create|update|delete')): ?>
         <div class="mt-4">
-          <form action="functions/add_note.php" method="post">
+          <form action="functions/add_note.php" method="post" enctype="multipart/form-data">
             <input type="hidden" name="id" value="<?= (int)$current_project['id'] ?>">
             <div class="mb-3">
               <textarea class="form-control" name="note" rows="3" required></textarea>
+            </div>
+            <div class="mb-3">
+              <input class="form-control" type="file" name="files[]" multiple>
             </div>
             <button class="btn btn-atlis" type="submit">Add Note</button>
           </form>

--- a/module/project/index.php
+++ b/module/project/index.php
@@ -64,13 +64,21 @@ unset($project);
     $priorityMap = array_column(get_lookup_items($pdo,'PROJECT_PRIORITY'), null, 'id');
 
     if ($action === 'details' && $current_project) {
-      $filesStmt = $pdo->prepare('SELECT id,file_name,file_path,file_size,file_type,date_created FROM module_projects_files WHERE project_id = :id ORDER BY date_created DESC');
+      $filesStmt = $pdo->prepare('SELECT id,user_id,file_name,file_path,file_size,file_type,date_created FROM module_projects_files WHERE project_id = :id AND note_id IS NULL ORDER BY date_created DESC');
       $filesStmt->execute([':id' => $project_id]);
       $files = $filesStmt->fetchAll(PDO::FETCH_ASSOC);
 
-      $notesStmt = $pdo->prepare('SELECT n.id, n.note_text, n.date_created, CONCAT(p.first_name, " ", p.last_name) AS user_name FROM module_projects_notes n LEFT JOIN users u ON n.user_id = u.id LEFT JOIN person p ON u.id = p.user_id WHERE n.project_id = :id ORDER BY n.date_created DESC');
+      $notesStmt = $pdo->prepare('SELECT n.id, n.user_id, n.note_text, n.date_created, CONCAT(p.first_name, " ", p.last_name) AS user_name FROM module_projects_notes n LEFT JOIN users u ON n.user_id = u.id LEFT JOIN person p ON u.id = p.user_id WHERE n.project_id = :id ORDER BY n.date_created DESC');
       $notesStmt->execute([':id' => $project_id]);
       $notes = $notesStmt->fetchAll(PDO::FETCH_ASSOC);
+
+      $noteFilesStmt = $pdo->prepare('SELECT id,user_id,file_name,file_path,file_size,file_type,date_created,note_id FROM module_projects_files WHERE project_id = :id AND note_id IS NOT NULL ORDER BY date_created DESC');
+      $noteFilesStmt->execute([':id' => $project_id]);
+      $noteFilesRaw = $noteFilesStmt->fetchAll(PDO::FETCH_ASSOC);
+      $noteFiles = [];
+      foreach ($noteFilesRaw as $nf) {
+        $noteFiles[$nf['note_id']][] = $nf;
+      }
 
         $tasksStmt = $pdo->prepare(
           'SELECT t.id, t.name, t.status, t.due_date, t.completed, li.label AS status_label, COALESCE(attr.attr_value, "secondary") AS status_color, ' .


### PR DESCRIPTION
## Summary
- allow uploading files when creating a project note and store them with note_id
- render note attachments in the project details view and show only project-level files in the Files section
- update schema: add module_projects_files.note_id column with foreign key to module_projects_notes

## Testing
- `php -l module/project/functions/add_note.php`
- `php -l module/project/include/details_view.php`
- `php -l module/project/index.php`


------
https://chatgpt.com/codex/tasks/task_e_689f8546fb788333ad67a458aeada050