### PR TITLE
Keep wizard footer visible and show submit on final step

### DIFF
--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -4331,7 +4331,8 @@
       CONFIRM_PASSWORD_INPUT: '[data-wizard-confirm-password]',
       NEXT_BTN: '[data-wizard-next-btn]',
       PREV_BTN: '[data-wizard-prev-btn]',
-      FOOTER: '[data-wizard-footer]'
+      FOOTER: '[data-wizard-footer]',
+      SUBMIT_BTN: '[data-wizard-submit-btn]'
     };
 
     const events = {
@@ -4354,6 +4355,7 @@
       );
       const nextButton = wizard.querySelector(selectors.NEXT_BTN);
       const prevButton = wizard.querySelector(selectors.PREV_BTN);
+      const submitButton = wizard.querySelector(selectors.SUBMIT_BTN);
       const wizardFooter = wizard.querySelector(selectors.FOOTER);
       const submitEvent = new Event(events.SUBMIT, {
         bubbles: true,
@@ -4436,15 +4438,24 @@
               }
             }
 
-            // card footer remove at last step
-            if (count > tabToggleButtonEl.length - 2) {
-              wizardFooter.classList.add('d-none');
-            } else {
+            if (wizardFooter) {
               wizardFooter.classList.remove('d-none');
             }
-            // prev-button removing
+
+            if (count === tabToggleButtonEl.length - 1) {
+              nextButton.classList.add('d-none');
+              if (submitButton) {
+                submitButton.classList.remove('d-none');
+              }
+            } else {
+              nextButton.classList.remove('d-none');
+              if (submitButton) {
+                submitButton.classList.add('d-none');
+              }
+            }
+
             if (prevButton) {
-              if (count > 0 && count !== tabToggleButtonEl.length - 1) {
+              if (count > 0) {
                 prevButton.classList.remove('d-none');
               } else {
                 prevButton.classList.add('d-none');

--- a/src/js/theme/wizard.js
+++ b/src/js/theme/wizard.js
@@ -13,7 +13,8 @@ const wizardInit = () => {
     CONFIRM_PASSWORD_INPUT: '[data-wizard-confirm-password]',
     NEXT_BTN: '[data-wizard-next-btn]',
     PREV_BTN: '[data-wizard-prev-btn]',
-    FOOTER: '[data-wizard-footer]'
+    FOOTER: '[data-wizard-footer]',
+    SUBMIT_BTN: '[data-wizard-submit-btn]'
   };
 
   const events = {
@@ -36,6 +37,7 @@ const wizardInit = () => {
     );
     const nextButton = wizard.querySelector(selectors.NEXT_BTN);
     const prevButton = wizard.querySelector(selectors.PREV_BTN);
+    const submitButton = wizard.querySelector(selectors.SUBMIT_BTN);
     const wizardFooter = wizard.querySelector(selectors.FOOTER);
     const submitEvent = new Event(events.SUBMIT, {
       bubbles: true,
@@ -118,15 +120,24 @@ const wizardInit = () => {
             }
           }
 
-          // card footer remove at last step
-          if (count > tabToggleButtonEl.length - 2) {
-            wizardFooter.classList.add('d-none');
-          } else {
+          if (wizardFooter) {
             wizardFooter.classList.remove('d-none');
           }
-          // prev-button removing
+
+          if (count === tabToggleButtonEl.length - 1) {
+            nextButton.classList.add('d-none');
+            if (submitButton) {
+              submitButton.classList.remove('d-none');
+            }
+          } else {
+            nextButton.classList.remove('d-none');
+            if (submitButton) {
+              submitButton.classList.add('d-none');
+            }
+          }
+
           if (prevButton) {
-            if (count > 0 && count !== tabToggleButtonEl.length - 1) {
+            if (count > 0) {
               prevButton.classList.remove('d-none');
             } else {
               prevButton.classList.add('d-none');


### PR DESCRIPTION
## Summary
- add submit button selector and logic to show it on final wizard step while hiding Next
- keep wizard footer visible so the Previous button remains accessible
- update compiled phoenix.js with corresponding changes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a163e69ae08333b6e08d234ac933dd