### PR TITLE
Add task hierarchy details and modal editing

### DIFF
--- a/module/task/include/list_view.php
+++ b/module/task/include/list_view.php
@@ -24,15 +24,21 @@
   </div>
   <div class="mb-4 todo-list">
     <?php foreach ($tasks as $task): ?>
-      <div class="row justify-content-between align-items-md-center hover-actions-trigger btn-reveal-trigger border-translucent py-3 gx-0 cursor-pointer border-top task-row" data-task-id="<?php echo (int)$task['id']; ?>">
+      <div class="row justify-content-between align-items-md-center hover-actions-trigger btn-reveal-trigger border-translucent py-3 gx-0 border-top task-row">
         <div class="col-auto">
-          <a href="index.php?action=edit&amp;id=<?php echo (int)$task['id']; ?>" class="btn btn-warning btn-sm edit-task-btn me-2" data-event-propagation-prevent="data-event-propagation-prevent"><?php echo (int)$task['id']; ?> - Edit</a>
+          <button type="button" class="btn btn-warning btn-sm edit-task-btn me-2" data-task-id="<?php echo (int)$task['id']; ?>" data-event-propagation-prevent="data-event-propagation-prevent"><?php echo (int)$task['id']; ?></button>
+        </div>
+        <div class="col-auto">
+          <?php $hierarchy = $task['project_name'] ?? $task['division_name'] ?? $task['agency_name'] ?? ''; ?>
+          <?php if ($hierarchy): ?>
+            <span class="badge badge-phoenix-info"><?php echo h($hierarchy); ?></span>
+          <?php endif; ?>
         </div>
         <div class="col-12 col-md flex-1 position-relative" style="z-index:1;">
           <div>
             <div class="form-check mb-1 mb-md-0 d-flex align-items-center lh-1 position-relative" style="z-index:1;">
-              <input class="form-check-input flex-shrink-0 form-check-line-through mt-0 me-2" type="checkbox" id="checkbox-todo-<?php echo (int)$task['id']; ?>" data-event-propagation-prevent="data-event-propagation-prevent" data-task-id="<?php echo (int)$task['id']; ?>" <?php echo (!empty($task['completed']) ? 'checked' : ''); ?> />
-              <label class="form-check-label mb-0 fs-8 me-2 line-clamp-1 flex-grow-1 flex-md-grow-0 cursor-pointer<?php echo (!empty($task['completed']) ? ' text-decoration-line-through' : ''); ?>" for="checkbox-todo-<?php echo (int)$task['id']; ?>"><?php echo h($task['name'] ?? ''); ?></label>
+              <input class="form-check-input flex-shrink-0 form-check-line-through mt-0 me-2" type="checkbox" id="checkbox-todo-<?php echo (int)$task['id']; ?>" data-task-id="<?php echo (int)$task['id']; ?>" <?php echo (!empty($task['completed']) ? 'checked' : ''); ?> />
+              <a href="index.php?action=details&amp;id=<?php echo (int)$task['id']; ?>" class="mb-0 fs-8 me-2 line-clamp-1 flex-grow-1 flex-md-grow-0 task-name-link<?php echo (!empty($task['completed']) ? ' text-decoration-line-through' : ''); ?>"><?php echo h($task['name'] ?? ''); ?></a>
               <span class="badge badge-phoenix fs-10 badge-phoenix-<?php echo h($task['status_color'] ?? 'secondary'); ?> me-2"><?php echo h($task['status_label'] ?? ''); ?></span>
               <span class="badge badge-phoenix fs-10 badge-phoenix-<?php echo h($task['priority_color'] ?? 'primary'); ?>"><?php echo h($task['priority_label'] ?? ''); ?></span>
             </div>
@@ -43,16 +49,14 @@
   </div>
 </div>
 
+<div class="modal fade" id="taskEditModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-xl">
+    <div class="modal-content"></div>
+  </div>
+</div>
+
 <script>
 document.addEventListener('DOMContentLoaded', function () {
-  document.querySelectorAll('.todo-list .task-row').forEach(function (row) {
-    row.addEventListener('click', function () {
-      const id = this.dataset.taskId;
-      if (id) {
-        window.location.href = 'index.php?action=details&id=' + id;
-      }
-    });
-  });
   document.querySelectorAll('.todo-list input[type="checkbox"][data-task-id]').forEach(function (checkbox) {
     checkbox.addEventListener('click', function (event) {
       event.stopPropagation();
@@ -60,7 +64,7 @@ document.addEventListener('DOMContentLoaded', function () {
     checkbox.addEventListener('change', function () {
       const taskId = this.dataset.taskId;
       const newState = this.checked ? 1 : 0;
-      const label = this.nextElementSibling;
+      const link = this.nextElementSibling;
       fetch('functions/toggle_complete.php', {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -72,20 +76,29 @@ document.addEventListener('DOMContentLoaded', function () {
           } else {
             this.checked = !newState;
           }
-          label.classList.toggle('text-decoration-line-through', this.checked);
+          link.classList.toggle('text-decoration-line-through', this.checked);
         }).catch(() => {
           this.checked = !newState;
-          label.classList.toggle('text-decoration-line-through', this.checked);
+          link.classList.toggle('text-decoration-line-through', this.checked);
         });
     });
   });
   document.querySelectorAll('.todo-list .edit-task-btn').forEach(function (btn) {
     btn.addEventListener('click', function (event) {
       event.stopPropagation();
+      const id = this.dataset.taskId;
+      fetch('index.php?action=create-edit&id=' + id)
+        .then(response => response.text())
+        .then(html => {
+          const modalEl = document.getElementById('taskEditModal');
+          modalEl.querySelector('.modal-content').innerHTML = html;
+          const modal = new bootstrap.Modal(modalEl);
+          modal.show();
+        });
     });
   });
-  document.querySelectorAll('.todo-list .form-check-label').forEach(function (label) {
-    label.addEventListener('click', function (event) {
+  document.querySelectorAll('.todo-list .task-name-link').forEach(function (link) {
+    link.addEventListener('click', function (event) {
       event.stopPropagation();
     });
   });

--- a/module/task/index.php
+++ b/module/task/index.php
@@ -78,8 +78,14 @@ $statusMap = array_column(get_lookup_items($pdo, 'TASK_STATUS'), null, 'id');
 
 $stmt = $pdo->query('SELECT t.id, t.name, t.status, t.priority, t.completed,
                              COALESCE(p_attr.attr_value, "secondary") AS priority_color,
-                             p.label AS priority_label
+                             p.label AS priority_label,
+                             pr.name AS project_name,
+                             d.name AS division_name,
+                             a.name AS agency_name
                       FROM module_tasks t
+                      LEFT JOIN module_projects pr ON t.project_id = pr.id
+                      LEFT JOIN module_division d ON t.division_id = d.id
+                      LEFT JOIN module_agency a ON t.agency_id = a.id
                       LEFT JOIN lookup_list_items p ON t.priority = p.id
                       LEFT JOIN lookup_list_item_attributes p_attr
                              ON p.id = p_attr.item_id AND p_attr.attr_code = "COLOR-CLASS"


### PR DESCRIPTION
## Summary
- show associated project/division/agency names when listing tasks
- restructure task list rows with direct links and modal editing
- load task edit form into Bootstrap modal via AJAX

## Testing
- `php -l module/task/index.php`
- `php -l module/task/include/list_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68a1181c691083339593765b277dc922