### PR TITLE
Add task completion chart and inline project metadata editing

### DIFF
--- a/module/project/functions/update_field.php
+++ b/module/project/functions/update_field.php
@@ -1,0 +1,25 @@
+<?php
+require '../../../includes/php_header.php';
+require_permission('project','update');
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $projectId = (int)($_POST['project_id'] ?? 0);
+    $field = $_POST['field'] ?? '';
+    $value = (int)($_POST['value'] ?? 0);
+    $allowed = ['status','priority'];
+    if ($projectId > 0 && in_array($field, $allowed, true)) {
+        $stmt = $pdo->prepare("UPDATE module_projects SET $field = :val, user_updated = :uid WHERE id = :id");
+        $stmt->execute([
+            ':val' => $value,
+            ':uid' => $this_user_id,
+            ':id' => $projectId
+        ]);
+        audit_log($pdo, $this_user_id, 'module_projects', $projectId, 'UPDATE', "Updated $field to $value");
+        echo json_encode(['success' => true]);
+        exit;
+    }
+}
+
+echo json_encode(['success' => false]);

--- a/module/project/index.php
+++ b/module/project/index.php
@@ -94,7 +94,7 @@ unset($project);
       }
 
         $tasksStmt = $pdo->prepare(
-          'SELECT t.id, t.name, t.status, t.due_date, t.completed, li.label AS status_label, COALESCE(attr.attr_value, "secondary") AS status_color, ' .
+          'SELECT t.id, t.name, t.status, t.due_date, t.completed, t.complete_date, li.label AS status_label, COALESCE(attr.attr_value, "secondary") AS status_color, ' .
           '(SELECT COUNT(*) FROM module_tasks_files tf WHERE tf.task_id = t.id) AS attachment_count ' .
           'FROM module_tasks t ' .
           'LEFT JOIN lookup_list_items li ON t.status = li.id ' .


### PR DESCRIPTION
## Summary
- visualize project progress via ECharts line chart and timeline of tasks and notes
- allow inline editing of status and priority through dropdown badges with AJAX persistence
- add backend endpoint for project field updates and capture task completion dates

## Testing
- `php -l module/project/include/details_view.php`
- `php -l module/project/functions/update_field.php`
- `php -l module/project/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68a169b289f48333acb74566b4191b91