### PR TITLE
feat(task): sync status with completion

### DIFF
--- a/module/task/functions/toggle_complete.php
+++ b/module/task/functions/toggle_complete.php
@@ -7,18 +7,36 @@ header('Content-Type: application/json');
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   $id = (int)($_POST['id'] ?? 0);
   $completed = isset($_POST['completed']) ? (int)$_POST['completed'] : 0;
+  $statusId = isset($_POST['status']) ? (int)$_POST['status'] : 0;
   if ($id > 0) {
     if ($completed === 1) {
-      $stmt = $pdo->prepare('UPDATE module_tasks SET completed = 1, completed_by = :uid, complete_date = NOW(), progress_percent = 100, user_updated = :uid WHERE id = :id');
+      $statusStmt = $pdo->prepare("SELECT li.id, li.label, COALESCE(attr.attr_value, 'secondary') AS color_class FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id LEFT JOIN lookup_list_item_attributes attr ON li.id = attr.item_id AND attr.attr_code = 'COLOR-CLASS' WHERE l.name = 'TASK_STATUS' AND li.code = 'COMPLETED' LIMIT 1");
+      $statusStmt->execute();
+      $statusRow = $statusStmt->fetch(PDO::FETCH_ASSOC) ?: [];
+      $statusId = (int)($statusRow['id'] ?? 0);
+      $statusLabel = $statusRow['label'] ?? '';
+      $statusColor = $statusRow['color_class'] ?? 'secondary';
+      $stmt = $pdo->prepare('UPDATE module_tasks SET completed = 1, completed_by = :uid, complete_date = NOW(), progress_percent = 100, user_updated = :uid, status = :status WHERE id = :id');
     } else {
-      $stmt = $pdo->prepare('UPDATE module_tasks SET completed = 0, completed_by = NULL, complete_date = NULL, progress_percent = 0, user_updated = :uid WHERE id = :id');
+      if (!$statusId) {
+        $origStmt = $pdo->prepare('SELECT status FROM module_tasks WHERE id = :id');
+        $origStmt->execute([':id' => $id]);
+        $statusId = (int)$origStmt->fetchColumn();
+      }
+      $statusStmt = $pdo->prepare("SELECT li.label, COALESCE(attr.attr_value, 'secondary') AS color_class FROM lookup_list_items li LEFT JOIN lookup_list_item_attributes attr ON li.id = attr.item_id AND attr.attr_code = 'COLOR-CLASS' WHERE li.id = :id LIMIT 1");
+      $statusStmt->execute([':id' => $statusId]);
+      $statusRow = $statusStmt->fetch(PDO::FETCH_ASSOC) ?: [];
+      $statusLabel = $statusRow['label'] ?? '';
+      $statusColor = $statusRow['color_class'] ?? 'secondary';
+      $stmt = $pdo->prepare('UPDATE module_tasks SET completed = 0, completed_by = NULL, complete_date = NULL, progress_percent = 0, user_updated = :uid, status = :status WHERE id = :id');
     }
     $stmt->execute([
       ':uid' => $this_user_id,
-      ':id' => $id
+      ':id' => $id,
+      ':status' => $statusId
     ]);
     audit_log($pdo, $this_user_id, 'module_tasks', $id, 'UPDATE', $completed ? 'Completed task' : 'Marked task incomplete');
-    echo json_encode(['success' => true, 'completed' => $completed]);
+    echo json_encode(['success' => true, 'completed' => $completed, 'status_label' => $statusLabel ?? '', 'status_color' => $statusColor ?? 'secondary']);
     exit;
   }
 }

--- a/module/task/include/list_view.php
+++ b/module/task/include/list_view.php
@@ -31,10 +31,10 @@
         <div class="col-12 col-md flex-1 position-relative" style="z-index:1;">
           <div>
             <div class="form-check mb-1 mb-md-0 d-flex align-items-center lh-1 position-relative" style="z-index:1;">
-              <input class="form-check-input flex-shrink-0 form-check-line-through mt-0 me-2" type="checkbox" id="checkbox-todo-<?php echo (int)$task['id']; ?>" data-task-id="<?php echo (int)$task['id']; ?>" <?php echo (!empty($task['completed']) ? 'checked' : ''); ?> />
+              <input class="form-check-input flex-shrink-0 form-check-line-through mt-0 me-2" type="checkbox" id="checkbox-todo-<?php echo (int)$task['id']; ?>" data-task-id="<?php echo (int)$task['id']; ?>" data-original-status="<?php echo (int)$task['status']; ?>" <?php echo (!empty($task['completed']) ? 'checked' : ''); ?> />
+              <span class="badge badge-phoenix fs-10 status-badge badge-phoenix-<?php echo h($task['status_color'] ?? 'secondary'); ?> me-2"><?php echo h($task['status_label'] ?? ''); ?></span>
               <a href="index.php?action=details&amp;id=<?php echo (int)$task['id']; ?>" class="mb-0 fs-8 me-2 line-clamp-1 flex-grow-1 flex-md-grow-0 fw-bold task-name-link<?php echo (!empty($task['completed']) ? ' text-decoration-line-through' : ''); ?>"><?php echo h($task['name'] ?? ''); ?></a>
             </div>
-            <span class="badge badge-phoenix fs-10 badge-phoenix-<?php echo h($task['status_color'] ?? 'secondary'); ?> me-2"><?php echo h($task['status_label'] ?? ''); ?></span>
             <span class="badge badge-phoenix fs-10 badge-phoenix-<?php echo h($task['priority_color'] ?? 'primary'); ?>"><?php echo h($task['priority_label'] ?? ''); ?></span>
             <?php $hierarchy = $task['project_name'] ?? $task['division_name'] ?? $task['agency_name'] ?? ''; ?>
             <?php if ($hierarchy): ?>
@@ -62,15 +62,21 @@ document.addEventListener('DOMContentLoaded', function () {
     checkbox.addEventListener('change', function () {
       const taskId = this.dataset.taskId;
       const newState = this.checked ? 1 : 0;
-      const link = this.nextElementSibling;
+      const originalStatus = this.dataset.originalStatus;
+      const link = this.closest('.form-check').querySelector('.task-name-link');
+      const badge = this.closest('.form-check').querySelector('.status-badge');
       fetch('functions/toggle_complete.php', {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: new URLSearchParams({ id: taskId, completed: newState })
+        body: new URLSearchParams({ id: taskId, completed: newState, status: originalStatus })
       }).then(response => response.json())
         .then(data => {
           if (data.success) {
             this.checked = data.completed == 1;
+            if (badge && data.status_label && data.status_color) {
+              badge.textContent = data.status_label;
+              badge.className = `badge badge-phoenix fs-10 status-badge me-2 badge-phoenix-${data.status_color}`;
+            }
           } else {
             this.checked = !newState;
           }


### PR DESCRIPTION
## Summary
- toggle task completion updates status to completed and restores previous status on undo
- return status metadata and refresh badge styling in list view

## Testing
- `php -l module/task/include/list_view.php`
- `php -l module/task/functions/toggle_complete.php`


------
https://chatgpt.com/codex/tasks/task_e_68a163ef87fc83338814c78a278581f1