### PR TITLE
Refactor task notes and files handling

### DIFF
--- a/module/task/index.php
+++ b/module/task/index.php
@@ -155,18 +155,14 @@ if ($action === 'details') {
     $notes = $notesStmt->fetchAll(PDO::FETCH_ASSOC);
 
     $taskFiles = [];
-    $noteFilesMap = [];
+    $noteFiles = [];
     foreach ($files as $f) {
       if (!empty($f['note_id'])) {
-        $noteFilesMap[$f['note_id']][] = $f;
+        $noteFiles[$f['note_id']][] = $f;
       } else {
         $taskFiles[] = $f;
       }
     }
-    foreach ($notes as &$n) {
-      $n['files'] = $noteFilesMap[$n['id']] ?? [];
-    }
-    unset($n);
   }
 } elseif ($action === 'create-edit' && isset($_GET['id'])) {
   $task_id = (int)($_GET['id'] ?? 0);


### PR DESCRIPTION
## Summary
- keep task notes and task-level files as separate arrays for details view
- overhaul task details sidebar with Phoenix-style "Task Notes" timeline and files list
- add shared image preview modal used by note attachments and task files

## Testing
- `php -l module/task/index.php`
- `php -l module/task/include/details_view.php`


------
https://chatgpt.com/codex/tasks/task_e_689f9b96cfa483338705d4bbf1549e68