### PR TITLE
Validate user names server-side

### DIFF
--- a/admin/users/edit.php
+++ b/admin/users/edit.php
@@ -66,10 +66,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $last_name  = trim($_POST['last_name'] ?? '');
     $roleIds    = $_POST['roles'] ?? [];
 
-    if ($username === '' || $email === '') {
-        $error = 'Username and email are required.';
+    if ($username === '' || $email === '' || $first_name === '' || $last_name === '') {
+        $error = 'Username, email, first name and last name are required.';
     } elseif (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
         $error = 'Invalid email address.';
+    } elseif (strlen($first_name) > 100 || strlen($last_name) > 100) {
+        $error = 'First name and last name must be 100 characters or fewer.';
     } else {
         $stmt = $pdo->prepare('SELECT id FROM users WHERE username = :username AND id != :id');
         $stmt->execute([':username'=>$username, ':id'=>$id]);

--- a/admin/users/new.php
+++ b/admin/users/new.php
@@ -47,10 +47,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   $last_name = trim($_POST['last_name'] ?? '');
   $roleIds = $_POST['roles'] ?? [];
 
-  if ($username === '' || $email === '' || $password === '') {
-    $error = 'Username, email and password are required.';
+  if ($username === '' || $email === '' || $password === '' || $first_name === '' || $last_name === '') {
+    $error = 'Username, email, password, first name and last name are required.';
   } elseif (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
     $error = 'Invalid email address.';
+  } elseif (strlen($first_name) > 100 || strlen($last_name) > 100) {
+    $error = 'First name and last name must be 100 characters or fewer.';
   } else {
     $stmt = $pdo->prepare('SELECT id FROM users WHERE username = :username');
     $stmt->execute([':username'=>$username]);


### PR DESCRIPTION
## Summary
- require first and last name when creating new users
- enforce first/last name on user update with length check

## Testing
- `php -l admin/users/new.php`
- `php -l admin/users/edit.php`


------
https://chatgpt.com/codex/tasks/task_e_68a118e7106083338a4eb3f6058e5270