### PR TITLE
feat(project): add card view template and task metrics

### DIFF
--- a/module/project/include/card_view.php
+++ b/module/project/include/card_view.php
@@ -26,7 +26,7 @@ foreach ($projects as $proj) {
     <ul class="nav nav-links mx-n2 project-tab">
       <li class="nav-item"><a class="nav-link px-2 py-1 active" aria-current="page" href="#"><span>All</span><span class="text-body-tertiary fw-semibold">(<?php echo count($projects); ?>)</span></a></li>
       <?php foreach (['Ongoing','Cancelled','Finished','Postponed'] as $tab): ?>
-      <li class="nav-item"><a class="nav-link px-2 py-1" href="#"><span><?php echo $tab; ?></span><span class="text-body-tertiary fw-semibold">(<?php echo $statusCounts[$tab] ?? 0; ?>)</span></a></li>
+      <li class="nav-item"><a class="nav-link px-2 py-1" href="#"><span><?php echo $tab; ?></span><span class="text-body-tertiary fw-semibold"><?php echo $statusCounts[$tab] ?? 0; ?></span></a></li>
       <?php endforeach; ?>
     </ul>
   </div>
@@ -38,11 +38,24 @@ foreach ($projects as $proj) {
           <span class="fas fa-search search-box-icon"></span>
         </form>
       </div>
+      <a class="btn btn-phoenix-primary px-3 me-1" href="index.php?action=list" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="List view"><span class="fa-solid fa-list fs-10"></span></a>
+      <a class="btn btn-phoenix-primary px-3 border-0 text-body" href="index.php?action=card" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="Card view">
+        <svg width="9" height="9" viewBox="0 0 9 9" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M0 0.5C0 0.223858 0.223858 0 0.5 0H3.5C3.77614 0 4 0.223858 4 0.5V3.5C4 3.77614 3.77614 4 3.5 4H0.5C0.223858 4 0 3.77614 0 3.5V0.5Z" fill="currentColor"/>
+          <path d="M0 5.5C0 5.22386 0.223858 5 0.5 5H3.5C3.77614 5 4 5.22386 4 5.5V8.5C4 8.77614 3.77614 9 3.5 9H0.5C0.223858 9 0 8.77614 0 8.5V5.5Z" fill="currentColor"/>
+          <path d="M5 0.5C5 0.223858 5.22386 0 5.5 0H8.5C8.77614 0 9 0.223858 9 0.5V3.5C9 3.77614 8.77614 4 8.5 4H5.5C5.22386 4 5 3.77614 5 3.5V0.5Z" fill="currentColor"/>
+          <path d="M5 5.5C5 5.22386 5.22386 5 5.5 5H8.5C8.77614 5 9 5.22386 9 5.5V8.5C9 8.77614 8.77614 9 8.5 9H5.5C5.22386 9 5 8.77614 5 8.5V5.5Z" fill="currentColor"/>
+        </svg>
+      </a>
     </div>
   </div>
 </div>
 <div class="row row-cols-1 row-cols-sm-2 row-cols-xl-3 row-cols-xxl-4 g-3 mb-9">
   <?php foreach ($projects as $project): ?>
+  <?php
+    $completed = $project['total_tasks'] - $project['in_progress'];
+    $progress = $project['total_tasks'] > 0 ? intval(($completed / $project['total_tasks']) * 100) : 0;
+  ?>
   <div class="col">
     <div class="card h-100 hover-actions-trigger">
       <div class="card-body position-relative">
@@ -55,8 +68,10 @@ foreach ($projects as $proj) {
           </div>
         </div>
         <span class="badge badge-phoenix fs-10 mb-4 badge-phoenix-<?php echo h($project['status_color'] ?? 'secondary'); ?>"><?php echo h($project['status_label'] ?? ''); ?></span>
-        <?php if (!empty($project['description'])): ?>
-        <p class="text-body-secondary line-clamp-2 mb-4"><?php echo h($project['description']); ?></p>
+        <?php if (!empty($project['agency_name']) || !empty($project['division_name'])): ?>
+        <p class="text-body-secondary line-clamp-2 mb-4">
+          <?php echo h($project['agency_name']); ?><?php if (!empty($project['division_name'])) echo ' / ' . h($project['division_name']); ?>
+        </p>
         <?php endif; ?>
         <?php if (!empty($project['start_date'])): ?>
         <div class="d-flex align-items-center mt-4">
@@ -66,6 +81,23 @@ foreach ($projects as $proj) {
         <?php if (!empty($project['complete_date'])): ?>
         <div class="d-flex align-items-center mt-2">
           <p class="mb-0 fw-bold fs-9">Deadline : <span class="fw-semibold text-body-tertiary text-opactity-85 ms-1"><?php echo h(date('F jS, Y', strtotime($project['complete_date']))); ?></span></p>
+        </div>
+        <?php endif; ?>
+        <div class="d-flex justify-content-between text-body-tertiary fw-semibold mt-3">
+          <p class="mb-2">Progress</p>
+          <p class="mb-2 text-body-emphasis"><?php echo $project['in_progress']; ?>/<?php echo $project['total_tasks']; ?></p>
+        </div>
+        <div class="progress bg-success-subtle">
+          <div class="progress-bar rounded bg-success" role="progressbar" style="width: <?php echo $progress; ?>%" aria-valuenow="<?php echo $progress; ?>" aria-valuemin="0" aria-valuemax="100"></div>
+        </div>
+        <?php if (!empty($project['assignees'])): ?>
+        <div class="avatar-group mt-3">
+          <?php foreach ($project['assignees'] as $assignee): ?>
+            <?php $pic = !empty($assignee['profile_pic']) ? 'module/users/uploads/' . $assignee['profile_pic'] : 'assets/img/team/avatar.webp'; ?>
+            <div class="avatar avatar-m rounded-circle">
+              <img class="rounded-circle" src="<?php echo getURLDir() . h($pic); ?>" alt="<?= h($assignee['name']); ?>" />
+            </div>
+          <?php endforeach; ?>
         </div>
         <?php endif; ?>
         <a class="stretched-link" href="index.php?action=details&id=<?php echo $project['id']; ?>"></a>


### PR DESCRIPTION
## Summary
- implement Phoenix-based card view with search, status tabs, and progress metrics
- query projects with task counts and agency/division info

## Testing
- `php -l module/project/index.php`
- `php -l module/project/include/card_view.php`


------
https://chatgpt.com/codex/tasks/task_e_689f9f5c1fc083339e767a807ba260e2