### PR TITLE
Allow users to delete their own project notes and files

### DIFF
--- a/module/project/functions/delete_file.php
+++ b/module/project/functions/delete_file.php
@@ -1,7 +1,5 @@
 <?php
 require '../../../includes/php_header.php';
-require_permission('project','update');
-
 $id = (int)($_POST['id'] ?? 0);
 $project_id = (int)($_POST['project_id'] ?? 0);
 
@@ -19,5 +17,5 @@ if ($id && $project_id) {
   }
 }
 
-header('Location: ../details_view.php?id=' . $project_id);
+header('Location: ../index.php?action=details&id=' . $project_id);
 exit;

--- a/module/project/functions/delete_note.php
+++ b/module/project/functions/delete_note.php
@@ -1,7 +1,5 @@
 <?php
 require '../../../includes/php_header.php';
-require_permission('project','update');
-
 $id = (int)($_POST['id'] ?? 0);
 $project_id = (int)($_POST['project_id'] ?? 0);
 
@@ -15,5 +13,5 @@ if ($id && $project_id) {
   }
 }
 
-header('Location: ../details_view.php?id=' . $project_id);
+header('Location: ../index.php?action=details&id=' . $project_id);
 exit;

--- a/module/project/include/details_view.php
+++ b/module/project/include/details_view.php
@@ -230,7 +230,16 @@ if (!empty($current_project)) {
                 </div>
                 <div class="col">
                   <div class="timeline-item-content ps-6 ps-md-3">
-                    <p class="fs-9 lh-sm mb-1"><?= nl2br(h($n['note_text'])) ?></p>
+                    <div class="d-flex">
+                      <p class="fs-9 lh-sm mb-1 flex-grow-1"><?= nl2br(h($n['note_text'])) ?></p>
+                      <?php if ($is_admin || ($n['user_id'] ?? 0) == $this_user_id): ?>
+                      <form action="functions/delete_note.php" method="post" class="ms-2" onsubmit="return confirm('Delete this note?');">
+                        <input type="hidden" name="id" value="<?= (int)$n['id'] ?>">
+                        <input type="hidden" name="project_id" value="<?= (int)$current_project['id'] ?>">
+                        <button class="btn btn-link p-0 text-danger" type="submit"><span class="fa-solid fa-trash"></span></button>
+                      </form>
+                      <?php endif; ?>
+                    </div>
                     <p class="fs-9 mb-0">by <a class="fw-semibold" href="#!"><?= h($n['user_name'] ?? '') ?></a></p>
                   </div>
                 </div>
@@ -279,6 +288,13 @@ if (!empty($current_project)) {
                   <?php endif; ?>
                 </p>
               </div>
+              <?php if ($is_admin || ($f['user_id'] ?? 0) == $this_user_id): ?>
+              <form action="functions/delete_file.php" method="post" onsubmit="return confirm('Delete this file?');">
+                <input type="hidden" name="id" value="<?= (int)$f['id'] ?>">
+                <input type="hidden" name="project_id" value="<?= (int)$current_project['id'] ?>">
+                <button class="btn btn-link p-0 text-danger" type="submit"><span class="fa-solid fa-trash"></span></button>
+              </form>
+              <?php endif; ?>
             </div>
             <div class="d-flex fs-9 text-body-tertiary mb-0 flex-wrap"><span><?= h($f['file_size']) ?></span><span class="text-body-quaternary mx-1">| </span><span class="text-nowrap"><?= h($f['file_type']) ?></span><span class="text-body-quaternary mx-1">| </span><span class="text-nowrap"><?= h($f['date_created']) ?></span></div>
             <?php if (strpos($f['file_type'], 'image/') === 0): ?>

--- a/module/project/index.php
+++ b/module/project/index.php
@@ -64,11 +64,11 @@ unset($project);
     $priorityMap = array_column(get_lookup_items($pdo,'PROJECT_PRIORITY'), null, 'id');
 
     if ($action === 'details' && $current_project) {
-      $filesStmt = $pdo->prepare('SELECT id,file_name,file_path,file_size,file_type,date_created FROM module_projects_files WHERE project_id = :id ORDER BY date_created DESC');
+      $filesStmt = $pdo->prepare('SELECT id, user_id, file_name, file_path, file_size, file_type, date_created FROM module_projects_files WHERE project_id = :id ORDER BY date_created DESC');
       $filesStmt->execute([':id' => $project_id]);
       $files = $filesStmt->fetchAll(PDO::FETCH_ASSOC);
 
-      $notesStmt = $pdo->prepare('SELECT n.id, n.note_text, n.date_created, CONCAT(p.first_name, " ", p.last_name) AS user_name FROM module_projects_notes n LEFT JOIN users u ON n.user_id = u.id LEFT JOIN person p ON u.id = p.user_id WHERE n.project_id = :id ORDER BY n.date_created DESC');
+      $notesStmt = $pdo->prepare('SELECT n.id, n.user_id, n.note_text, n.date_created, CONCAT(p.first_name, " ", p.last_name) AS user_name FROM module_projects_notes n LEFT JOIN users u ON n.user_id = u.id LEFT JOIN person p ON u.id = p.user_id WHERE n.project_id = :id ORDER BY n.date_created DESC');
       $notesStmt->execute([':id' => $project_id]);
       $notes = $notesStmt->fetchAll(PDO::FETCH_ASSOC);
 


### PR DESCRIPTION
## Summary
- Remove permission gate from note and file deletion and redirect back to project details
- Expose note/file owners in index results for permission checks
- Add delete controls for notes and uploaded files when owned by current user

## Testing
- `php -l module/project/functions/delete_note.php`
- `php -l module/project/functions/delete_file.php`
- `php -l module/project/include/details_view.php`
- `php -l module/project/index.php`


------
https://chatgpt.com/codex/tasks/task_e_689f85475cfc83339273cc4338289567