### PR TITLE
Refactor admin user wizard to two steps

### DIFF
--- a/admin/users/form_edit.php
+++ b/admin/users/form_edit.php
@@ -18,9 +18,6 @@ if (!defined('IN_APP')) {
       <li class="nav-item"><a class="nav-link fw-semibold" href="#user-tab2" data-bs-toggle="tab" data-wizard-step="2">
           <div class="text-center d-inline-block"><span class="nav-item-circle-parent"><span class="nav-item-circle"><span class="fas fa-user"></span></span></span><span class="d-none d-md-block mt-1 fs-9">Details</span></div>
         </a></li>
-      <li class="nav-item"><a class="nav-link fw-semibold" href="#user-tab3" data-bs-toggle="tab" data-wizard-step="3">
-          <div class="text-center d-inline-block"><span class="nav-item-circle-parent"><span class="nav-item-circle"><span class="fas fa-check"></span></span></span><span class="d-none d-md-block mt-1 fs-9">Done</span></div>
-        </a></li>
     </ul>
   </div>
   <div class="card-body pt-4 pb-0">
@@ -55,6 +52,7 @@ if (!defined('IN_APP')) {
       </div>
       <div class="tab-pane" role="tabpanel" id="user-tab2" aria-labelledby="user-tab2">
         <form class="needs-validation" novalidate data-wizard-form="2" method="post">
+          <input type="hidden" name="csrf_token" value="<?= $token; ?>">
           <div class="mb-3">
             <label class="form-label">First Name</label>
             <input type="text" class="form-control" name="first_name" value="<?= htmlspecialchars($first_name); ?>">
@@ -91,20 +89,15 @@ if (!defined('IN_APP')) {
           </div>
         </form>
       </div>
-      <div class="tab-pane" role="tabpanel" id="user-tab3" aria-labelledby="user-tab3">
-        <form class="needs-validation" novalidate data-wizard-form="3" method="post">
-          <input type="hidden" name="csrf_token" value="<?= $token; ?>">
-          <p class="fs-9 text-700 mb-0">Review your changes and click Save to update the user.</p>
-        </form>
-      </div>
     </div>
   </div>
   <div class="card-footer border-top-0" data-wizard-footer="data-wizard-footer">
     <div class="d-flex pager wizard list-inline mb-0">
-      <button class="d-none btn btn-link ps-0" type="button" data-wizard-prev-btn="data-wizard-prev-btn"><span class="fas fa-chevron-left me-1" data-fa-transform="shrink-3"></span>Previous</button>
-      <button class="btn btn-primary px-6" type="submit" data-wizard-next-btn="data-wizard-next-btn">
+      <button class="btn btn-link ps-0 d-none" type="button" data-wizard-prev-btn="data-wizard-prev-btn"><span class="fas fa-chevron-left me-1" data-fa-transform="shrink-3"></span>Previous</button>
+      <button class="btn btn-primary px-6" type="button" data-wizard-next-btn="data-wizard-next-btn">
         Next<span class="fas fa-chevron-right ms-1" data-fa-transform="shrink-3"></span>
       </button>
+      <button class="btn btn-primary px-6 d-none" type="submit" data-wizard-submit-btn="data-wizard-submit-btn">Save</button>
     </div>
   </div>
 </div>

--- a/admin/users/form_new.php
+++ b/admin/users/form_new.php
@@ -18,9 +18,6 @@ if (!defined('IN_APP')) {
       <li class="nav-item"><a class="nav-link fw-semibold" href="#user-tab2" data-bs-toggle="tab" data-wizard-step="2">
           <div class="text-center d-inline-block"><span class="nav-item-circle-parent"><span class="nav-item-circle"><span class="fas fa-user"></span></span></span><span class="d-none d-md-block mt-1 fs-9">Details</span></div>
         </a></li>
-      <li class="nav-item"><a class="nav-link fw-semibold" href="#user-tab3" data-bs-toggle="tab" data-wizard-step="3">
-          <div class="text-center d-inline-block"><span class="nav-item-circle-parent"><span class="nav-item-circle"><span class="fas fa-check"></span></span></span><span class="d-none d-md-block mt-1 fs-9">Done</span></div>
-        </a></li>
     </ul>
   </div>
   <div class="card-body pt-4 pb-0">
@@ -51,6 +48,7 @@ if (!defined('IN_APP')) {
       </div>
       <div class="tab-pane" role="tabpanel" id="user-tab2" aria-labelledby="user-tab2">
         <form class="needs-validation" novalidate data-wizard-form="2" method="post">
+          <input type="hidden" name="csrf_token" value="<?= $token; ?>">
           <div class="mb-3">
             <label class="form-label">First Name</label>
             <input type="text" class="form-control" name="first_name">
@@ -88,20 +86,15 @@ if (!defined('IN_APP')) {
 
         </form>
       </div>
-      <div class="tab-pane" role="tabpanel" id="user-tab3" aria-labelledby="user-tab3">
-        <form class="needs-validation" novalidate data-wizard-form="3" method="post">
-          <input type="hidden" name="csrf_token" value="<?= $token; ?>">
-          <p class="fs-9 text-700 mb-0">Review your information and click Save to create the user.</p>
-        </form>
-      </div>
     </div>
   </div>
   <div class="card-footer border-top-0" data-wizard-footer="data-wizard-footer">
     <div class="d-flex pager wizard list-inline mb-0">
-      <button class="d-none btn btn-link ps-0" type="button" data-wizard-prev-btn="data-wizard-prev-btn"><span class="fas fa-chevron-left me-1" data-fa-transform="shrink-3"></span>Previous</button>
-      <button class="btn btn-primary px-6" type="submit" data-wizard-next-btn="data-wizard-next-btn">
+      <button class="btn btn-link ps-0 d-none" type="button" data-wizard-prev-btn="data-wizard-prev-btn"><span class="fas fa-chevron-left me-1" data-fa-transform="shrink-3"></span>Previous</button>
+      <button class="btn btn-primary px-6" type="button" data-wizard-next-btn="data-wizard-next-btn">
         Next<span class="fas fa-chevron-right ms-1" data-fa-transform="shrink-3"></span>
       </button>
+      <button class="btn btn-primary px-6 d-none" type="submit" data-wizard-submit-btn="data-wizard-submit-btn">Save</button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- remove "Done" step from admin user creation/edit forms
- move CSRF token to second form step
- update wizard footer buttons for prev/next/save workflow

## Testing
- `php -l admin/users/form_new.php`
- `php -l admin/users/form_edit.php`


------
https://chatgpt.com/codex/tasks/task_e_68a163e6b4a483338d1923a5fc15c3b8