### PR TITLE
Refine task views and note deletion

### DIFF
--- a/module/task/functions/delete_note.php
+++ b/module/task/functions/delete_note.php
@@ -8,6 +8,17 @@ if ($note_id && $task_id) {
   $stmt->execute([':id' => $note_id, ':tid' => $task_id]);
   $note = $stmt->fetch(PDO::FETCH_ASSOC);
   if ($note && (int)$note['user_id'] === (int)$this_user_id) {
+    $stmtFiles = $pdo->prepare('SELECT id, file_path, file_name FROM module_tasks_files WHERE note_id = :id');
+    $stmtFiles->execute([':id' => $note_id]);
+    $files = $stmtFiles->fetchAll(PDO::FETCH_ASSOC);
+    foreach ($files as $file) {
+      $pdo->prepare('DELETE FROM module_tasks_files WHERE id = :fid')->execute([':fid' => $file['id']]);
+      $fullPath = __DIR__ . '/../../..' . $file['file_path'];
+      if (is_file($fullPath)) {
+        unlink($fullPath);
+      }
+      admin_audit_log($pdo, $this_user_id, 'module_tasks_files', $file['id'], 'DELETE', '', json_encode(['file' => $file['file_name']]));
+    }
     $pdo->prepare('DELETE FROM module_tasks_notes WHERE id = :id')->execute([':id' => $note_id]);
     admin_audit_log($pdo, $this_user_id, 'module_tasks_notes', $note_id, 'DELETE', '', $note['note_text']);
   }

--- a/module/task/include/create_edit_view.php
+++ b/module/task/include/create_edit_view.php
@@ -31,6 +31,6 @@ $actionUrl = $editing ? 'functions/update.php' : 'functions/create.php';
     <label class="form-label">Description</label>
     <textarea name="description" class="form-control" rows="4"><?php echo h($current_task['description'] ?? ''); ?></textarea>
   </div>
-  <button type="submit" class="btn btn-primary"><?php echo $editing ? 'Update' : 'Create'; ?></button>
+  <button type="submit" class="btn <?php echo $editing ? 'btn-atlis' : 'btn-success'; ?>"><?php echo $editing ? 'Update' : 'Create'; ?></button>
 </form>
 

--- a/module/task/include/details_view.php
+++ b/module/task/include/details_view.php
@@ -117,7 +117,7 @@ require_once __DIR__ . '/../../../includes/functions.php';
                         <form action="functions/delete_note.php" method="post" class="ms-2" onsubmit="return confirm('Delete this note?');">
                           <input type="hidden" name="id" value="<?= (int)$n['id'] ?>">
                           <input type="hidden" name="task_id" value="<?= (int)$current_task['id'] ?>">
-                          <button class="btn btn-link p-0 text-danger" type="submit"><span class="fa-solid fa-trash"></span></button>
+                          <button class="btn btn-danger btn-sm" type="submit"><span class="fa-solid fa-trash"></span></button>
                         </form>
                         <?php endif; ?>
                       </div>
@@ -158,7 +158,7 @@ require_once __DIR__ . '/../../../includes/functions.php';
               <div class="mb-3">
                 <input class="form-control" type="file" name="files[]" multiple>
               </div>
-              <center><button class="btn btn-atlis" type="submit">Add Note</button></center>
+              <center><button class="btn btn-success" type="submit">Add Note</button></center>
             </form>
           </div>
           <?php endif; ?>
@@ -173,7 +173,7 @@ require_once __DIR__ . '/../../../includes/functions.php';
             <div class="input-group">
               <input type="hidden" name="id" value="<?= (int)$current_task['id'] ?>">
               <input class="form-control" type="file" name="file" id="taskFileUpload" aria-describedby="taskFileUpload" aria-label="Upload" required>
-              <button class="btn btn-atlis" type="submit">Upload New</button>
+              <button class="btn btn-success" type="submit">Upload New</button>
             </div>
           </form>
         </div>
@@ -196,7 +196,7 @@ require_once __DIR__ . '/../../../includes/functions.php';
                 <form action="functions/delete_file.php" method="post" onsubmit="return confirm('Delete this file?');">
                   <input type="hidden" name="id" value="<?= (int)$f['id'] ?>">
                   <input type="hidden" name="task_id" value="<?= (int)$current_task['id'] ?>">
-                  <button class="btn btn-link p-0 text-danger" type="submit"><span class="fa-solid fa-trash"></span></button>
+                  <button class="btn btn-danger btn-sm" type="submit"><span class="fa-solid fa-trash"></span></button>
                 </form>
                 <?php endif; ?>
               </div>


### PR DESCRIPTION
## Summary
- Use success styling for note creation and uploads, and small danger buttons for deletions in task details
- Switch task form to success vs. atlis button depending on create or update
- Remove note attachments and files when deleting a note and ensure modal image paths are rooted

## Testing
- `php -l module/task/include/details_view.php`
- `php -l module/task/include/create_edit_view.php`
- `php -l module/task/functions/delete_note.php`


------
https://chatgpt.com/codex/tasks/task_e_68a134bc3a188333a8fe61deaeafdf44