### PR TITLE
Link contractors to existing user accounts

### DIFF
--- a/admin/contractors/functions/create.php
+++ b/admin/contractors/functions/create.php
@@ -2,15 +2,42 @@
 require '../../includes/php_header.php';
 require_permission('contractors','create');
 
-$first = trim($_POST['first_name'] ?? '');
-$last  = trim($_POST['last_name'] ?? '');
-if($first !== '' && $last !== ''){
-  $stmt = $pdo->prepare('INSERT INTO module_contractors (user_id,user_updated,first_name,last_name) VALUES (:uid,:uid,:first,:last)');
-  $stmt->execute([':uid'=>$this_user_id, ':first'=>$first, ':last'=>$last]);
-  $id = $pdo->lastInsertId();
-  admin_audit_log($pdo,$this_user_id,'module_contractors',$id,'CREATE',null,json_encode(['first_name'=>$first,'last_name'=>$last]),'Created contractor');
-  header('Location: ../contractor.php?id='.$id);
-  exit;
+$userId = (int)($_POST['user_id'] ?? 0);
+if($userId){
+  $stmt = $pdo->prepare('SELECT p.id FROM users u JOIN person p ON u.id = p.user_id WHERE u.id = :uid');
+  $stmt->execute([':uid'=>$userId]);
+  $personId = $stmt->fetchColumn();
+  if($personId){
+    $statusItems = get_lookup_items($pdo, 'CONTRACTOR_STATUS');
+    $statusId = null;
+    foreach($statusItems as $s){ if(!empty($s['is_default'])){ $statusId = $s['id']; break; } }
+    if(!$statusId && !empty($statusItems)){ $statusId = $statusItems[0]['id']; }
+
+    $typeItems = get_lookup_items($pdo, 'CONTRACTOR_TYPE');
+    $typeId = null;
+    foreach($typeItems as $t){ if(!empty($t['is_default'])){ $typeId = $t['id']; break; } }
+    if(!$typeId && !empty($typeItems)){ $typeId = $typeItems[0]['id']; }
+
+    $payItems = get_lookup_items($pdo, 'CONTRACTOR_COMPENSATION_TYPE');
+    $payId = null;
+    foreach($payItems as $p){ if(!empty($p['is_default'])){ $payId = $p['id']; break; } }
+    if(!$payId && !empty($payItems)){ $payId = $payItems[0]['id']; }
+
+    $stmt = $pdo->prepare('INSERT INTO module_contractors (user_id,user_updated,person_id,status_id,contractor_type_id,pay_type_id) VALUES (:user_id,:uid,:person_id,:status_id,:type_id,:pay_id)');
+    $stmt->execute([
+      ':user_id'=>$userId,
+      ':uid'=>$this_user_id,
+      ':person_id'=>$personId,
+      ':status_id'=>$statusId,
+      ':type_id'=>$typeId,
+      ':pay_id'=>$payId
+    ]);
+    $id = $pdo->lastInsertId();
+    admin_audit_log($pdo,$this_user_id,'module_contractors',$id,'CREATE',null,json_encode(['user_id'=>$userId,'person_id'=>$personId]),'Created contractor');
+    header('Location: ../contractor.php?id='.$id);
+    exit;
+  }
 }
 header('Location: ../contractor.php');
 exit;
+

--- a/admin/contractors/functions/update.php
+++ b/admin/contractors/functions/update.php
@@ -2,16 +2,31 @@
 require '../../includes/php_header.php';
 require_permission('contractors','update');
 
-$id    = (int)($_POST['id'] ?? 0);
-$first = trim($_POST['first_name'] ?? '');
-$last  = trim($_POST['last_name'] ?? '');
-if($id && $first !== '' && $last !== ''){
-  $stmtOld = $pdo->prepare('SELECT first_name,last_name FROM module_contractors WHERE id=:id');
+$id = (int)($_POST['id'] ?? 0);
+$statusId = $_POST['status_id'] ?? null;
+$payTypeId = $_POST['pay_type_id'] ?? null;
+$start = $_POST['start_date'] ?? null;
+$end = $_POST['end_date'] ?? null;
+$rate = $_POST['current_rate'] ?? null;
+
+if($id){
+  $stmtOld = $pdo->prepare('SELECT status_id,pay_type_id,start_date,end_date,current_rate FROM module_contractors WHERE id=:id');
   $stmtOld->execute([':id'=>$id]);
   $old = $stmtOld->fetch(PDO::FETCH_ASSOC);
-  $stmt = $pdo->prepare('UPDATE module_contractors SET first_name=:first,last_name=:last,user_updated=:uid WHERE id=:id');
-  $stmt->execute([':first'=>$first, ':last'=>$last, ':uid'=>$this_user_id, ':id'=>$id]);
-  admin_audit_log($pdo,$this_user_id,'module_contractors',$id,'UPDATE',json_encode($old),json_encode(['first_name'=>$first,'last_name'=>$last]),'Updated contractor');
+
+  $stmt = $pdo->prepare('UPDATE module_contractors SET status_id=:status,pay_type_id=:pay,start_date=:start,end_date=:end,current_rate=:rate,user_updated=:uid WHERE id=:id');
+  $stmt->execute([
+    ':status'=>$statusId,
+    ':pay'=>$payTypeId,
+    ':start'=>$start !== '' ? $start : null,
+    ':end'=>$end !== '' ? $end : null,
+    ':rate'=>$rate !== '' ? $rate : null,
+    ':uid'=>$this_user_id,
+    ':id'=>$id
+  ]);
+
+  admin_audit_log($pdo,$this_user_id,'module_contractors',$id,'UPDATE',json_encode($old),json_encode(['status_id'=>$statusId,'pay_type_id'=>$payTypeId,'start_date'=>$start,'end_date'=>$end,'current_rate'=>$rate]),'Updated contractor');
 }
 header('Location: ../contractor.php?id='.$id);
 exit;
+


### PR DESCRIPTION
## Summary
- populate Add Contractor form with available users and replace name inputs with a user selector
- create contractor records from selected user and default lookup values
- update contractors' status, pay type, dates and rate instead of name fields

## Testing
- `php -l admin/contractors/contractor.php`
- `php -l admin/contractors/functions/create.php`
- `php -l admin/contractors/functions/update.php`


------
https://chatgpt.com/codex/tasks/task_e_68a3eba21efc83339fa423ef29da9925