### PR TITLE
Add user wizard forms and server logic

### DIFF
--- a/admin/users/edit.php
+++ b/admin/users/edit.php
@@ -1,0 +1,47 @@
+<?php
+require '../admin_header.php';
+require_permission('users','update');
+header('Content-Type: application/json');
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$errors = [];
+$username = trim($_POST['username'] ?? '');
+$email = trim($_POST['email'] ?? '');
+$password = $_POST['password'] ?? '';
+$first_name = trim($_POST['first_name'] ?? '');
+$last_name = trim($_POST['last_name'] ?? '');
+
+if ($first_name === '') { $errors['first_name'] = 'First name required'; }
+if ($last_name === '') { $errors['last_name'] = 'Last name required'; }
+if ($username === '') { $errors['username'] = 'Username required'; }
+if ($email === '') { $errors['email'] = 'Email required'; }
+
+if ($errors) {
+  echo json_encode(['status' => 'error', 'errors' => $errors]);
+  exit;
+}
+
+try {
+  $pdo->beginTransaction();
+  $sql = 'UPDATE users SET username=:username, email=:email';
+  $params = [':username' => $username, ':email' => $email, ':uid' => $this_user_id, ':id' => $id];
+  if ($password) {
+    $sql .= ', password=:password';
+    $params[':password'] = password_hash($password, PASSWORD_DEFAULT);
+  }
+  $sql .= ', user_updated=:uid WHERE id=:id';
+  $stmt = $pdo->prepare($sql);
+  $stmt->execute($params);
+
+  $stmt = $pdo->prepare('UPDATE person SET first_name=:first_name, last_name=:last_name, user_updated=:uid WHERE user_id=:id');
+  $stmt->execute([':first_name' => $first_name, ':last_name' => $last_name, ':uid' => $this_user_id, ':id' => $id]);
+
+  admin_audit_log($pdo, $this_user_id, 'users', $id, 'UPDATE', null, json_encode(['username'=>$username,'email'=>$email]));
+  admin_audit_log($pdo, $this_user_id, 'person', $id, 'UPDATE', null, json_encode(['user_id'=>$id,'first_name'=>$first_name,'last_name'=>$last_name]));
+
+  $pdo->commit();
+  echo json_encode(['status' => 'success']);
+} catch (Exception $e) {
+  $pdo->rollBack();
+  echo json_encode(['status' => 'error', 'message' => $e->getMessage()]);
+}

--- a/admin/users/form_edit.php
+++ b/admin/users/form_edit.php
@@ -1,0 +1,73 @@
+<?php
+require '../admin_header.php';
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$username = $email = $first_name = $last_name = '';
+if ($id) {
+  $stmt = $pdo->prepare('SELECT u.username, u.email, p.first_name, p.last_name FROM users u LEFT JOIN person p ON u.id = p.user_id WHERE u.id = :id');
+  $stmt->execute([':id' => $id]);
+  if ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+    $username = $row['username'];
+    $email = $row['email'];
+    $first_name = $row['first_name'];
+    $last_name = $row['last_name'];
+  }
+}
+?>
+<h2 class="mb-4">Edit User</h2>
+<div class="card theme-wizard mb-5" data-theme-wizard="data-theme-wizard">
+  <div class="card-body">
+    <div class="tab-content">
+      <div class="tab-pane active" id="step1" role="tabpanel">
+        <form id="wizardForm1" data-wizard-form="1">
+          <div class="mb-3">
+            <label class="form-label">Username</label>
+            <input type="text" name="username" class="form-control" value="<?=h($username)?>" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Email</label>
+            <input type="email" name="email" class="form-control" value="<?=h($email)?>" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Password (leave blank to keep)</label>
+            <input type="password" name="password" class="form-control">
+          </div>
+        </form>
+      </div>
+      <div class="tab-pane" id="step2" role="tabpanel">
+        <form id="wizardForm2" data-wizard-form="2">
+          <div class="mb-3">
+            <label class="form-label">First Name</label>
+            <input type="text" name="first_name" class="form-control" value="<?=h($first_name)?>" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Last Name</label>
+            <input type="text" name="last_name" class="form-control" value="<?=h($last_name)?>" required>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div class="card-footer">
+    <form id="finalForm" method="post" action="edit.php?id=<?=$id?>">
+      <button type="button" id="saveBtn" class="btn btn-warning">Save</button>
+    </form>
+  </div>
+</div>
+<script>
+document.getElementById('saveBtn').addEventListener('click', function(){
+  const finalForm = document.getElementById('finalForm');
+  finalForm.querySelectorAll('input[type="hidden"]').forEach(el => el.remove());
+  document.querySelectorAll('[data-wizard-form]').forEach(form => {
+    const fd = new FormData(form);
+    for (const [key, value] of fd.entries()) {
+      const input = document.createElement('input');
+      input.type = 'hidden';
+      input.name = key;
+      input.value = value;
+      finalForm.appendChild(input);
+    }
+  });
+  finalForm.submit();
+});
+</script>
+<?php require '../admin_footer.php'; ?>

--- a/admin/users/form_new.php
+++ b/admin/users/form_new.php
@@ -1,0 +1,61 @@
+<?php
+require '../admin_header.php';
+?>
+<h2 class="mb-4">Add User</h2>
+<div class="card theme-wizard mb-5" data-theme-wizard="data-theme-wizard">
+  <div class="card-body">
+    <div class="tab-content">
+      <div class="tab-pane active" id="step1" role="tabpanel">
+        <form id="wizardForm1" data-wizard-form="1">
+          <div class="mb-3">
+            <label class="form-label">Username</label>
+            <input type="text" name="username" class="form-control" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Email</label>
+            <input type="email" name="email" class="form-control" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Password</label>
+            <input type="password" name="password" class="form-control">
+          </div>
+        </form>
+      </div>
+      <div class="tab-pane" id="step2" role="tabpanel">
+        <form id="wizardForm2" data-wizard-form="2">
+          <div class="mb-3">
+            <label class="form-label">First Name</label>
+            <input type="text" name="first_name" class="form-control" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Last Name</label>
+            <input type="text" name="last_name" class="form-control" required>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div class="card-footer">
+    <form id="finalForm" method="post" action="new.php">
+      <button type="button" id="saveBtn" class="btn btn-success">Save</button>
+    </form>
+  </div>
+</div>
+<script>
+document.getElementById('saveBtn').addEventListener('click', function(){
+  const finalForm = document.getElementById('finalForm');
+  finalForm.querySelectorAll('input[type="hidden"]').forEach(el => el.remove());
+  document.querySelectorAll('[data-wizard-form]').forEach(form => {
+    const fd = new FormData(form);
+    for (const [key, value] of fd.entries()) {
+      const input = document.createElement('input');
+      input.type = 'hidden';
+      input.name = key;
+      input.value = value;
+      finalForm.appendChild(input);
+    }
+  });
+  finalForm.submit();
+});
+</script>
+<?php require '../admin_footer.php'; ?>

--- a/admin/users/new.php
+++ b/admin/users/new.php
@@ -1,0 +1,43 @@
+<?php
+require '../admin_header.php';
+require_permission('users','create');
+header('Content-Type: application/json');
+
+$errors = [];
+$username = trim($_POST['username'] ?? '');
+$email = trim($_POST['email'] ?? '');
+$password = $_POST['password'] ?? '';
+$first_name = trim($_POST['first_name'] ?? '');
+$last_name = trim($_POST['last_name'] ?? '');
+
+if ($first_name === '') { $errors['first_name'] = 'First name required'; }
+if ($last_name === '') { $errors['last_name'] = 'Last name required'; }
+if ($username === '') { $errors['username'] = 'Username required'; }
+if ($email === '') { $errors['email'] = 'Email required'; }
+
+if ($errors) {
+  echo json_encode(['status' => 'error', 'errors' => $errors]);
+  exit;
+}
+
+$hash = $password ? password_hash($password, PASSWORD_DEFAULT) : '';
+
+try {
+  $pdo->beginTransaction();
+  $stmt = $pdo->prepare('INSERT INTO users (username, email, password, user_id, user_updated) VALUES (:username, :email, :password, :uid, :uid)');
+  $stmt->execute([':username' => $username, ':email' => $email, ':password' => $hash, ':uid' => $this_user_id]);
+  $userId = $pdo->lastInsertId();
+
+  $stmt = $pdo->prepare('INSERT INTO person (user_id, first_name, last_name, user_updated) VALUES (:user_id, :first_name, :last_name, :uid)');
+  $stmt->execute([':user_id' => $userId, ':first_name' => $first_name, ':last_name' => $last_name, ':uid' => $this_user_id]);
+  $personId = $pdo->lastInsertId();
+
+  admin_audit_log($pdo, $this_user_id, 'users', $userId, 'CREATE', null, json_encode(['username'=>$username,'email'=>$email]));
+  admin_audit_log($pdo, $this_user_id, 'person', $personId, 'CREATE', null, json_encode(['user_id'=>$userId,'first_name'=>$first_name,'last_name'=>$last_name]));
+
+  $pdo->commit();
+  echo json_encode(['status' => 'success', 'user_id' => $userId]);
+} catch (Exception $e) {
+  $pdo->rollBack();
+  echo json_encode(['status' => 'error', 'message' => $e->getMessage()]);
+}


### PR DESCRIPTION
## Summary
- Add multi-step user creation and editing forms that consolidate wizard data before submission
- Implement server-side handlers requiring first/last name, hashing passwords, and linking users to person records

## Testing
- `php -l admin/users/form_new.php`
- `php -l admin/users/form_edit.php`
- `php -l admin/users/new.php`
- `php -l admin/users/edit.php`
- `php -r 'session_start(); $_POST=["username"=>"test","email"=>"test@example.com","password"=>"pass","first_name"=>"T","last_name"=>"U"]; chdir("admin/users"); include "new.php";'` *(fails: Connection failed: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a1770809608333b5611514d58030ca