### PR TITLE
feat: add project list filters and progress bar

### DIFF
--- a/module/project/include/list_view.php
+++ b/module/project/include/list_view.php
@@ -6,7 +6,7 @@
     <li class="breadcrumb-item active" aria-current="page">List View</li>
   </ol>
 </nav>
-<div id="projectSummary" data-list='{"valueNames":["project","assignees","start","deadline","projectprogress","status","action"],"page":6,"pagination":true}'>
+<div id="projectSummary" data-list='{"valueNames":["project","assignees","start","deadline","projectprogress","status","priority","action"],"page":6,"pagination":true}'>
   <div class="row align-items-end justify-content-between pb-4 g-3">
     <div class="col-auto">
       <h3>Projects</h3>
@@ -26,6 +26,24 @@
     </div>
     <?php endif; ?>
   </div>
+  <div class="row g-3 mb-3">
+    <div class="col-6 col-md-3">
+      <select class="form-select form-select-sm" id="filter-status">
+        <option value="">All Statuses</option>
+        <?php foreach ($statusItems as $status): ?>
+          <option value="<?= h($status['label']); ?>"><?= h($status['label']); ?></option>
+        <?php endforeach; ?>
+      </select>
+    </div>
+    <div class="col-6 col-md-3">
+      <select class="form-select form-select-sm" id="filter-priority">
+        <option value="">All Priorities</option>
+        <?php foreach ($priorityItems as $priority): ?>
+          <option value="<?= h($priority['label']); ?>"><?= h($priority['label']); ?></option>
+        <?php endforeach; ?>
+      </select>
+    </div>
+  </div>
   <div class="table-responsive ms-n1 ps-1 scrollbar">
     <table class="table fs-9 mb-0 border-top border-translucent">
       <thead>
@@ -42,7 +60,10 @@
       <tbody class="list" id="project-summary-table-body">
         <?php foreach ($projects as $project): ?>
         <tr class="position-static">
-          <td class="align-middle time white-space-nowrap ps-0 project"><a class="fw-bold fs-8" href="index.php?action=details&id=<?php echo $project['id']; ?>"><?php echo h($project['name']); ?></a></td>
+          <td class="align-middle time white-space-nowrap ps-0 project">
+            <a class="fw-bold fs-8" href="index.php?action=details&id=<?php echo $project['id']; ?>"><?php echo h($project['name']); ?></a>
+            <span class="d-none priority"><?php echo h($project['priority_label'] ?? ''); ?></span>
+          </td>
           <td class="align-middle white-space-nowrap assignees ps-3">
             <div class="avatar-group avatar-group-dense">
               <?php foreach ($project['assignees'] as $assignee): ?>
@@ -55,7 +76,12 @@
           </td>
           <td class="align-middle ps-3 start"><?php echo !empty($project['start_date']) ? h(date('F jS, Y', strtotime($project['start_date']))) : ''; ?></td>
           <td class="align-middle ps-3 deadline"><?php echo !empty($project['complete_date']) ? h(date('F jS, Y', strtotime($project['complete_date']))) : ''; ?></td>
-          <td class="align-middle ps-3 projectprogress"><?php echo h($project['completed_tasks']) . '/' . h($project['total_tasks']); ?></td>
+          <?php $progress = ($project['total_tasks'] > 0 ? ($project['completed_tasks'] / $project['total_tasks']) * 100 : 0); ?>
+          <td class="align-middle ps-3 projectprogress">
+            <div class="progress" style="height:5px;">
+              <div class="progress-bar" role="progressbar" style="width: <?= round($progress); ?>%;" aria-valuenow="<?= round($progress); ?>" aria-valuemin="0" aria-valuemax="100"></div>
+            </div>
+          </td>
           <td class="align-middle ps-8 status"><span class="badge badge-phoenix fs-10 badge-phoenix-<?php echo h($project['status_color']); ?>"><?php echo h($project['status_label']); ?></span></td>
           <td class="align-middle text-end">
             <div class="btn-reveal-trigger position-static">
@@ -78,3 +104,27 @@
     </div>
   </div>
 </div>
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+  const projectSummaryEl = document.getElementById('projectSummary');
+  const options = window.phoenix.utils.getData(projectSummaryEl, 'list');
+  const projectList = new List(projectSummaryEl, options);
+
+  const statusFilter = document.getElementById('filter-status');
+  const priorityFilter = document.getElementById('filter-priority');
+
+  function applyFilters() {
+    const s = statusFilter.value;
+    const p = priorityFilter.value;
+    projectList.filter(item => {
+      const v = item.values();
+      const statusMatch = !s || v.status === s;
+      const priorityMatch = !p || v.priority === p;
+      return statusMatch && priorityMatch;
+    });
+  }
+
+  statusFilter.addEventListener('change', applyFilters);
+  priorityFilter.addEventListener('change', applyFilters);
+});
+</script>

--- a/module/project/index.php
+++ b/module/project/index.php
@@ -37,6 +37,9 @@ $sql = "SELECT p.id,
                p.complete_date,
                li.label AS status_label,
                COALESCE(attr.attr_value, 'secondary') AS status_color,
+               p.priority,
+               lp.label AS priority_label,
+               COALESCE(pattr.attr_value, 'secondary') AS priority_color,
                a.name AS agency_name,
                d.name AS division_name,
                COUNT(t.id) AS total_tasks,
@@ -45,6 +48,8 @@ $sql = "SELECT p.id,
         FROM module_projects p
         LEFT JOIN lookup_list_items li ON p.status = li.id
         LEFT JOIN lookup_list_item_attributes attr ON li.id = attr.item_id AND attr.attr_code = 'COLOR-CLASS'
+        LEFT JOIN lookup_list_items lp ON p.priority = lp.id
+        LEFT JOIN lookup_list_item_attributes pattr ON lp.id = pattr.item_id AND pattr.attr_code = 'COLOR-CLASS'
         LEFT JOIN module_agency a ON p.agency_id = a.id
         LEFT JOIN module_division d ON p.division_id = d.id
         LEFT JOIN module_tasks t ON t.project_id = p.id
@@ -64,6 +69,9 @@ foreach ($projects as &$project) {
   $project['assignees'] = $assignments[$project['id']] ?? [];
 }
 unset($project);
+
+$statusItems   = get_lookup_items($pdo, 'PROJECT_STATUS');
+$priorityItems = get_lookup_items($pdo, 'PROJECT_PRIORITY');
 
   if ($action === 'details' || ($action === 'create-edit' && isset($_GET['id']))) {
     $project_id = (int)($_GET['id'] ?? 0);


### PR DESCRIPTION
## Summary
- add status and priority filters on project list
- render progress as bootstrap progress bar
- wire dropdowns to list.js for client-side filtering

## Testing
- `php -l module/project/index.php`
- `php -l module/project/include/list_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68a23c5341e88333860c4f60486077d8