### PR TITLE
Add project priority metadata and display

### DIFF
--- a/module/project/include/list_view.php
+++ b/module/project/include/list_view.php
@@ -6,7 +6,7 @@
     <li class="breadcrumb-item active" aria-current="page">List View</li>
   </ol>
 </nav>
-<div id="projectSummary" data-list='{"valueNames":["project","assignees","start","deadline","projectprogress","status","action"],"page":6,"pagination":true}'>
+<div id="projectSummary" data-list='{"valueNames":["project","assignees","start","deadline","projectprogress","status","priority","action"],"page":6,"pagination":true}'>
   <div class="row align-items-end justify-content-between pb-4 g-3">
     <div class="col-auto">
       <h3>Projects</h3>
@@ -36,6 +36,7 @@
           <th class="sort align-middle ps-3" scope="col" data-sort="deadline" style="width:15%;">DEADLINE</th>
           <th class="sort align-middle ps-3" scope="col" data-sort="projectprogress" style="width:5%;">PROGRESS</th>
           <th class="align-middle ps-8" scope="col" data-sort="status" style="width:10%;">STATUS</th>
+          <th class="align-middle ps-3" scope="col" data-sort="priority" style="width:10%;">PRIORITY</th>
           <th class="sort align-middle text-end" scope="col" style="width:10%;"></th>
         </tr>
       </thead>
@@ -57,6 +58,11 @@
           <td class="align-middle ps-3 deadline"><?php echo !empty($project['complete_date']) ? h(date('F jS, Y', strtotime($project['complete_date']))) : ''; ?></td>
           <td class="align-middle ps-3 projectprogress"><?php echo h($project['completed_tasks']) . '/' . h($project['total_tasks']); ?></td>
           <td class="align-middle ps-8 status"><span class="badge badge-phoenix fs-10 badge-phoenix-<?php echo h($project['status_color']); ?>"><?php echo h($project['status_label']); ?></span></td>
+          <td class="align-middle ps-3 priority">
+            <span class="badge badge-phoenix fs-10 badge-phoenix-<?php echo h($project['priority_color']); ?>">
+              <?php echo h($project['priority_label']); ?>
+            </span>
+          </td>
           <td class="align-middle text-end">
             <div class="btn-reveal-trigger position-static">
               <a class="btn btn-sm dropdown-toggle dropdown-caret-none transition-none btn-reveal fs-10" href="index.php?action=details&id=<?php echo $project['id']; ?>"><span class="fas fa-chevron-right fs-10"></span></a>

--- a/module/project/index.php
+++ b/module/project/index.php
@@ -30,26 +30,30 @@ if ($action === 'create') {
 
 require_permission('project','read');
 
-$sql = "SELECT p.id,
-               p.name,
-               p.description,
-               p.start_date,
-               p.complete_date,
-               li.label AS status_label,
-               COALESCE(attr.attr_value, 'secondary') AS status_color,
-               a.name AS agency_name,
-               d.name AS division_name,
-               COUNT(t.id) AS total_tasks,
-               SUM(CASE WHEN t.completed = 0 OR t.completed IS NULL THEN 1 ELSE 0 END) AS in_progress,
-               SUM(CASE WHEN t.completed = 1 THEN 1 ELSE 0 END) AS completed_tasks
-        FROM module_projects p
-        LEFT JOIN lookup_list_items li ON p.status = li.id
-        LEFT JOIN lookup_list_item_attributes attr ON li.id = attr.item_id AND attr.attr_code = 'COLOR-CLASS'
-        LEFT JOIN module_agency a ON p.agency_id = a.id
-        LEFT JOIN module_division d ON p.division_id = d.id
-        LEFT JOIN module_tasks t ON t.project_id = p.id
-        GROUP BY p.id
-        ORDER BY p.name";
+         $sql = "SELECT p.id,
+                p.name,
+                p.description,
+                p.start_date,
+                p.complete_date,
+                li.label AS status_label,
+                COALESCE(attr.attr_value, 'secondary') AS status_color,
+                lp.label AS priority_label,
+                COALESCE(pattr.attr_value, 'secondary') AS priority_color,
+                a.name AS agency_name,
+                d.name AS division_name,
+                COUNT(t.id) AS total_tasks,
+                SUM(CASE WHEN t.completed = 0 OR t.completed IS NULL THEN 1 ELSE 0 END) AS in_progress,
+                SUM(CASE WHEN t.completed = 1 THEN 1 ELSE 0 END) AS completed_tasks
+         FROM module_projects p
+         LEFT JOIN lookup_list_items li ON p.status = li.id
+         LEFT JOIN lookup_list_item_attributes attr ON li.id = attr.item_id AND attr.attr_code = 'COLOR-CLASS'
+         LEFT JOIN lookup_list_items lp ON p.priority = lp.id
+         LEFT JOIN lookup_list_item_attributes pattr ON lp.id = pattr.item_id AND pattr.attr_code = 'COLOR-CLASS'
+         LEFT JOIN module_agency a ON p.agency_id = a.id
+         LEFT JOIN module_division d ON p.division_id = d.id
+         LEFT JOIN module_tasks t ON t.project_id = p.id
+         GROUP BY p.id
+         ORDER BY p.name";
 $projects = $pdo->query($sql)->fetchAll(PDO::FETCH_ASSOC);
 
 $assignStmt = $pdo->query("SELECT pa.project_id, pa.assigned_user_id, u.profile_pic, CONCAT(per.first_name, ' ', per.last_name) AS name


### PR DESCRIPTION
## Summary
- Include project priority label and color in project query
- Show project priority badges and sortable column in list view

## Testing
- `php -l module/project/index.php`
- `php -l module/project/include/list_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68a23c51b00483338b0cf8274ec9cc21