### PR TITLE
Add Dropzone uploads and gallery for project files

### DIFF
--- a/includes/html_header.php
+++ b/includes/html_header.php
@@ -21,6 +21,7 @@
 
   <!-- Vendor CSS (Phoenix, FontAwesome, etc) -->
   <link href="<?php echo getURLDir(); ?>vendors/glightbox/glightbox.min.css" rel="stylesheet">
+  <link href="<?php echo getURLDir(); ?>vendors/dropzone/dropzone.css" rel="stylesheet">
   <link href="<?php echo getURLDir(); ?>vendors/choices/choices.min.css" rel="stylesheet">
   <link href="<?php echo getURLDir(); ?>vendors/simplebar/simplebar.min.css" rel="stylesheet">
   <link href="<?php echo getURLDir(); ?>vendors/flatpickr/flatpickr.min.css" rel="stylesheet">

--- a/module/project/functions/upload_file.php
+++ b/module/project/functions/upload_file.php
@@ -2,31 +2,61 @@
 require '../../../includes/php_header.php';
 require_permission('project','update');
 
-$id = (int)($_POST['id'] ?? 0);
-if($id && isset($_FILES['file'])){
-  $file = $_FILES['file'];
-  $uploadDir = '../uploads/';
-  if(!is_dir($uploadDir)){
-    mkdir($uploadDir,0777,true);
-  }
-  $baseName = basename($file['name']);
-  $safeName = preg_replace('/[^A-Za-z0-9._-]/','_', $baseName);
-  $targetName = 'project_' . $id . '_' . time() . '_' . $safeName;
-  $targetPath = $uploadDir . $targetName;
-  if(move_uploaded_file($file['tmp_name'],$targetPath)){
-    $filePathDb = '/module/project/uploads/' . $targetName;
-    $stmt = $pdo->prepare('INSERT INTO module_projects_files (user_id,user_updated,project_id,file_name,file_path,file_size,file_type) VALUES (:uid,:uid,:pid,:name,:path,:size,:type)');
-    $stmt->execute([
-      ':uid' => $this_user_id,
-      ':pid' => $id,
-      ':name' => $baseName,
-      ':path' => $filePathDb,
-      ':size' => $file['size'],
-      ':type' => $file['type']
-    ]);
-    $fileId = $pdo->lastInsertId();
-    admin_audit_log($pdo,$this_user_id,'module_projects_files',$fileId,'UPLOAD','',json_encode(['file'=>$baseName]));
-  }
+$project_id = (int)($_POST['project_id'] ?? 0);
+$note_id = isset($_POST['note_id']) && $_POST['note_id'] !== '' ? (int)$_POST['note_id'] : null;
+$response = [];
+
+if ($project_id && !empty($_FILES['file'])) {
+    $uploadDir = '../uploads/';
+    if (!is_dir($uploadDir)) {
+        mkdir($uploadDir, 0777, true);
+    }
+
+    $files = $_FILES['file'];
+    if (!is_array($files['name'])) {
+        $files = [
+            'name' => [$files['name']],
+            'type' => [$files['type']],
+            'tmp_name' => [$files['tmp_name']],
+            'error' => [$files['error']],
+            'size' => [$files['size']]
+        ];
+    }
+
+    foreach ($files['name'] as $index => $name) {
+        if ($files['error'][$index] !== UPLOAD_ERR_OK) {
+            continue;
+        }
+        $baseName = basename($name);
+        $safeName = preg_replace('/[^A-Za-z0-9._-]/', '_', $baseName);
+        $targetName = 'project_' . $project_id . '_' . time() . '_' . $safeName;
+        $targetPath = $uploadDir . $targetName;
+        if (move_uploaded_file($files['tmp_name'][$index], $targetPath)) {
+            $filePathDb = '/module/project/uploads/' . $targetName;
+            $stmt = $pdo->prepare('INSERT INTO module_projects_files (user_id,user_updated,project_id,note_id,file_name,file_path,file_size,file_type) VALUES (:uid,:uid,:pid,:nid,:name,:path,:size,:type)');
+            $stmt->execute([
+                ':uid' => $this_user_id,
+                ':pid' => $project_id,
+                ':nid' => $note_id,
+                ':name' => $baseName,
+                ':path' => $filePathDb,
+                ':size' => $files['size'][$index],
+                ':type' => $files['type'][$index]
+            ]);
+            $fileId = $pdo->lastInsertId();
+            admin_audit_log($pdo, $this_user_id, 'module_projects_files', $fileId, 'UPLOAD', '', json_encode(['file' => $baseName]));
+
+            $response[] = [
+                'id' => $fileId,
+                'name' => $baseName,
+                'path' => $filePathDb,
+                'size' => $files['size'][$index],
+                'type' => $files['type'][$index]
+            ];
+        }
+    }
 }
-header('Location: ../index.php?action=details&id=' . $id);
+
+header('Content-Type: application/json');
+echo json_encode(['files' => $response]);
 exit;

--- a/module/project/include/details_view.php
+++ b/module/project/include/details_view.php
@@ -140,47 +140,81 @@ if (!empty($current_project)) {
                 </div>
                 <?php if (user_has_permission('project','create|update|delete')): ?>
                 <div class="px-4 px-lg-6 py-4">
-                  <form action="functions/upload_file.php" method="post" enctype="multipart/form-data" class="mb-3">
-                    <div class="input-group">
-                      <input type="hidden" name="id" value="<?= (int)$current_project['id'] ?>">
-                      <input class="form-control" type="file" name="file" id="projectFileUpload" aria-describedby="projectFileUpload" aria-label="Upload" required>
-                      <button class="btn btn-success" type="submit">Upload New</button>
+                  <form action="functions/upload_file.php" method="post" enctype="multipart/form-data" class="dropzone dropzone-multiple p-0" id="project-file-dropzone" data-dropzone="data-dropzone" data-options='{"url":"functions/upload_file.php"}'>
+                    <input type="hidden" name="project_id" value="<?= (int)$current_project['id'] ?>">
+                    <input type="hidden" name="note_id" value="">
+                    <div class="fallback">
+                      <input type="file" name="file" multiple />
                     </div>
+                    <div class="dz-message" data-dz-message="data-dz-message">
+                      <div class="dz-message-text"><img class="me-2" src="<?php echo getURLDir(); ?>assets/img/icons/cloud-upload.svg" width="25" alt="" />Drop files here or click to upload</div>
+                    </div>
+                    <div class="dz-preview dz-preview-multiple m-0 d-flex flex-column"></div>
                   </form>
                 </div>
                 <?php endif; ?>
 
-                <?php if (!empty($files)): ?>
-                  <?php foreach ($files as $f): ?>
-                  <div class="border-top px-4 px-lg-6 py-4">
-                    <div class="me-n3">
-                      <div class="d-flex flex-between-center">
-                        <div class="d-flex mb-1"><span class="fa-solid <?= strpos($f['file_type'], 'image/') === 0 ? 'fa-image' : 'fa-file' ?> me-2 text-body-tertiary fs-9"></span>
-                          <p class="text-body-highlight mb-0 lh-1">
-                            <?php if (strpos($f['file_type'], 'image/') === 0): ?>
-                              <a class="text-body-highlight" href="#" data-bs-toggle="modal" data-bs-target="#imageModal" data-img-src="<?php echo getURLDir(); ?><?= h($f['file_path']) ?>"><?= h($f['file_name']) ?></a>
-                            <?php else: ?>
-                              <a class="text-body-highlight" href="<?php echo getURLDir(); ?><?= h($f['file_path']) ?>"><?= h($f['file_name']) ?></a>
+                <?php if (!empty($files)):
+                  $imageFiles = [];
+                  $otherFiles = [];
+                  foreach ($files as $f) {
+                    if (strpos($f['file_type'], 'image/') === 0) {
+                      $imageFiles[] = $f;
+                    } else {
+                      $otherFiles[] = $f;
+                    }
+                  }
+                ?>
+                  <?php if (!empty($imageFiles)): ?>
+                    <div class="border-top px-4 px-lg-6 py-4">
+                      <div class="row g-3">
+                        <?php foreach ($imageFiles as $f): ?>
+                          <div class="col-6 col-md-4 col-lg-3 position-relative">
+                            <a href="<?php echo getURLDir(); ?><?= h($f['file_path']) ?>" data-gallery="project-gallery">
+                              <img class="img-fluid rounded" src="<?php echo getURLDir(); ?><?= h($f['file_path']) ?>" alt="<?= h($f['file_name']) ?>">
+                            </a>
+                            <?php if ($is_admin || ($f['user_id'] ?? 0) == $this_user_id): ?>
+                              <form action="functions/delete_file.php" method="post" class="position-absolute top-0 end-0 m-2" onsubmit="return confirm('Delete this file?');">
+                                <input type="hidden" name="id" value="<?= (int)$f['id'] ?>">
+                                <input type="hidden" name="project_id" value="<?= (int)$current_project['id'] ?>">
+                                <button class="p-0 text-danger bg-transparent border-0" type="submit"><span class="fa-solid fa-trash"></span></button>
+                              </form>
                             <?php endif; ?>
-                          </p>
-                        </div>
-                        <?php if ($is_admin || ($f['user_id'] ?? 0) == $this_user_id): ?>
-                        <form action="functions/delete_file.php" method="post" onsubmit="return confirm('Delete this file?');">
-                          <input type="hidden" name="id" value="<?= (int)$f['id'] ?>">
-                          <input type="hidden" name="project_id" value="<?= (int)$current_project['id'] ?>">
-                          <button class="p-0 text-danger bg-transparent border-0" type="submit"><span class="fa-solid fa-trash"></span></button>
-                        </form>
-                        <?php endif; ?>
+                          </div>
+                        <?php endforeach; ?>
                       </div>
-                      <div class="d-flex fs-9 text-body-tertiary mb-0 flex-wrap"><span><?= h($f['file_size']) ?></span><span class="text-body-quaternary mx-1">| </span><span class="text-nowrap"><?= h($f['file_type']) ?></span><span class="text-body-quaternary mx-1">| </span><span class="text-nowrap"><?= h($f['date_created']) ?></span><span class="text-body-quaternary mx-1">|</span><span class="text-nowrap">by <?= h($f['user_name'] ?? '') ?></span></div>
-                      <?php if (strpos($f['file_type'], 'image/') === 0): ?>
-                        <a href="#" data-bs-toggle="modal" data-bs-target="#imageModal" data-img-src="<?php echo getURLDir(); ?><?= h($f['file_path']) ?>">
-                          <img class="rounded-2 mt-2" src="<?php echo getURLDir(); ?><?= h($f['file_path']) ?>" alt="" style="width:320px" />
-                        </a>
-                      <?php endif; ?>
                     </div>
-                  </div>
-                  <?php endforeach; ?>
+                  <?php endif; ?>
+
+                  <?php if (!empty($otherFiles)): ?>
+                    <?php foreach ($otherFiles as $f): ?>
+                      <div class="border-top px-4 px-lg-6 py-4">
+                        <div class="me-n3">
+                          <div class="d-flex flex-between-center">
+                            <div class="d-flex mb-1"><span class="fa-solid fa-file me-2 text-body-tertiary fs-9"></span>
+                              <p class="text-body-highlight mb-0 lh-1">
+                                <a class="text-body-highlight" href="<?php echo getURLDir(); ?><?= h($f['file_path']) ?>"><?= h($f['file_name']) ?></a>
+                              </p>
+                            </div>
+                            <?php if ($is_admin || ($f['user_id'] ?? 0) == $this_user_id): ?>
+                              <form action="functions/delete_file.php" method="post" onsubmit="return confirm('Delete this file?');">
+                                <input type="hidden" name="id" value="<?= (int)$f['id'] ?>">
+                                <input type="hidden" name="project_id" value="<?= (int)$current_project['id'] ?>">
+                                <button class="p-0 text-danger bg-transparent border-0" type="submit"><span class="fa-solid fa-trash"></span></button>
+                              </form>
+                            <?php endif; ?>
+                          </div>
+                          <div class="d-flex fs-9 text-body-tertiary mb-0 flex-wrap"><span><?= h($f['file_size']) ?></span><span class="text-body-quaternary mx-1">| </span><span class="text-nowrap"><?= h($f['file_type']) ?></span><span class="text-body-quaternary mx-1">| </span><span class="text-nowrap"><?= h($f['date_created']) ?></span><span class="text-body-quaternary mx-1">|</span><span class="text-nowrap">by <?= h($f['user_name'] ?? '') ?></span></div>
+                        </div>
+                      </div>
+                    <?php endforeach; ?>
+                  <?php endif; ?>
+
+                  <?php if (empty($imageFiles) && empty($otherFiles)): ?>
+                    <div class="border-top px-4 px-lg-6 py-4">
+                      <p class="fs-9 text-body-secondary mb-0">No files uploaded.</p>
+                    </div>
+                  <?php endif; ?>
                 <?php else: ?>
                   <div class="border-top px-4 px-lg-6 py-4">
                     <p class="fs-9 text-body-secondary mb-0">No files uploaded.</p>
@@ -302,7 +336,7 @@ if (!empty($current_project)) {
                                 <div class="d-flex mb-1"><span class="fa-solid <?= strpos($f['file_type'], 'image/') === 0 ? 'fa-image' : 'fa-file' ?> me-2 text-body-tertiary fs-9"></span>
                                   <p class="text-body-highlight mb-0 lh-1">
                                     <?php if (strpos($f['file_type'], 'image/') === 0): ?>
-                                      <a class="text-body-highlight" href="#" data-bs-toggle="modal" data-bs-target="#imageModal" data-img-src="<?php echo getURLDir(); ?><?= h($f['file_path']) ?>"><?= h($f['file_name']) ?></a>
+                                      <a class="text-body-highlight" href="<?php echo getURLDir(); ?><?= h($f['file_path']) ?>" data-gallery="note-<?= (int)$n['id'] ?>"><?= h($f['file_name']) ?></a>
                                     <?php else: ?>
                                       <a class="text-body-highlight" href="<?php echo getURLDir(); ?><?= h($f['file_path']) ?>"><?= h($f['file_name']) ?></a>
                                     <?php endif; ?>


### PR DESCRIPTION
## Summary
- integrate Dropzone into project details for drag-and-drop uploads with progress
- handle multiple file uploads on backend with optional note linkage and JSON response
- display project and note images in gallery view using Phoenix/GLightbox

## Testing
- `php -l includes/html_header.php`
- `php -l module/project/functions/upload_file.php`
- `php -l module/project/include/details_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68a169b1f43c8333b981f62340a412e3