### PR TITLE
Anchor contractor function includes to directory paths

### DIFF
--- a/admin/contractors/functions/add_compensation.php
+++ b/admin/contractors/functions/add_compensation.php
@@ -1,5 +1,5 @@
 <?php
-require '../../includes/php_header.php';
+require __DIR__ . '/../../includes/php_header.php';
 require_permission('contractors','update');
 
 $cid  = (int)($_POST['contractor_id'] ?? 0);

--- a/admin/contractors/functions/add_contact.php
+++ b/admin/contractors/functions/add_contact.php
@@ -1,5 +1,5 @@
 <?php
-require '../../includes/php_header.php';
+require __DIR__ . '/../../includes/php_header.php';
 require_permission('contractors','update');
 
 $cid  = (int)($_POST['contractor_id'] ?? 0);

--- a/admin/contractors/functions/add_note.php
+++ b/admin/contractors/functions/add_note.php
@@ -1,5 +1,5 @@
 <?php
-require '../../includes/php_header.php';
+require __DIR__ . '/../../includes/php_header.php';
 require_permission('contractors','update');
 
 $cid  = (int)($_POST['contractor_id'] ?? 0);

--- a/admin/contractors/functions/create.php
+++ b/admin/contractors/functions/create.php
@@ -1,5 +1,5 @@
 <?php
-require '../../includes/php_header.php';
+require __DIR__ . '/../../includes/php_header.php';
 require_permission('contractors','create');
 
 $first = trim($_POST['first_name'] ?? '');

--- a/admin/contractors/functions/update.php
+++ b/admin/contractors/functions/update.php
@@ -1,5 +1,5 @@
 <?php
-require '../../includes/php_header.php';
+require __DIR__ . '/../../includes/php_header.php';
 require_permission('contractors','update');
 
 $id    = (int)($_POST['id'] ?? 0);

--- a/admin/contractors/functions/upload_file.php
+++ b/admin/contractors/functions/upload_file.php
@@ -1,5 +1,5 @@
 <?php
-require '../../includes/php_header.php';
+require __DIR__ . '/../../includes/php_header.php';
 
 require_permission('contractors','update');
 


### PR DESCRIPTION
## Summary
- Anchor contractor admin function scripts to their directory with `__DIR__` when including `php_header.php`
- Applies to create, update, add_note, add_contact, add_compensation, and upload_file handlers

## Testing
- `php -l admin/contractors/functions/create.php admin/contractors/functions/update.php admin/contractors/functions/add_note.php admin/contractors/functions/add_contact.php admin/contractors/functions/add_compensation.php admin/contractors/functions/upload_file.php`


------
https://chatgpt.com/codex/tasks/task_e_68a3eba2a25c8333a38f1bb8d21b6617