### PR TITLE
Use wizard Next button for submission

### DIFF
--- a/admin/users/form_edit.php
+++ b/admin/users/form_edit.php
@@ -102,8 +102,9 @@ if (!defined('IN_APP')) {
   <div class="card-footer border-top-0" data-wizard-footer="data-wizard-footer">
     <div class="d-flex pager wizard list-inline mb-0">
       <button class="d-none btn btn-link ps-0" type="button" data-wizard-prev-btn="data-wizard-prev-btn"><span class="fas fa-chevron-left me-1" data-fa-transform="shrink-3"></span>Previous</button>
-      <button class="btn btn-primary px-6" type="button" data-wizard-next-btn="data-wizard-next-btn">Next<span class="fas fa-chevron-right ms-1" data-fa-transform="shrink-3"></span></button>
-      <button class="btn <?= $btnClass; ?> d-none ms-auto" type="submit" data-wizard-submit-btn="data-wizard-submit-btn">Save</button>
+      <button class="btn btn-primary px-6" type="submit" data-wizard-next-btn="data-wizard-next-btn">
+        Next<span class="fas fa-chevron-right ms-1" data-fa-transform="shrink-3"></span>
+      </button>
     </div>
   </div>
 </div>

--- a/admin/users/form_new.php
+++ b/admin/users/form_new.php
@@ -99,8 +99,9 @@ if (!defined('IN_APP')) {
   <div class="card-footer border-top-0" data-wizard-footer="data-wizard-footer">
     <div class="d-flex pager wizard list-inline mb-0">
       <button class="d-none btn btn-link ps-0" type="button" data-wizard-prev-btn="data-wizard-prev-btn"><span class="fas fa-chevron-left me-1" data-fa-transform="shrink-3"></span>Previous</button>
-      <button class="btn btn-primary px-6" type="button" data-wizard-next-btn="data-wizard-next-btn">Next<span class="fas fa-chevron-right ms-1" data-fa-transform="shrink-3"></span></button>
-      <button class="btn <?= $btnClass; ?> d-none ms-auto" type="submit" data-wizard-submit-btn="data-wizard-submit-btn">Save</button>
+      <button class="btn btn-primary px-6" type="submit" data-wizard-next-btn="data-wizard-next-btn">
+        Next<span class="fas fa-chevron-right ms-1" data-fa-transform="shrink-3"></span>
+      </button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- remove extra save button in user wizard forms
- let Next button submit wizard and display Save on final step

## Testing
- `php -l admin/users/form_new.php`
- `php -l admin/users/form_edit.php`


------
https://chatgpt.com/codex/tasks/task_e_68a1349cdf408333be733f4d8274f7fe