### PR TITLE
Switch to users_profile_pics for avatar paths

### DIFF
--- a/includes/navigation.php
+++ b/includes/navigation.php
@@ -105,7 +105,7 @@
 
         <li class="nav-item dropdown"><a class="nav-link lh-1 pe-0" id="navbarDropdownUser" href="#!" role="button" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-haspopup="true" aria-expanded="false">
             <div class="avatar avatar-l ">
-              <img class="rounded-circle" src="<?php echo getURLDir(); echo $this_user_profile_pic; ?>" alt="<?php echo $this_user_name; ?>" />
+              <img class="rounded-circle" src="<?php echo getURLDir() . (!empty($this_user_profile_pic) ? $this_user_profile_pic : 'assets/img/team/avatar.webp'); ?>" alt="<?php echo $this_user_name; ?>" />
             </div>
           </a>
           <div class="dropdown-menu dropdown-menu-end navbar-dropdown-caret py-0 dropdown-profile shadow border" aria-labelledby="navbarDropdownUser">
@@ -113,7 +113,7 @@
               <div class="card-body p-0">
                 <div class="text-center pt-4 pb-3">
                   <div class="avatar avatar-xl ">
-                    <img class="rounded-circle" src="<?php echo getURLDir(); ?>module/users/uploads/<?php echo $this_user_profile_pic; ?>" alt="<?php echo $this_user_name; ?>" />
+                    <img class="rounded-circle" src="<?php echo getURLDir() . (!empty($this_user_profile_pic) ? $this_user_profile_pic : 'assets/img/team/avatar.webp'); ?>" alt="<?php echo $this_user_name; ?>" />
                   </div>
                   <h6 class="mt-2 text-body-emphasis"><?php echo $this_user_name; ?></h6>
                 </div>

--- a/includes/php_header.php
+++ b/includes/php_header.php
@@ -28,8 +28,9 @@ if ($is_logged_in) {
   // STRINGS AREN'T FUN IN MySQL QUERIES
   $email = $_SESSION['this_user_email'];
 
-  $sql = "SELECT *
+  $sql = "SELECT u.*, upp.file_path
           FROM users u
+          LEFT JOIN users_profile_pics upp ON u.current_profile_pic_id = upp.id
           WHERE u.email = :email";
   $stmt = $pdo->prepare($sql);
   $stmt->bindParam(':email', $email, PDO::PARAM_STR);
@@ -38,7 +39,7 @@ if ($is_logged_in) {
     $this_user_id = $row['id']; // primary key ID
     $this_user_email = $row['email']; // email user signed up with
     $this_user_email_verified = $row['email_verified']; // 1 or 0
-    $this_user_profile_pic = $row['profile_pic']; // just the image_name (not path!)
+    $this_user_profile_pic = $row['file_path'];
     $this_user_type = $row['type']; // either 'admin' or 'user'
     $this_user_status = $row['status']; // 1 or 0
     $this_user_date_created = $row['date_created'];

--- a/module/project/functions/add_note.php
+++ b/module/project/functions/add_note.php
@@ -56,7 +56,7 @@ if($id && $note !== ''){
     }
   }
 
-  $noteStmt = $pdo->prepare('SELECT n.id, n.user_id, n.note_text, n.date_created, u.profile_pic, CONCAT(p.first_name, " ", p.last_name) AS user_name FROM module_projects_notes n LEFT JOIN users u ON n.user_id = u.id LEFT JOIN person p ON u.id = p.user_id WHERE n.id = :id');
+  $noteStmt = $pdo->prepare('SELECT n.id, n.user_id, n.note_text, n.date_created, upp.file_path, CONCAT(p.first_name, " ", p.last_name) AS user_name FROM module_projects_notes n LEFT JOIN users u ON n.user_id = u.id LEFT JOIN users_profile_pics upp ON u.current_profile_pic_id = upp.id AND upp.is_active = 1 LEFT JOIN person p ON u.id = p.user_id WHERE n.id = :id');
   $noteStmt->execute([':id' => $noteId]);
   $noteRow = $noteStmt->fetch(PDO::FETCH_ASSOC) ?: [];
   $noteRow['files'] = $uploaded;

--- a/module/project/include/card_view.php
+++ b/module/project/include/card_view.php
@@ -80,7 +80,7 @@ foreach ($projects as $proj) {
         <?php if (!empty($project['assignees'])): ?>
         <div class="avatar-group mt-3">
           <?php foreach ($project['assignees'] as $assignee):
-            $pic = !empty($assignee['profile_pic']) ? 'module/users/uploads/' . $assignee['profile_pic'] : 'assets/img/team/avatar.webp';
+            $pic = !empty($assignee['file_path']) ? $assignee['file_path'] : 'assets/img/team/avatar.webp';
           ?>
           <div class="avatar avatar-m rounded-circle">
             <a href="#" data-bs-toggle="modal" data-bs-target="#imageModal" data-img-src="<?php echo getURLDir() . h($pic); ?>">

--- a/module/project/include/details_view.php
+++ b/module/project/include/details_view.php
@@ -38,13 +38,13 @@ if (!empty($current_project)) {
         }
     }
     foreach ($notes as $n) {
-        $timelineEvents[] = [
-            'type' => 'note',
-            'date' => $n['date_created'] ?? '',
-            'note_text' => $n['note_text'] ?? '',
-            'user_name' => $n['user_name'] ?? '',
-            'profile_pic' => $n['profile_pic'] ?? ''
-        ];
+            $timelineEvents[] = [
+                'type' => 'note',
+                'date' => $n['date_created'] ?? '',
+                'note_text' => $n['note_text'] ?? '',
+                'user_name' => $n['user_name'] ?? '',
+                'file_path' => $n['file_path'] ?? ''
+            ];
     }
     usort($timelineEvents, function($a, $b) {
         return strtotime($b['date']) <=> strtotime($a['date']);
@@ -147,9 +147,10 @@ if (!empty($current_project)) {
                         <?php foreach ($assignedUsers as $au): ?>
                           <li class="d-flex align-items-center mb-2">
                             <div class="avatar avatar-xl me-2">
-                              <a href="#" data-bs-toggle="modal" data-bs-target="#imageModal" data-img-src="<?php echo getURLDir(); ?>module/users/uploads/<?= h($au['profile_pic'] ?? '') ?>">
-                                <img class="rounded-circle avatar avatar-m me-2" src="<?php echo getURLDir(); ?>module/users/uploads/<?= h($au['profile_pic'] ?? '') ?>" alt="<?= h($au['name']) ?>" />
-                              </a>
+                          <?php $pic = !empty($au['file_path']) ? $au['file_path'] : 'assets/img/team/avatar.webp'; ?>
+                          <a href="#" data-bs-toggle="modal" data-bs-target="#imageModal" data-img-src="<?php echo getURLDir() . h($pic); ?>">
+                                <img class="rounded-circle avatar avatar-m me-2" src="<?php echo getURLDir() . h($pic); ?>" alt="<?= h($au['name']) ?>" />
+                          </a>
                             </div>
                             <div class="d-flex align-items-center flex-grow-1">
                               <h6 class="mb-0"><?= h($au['name']) ?></h6>
@@ -347,7 +348,8 @@ if (!empty($current_project)) {
                         <span class="me-2 badge badge-phoenix fs-10 task-priority badge-phoenix-<?= h($t['priority_color']) ?>" data-value="<?= (int)$t['priority'] ?>"><?= h($t['priority_label']) ?></span>
                         <?php if (!empty($t['assignees'])): ?>
                           <?php foreach ($t['assignees'] as $a): ?>
-                            <img src="<?php echo getURLDir(); ?>module/users/uploads/<?= h($a['profile_pic']) ?>" class="avatar avatar-m me-1 rounded-circle" title="<?= h($a['name']) ?>" alt="<?= h($a['name']) ?>" />
+                            <?php $apic = !empty($a['file_path']) ? $a['file_path'] : 'assets/img/team/avatar.webp'; ?>
+                            <img src="<?php echo getURLDir() . h($apic); ?>" class="avatar avatar-m me-1 rounded-circle" title="<?= h($a['name']) ?>" alt="<?= h($a['name']) ?>" />
                           <?php endforeach; ?>
                         <?php else: ?>
                           <span class="fa-regular fa-user text-body-tertiary me-1"></span>
@@ -431,7 +433,8 @@ if (!empty($current_project)) {
                           </ul>
                         <?php endif; ?>
 
-                        <p class="fs-9 mb-0 d-flex align-items-center"><a href="#" data-bs-toggle="modal" data-bs-target="#imageModal" data-img-src="<?php echo getURLDir(); ?>module/users/uploads/<?= h($n['profile_pic'] ?? '') ?>"><img src="<?php echo getURLDir(); ?>module/users/uploads/<?= h($n['profile_pic'] ?? '') ?>" class="rounded-circle avatar avatar-m me-2" alt="" /></a>by <a class="fw-semibold ms-1" href="#!"><?= h($n['user_name'] ?? '') ?></a></p>
+                        <?php $npic = !empty($n['file_path']) ? $n['file_path'] : 'assets/img/team/avatar.webp'; ?>
+                        <p class="fs-9 mb-0 d-flex align-items-center"><a href="#" data-bs-toggle="modal" data-bs-target="#imageModal" data-img-src="<?php echo getURLDir() . h($npic); ?>"><img src="<?php echo getURLDir() . h($npic); ?>" class="rounded-circle avatar avatar-m me-2" alt="" /></a>by <a class="fw-semibold ms-1" href="#!"><?= h($n['user_name'] ?? '') ?></a></p>
                       </div>
                     </div>
                   </div>
@@ -530,7 +533,7 @@ document.addEventListener('DOMContentLoaded', function () {
   function renderTask(t){
     var overdue = t.due_date && !t.completed && new Date(t.due_date) < new Date();
     var assignees='';
-    if(t.assignees){ t.assignees.forEach(function(a){ assignees += `<img src="<?php echo getURLDir(); ?>module/users/uploads/${a.profile_pic}" class="avatar avatar-m me-1 rounded-circle" title="${a.name}" alt="${a.name}" />`; }); }
+    if(t.assignees){ t.assignees.forEach(function(a){ var pic = a.file_path ? '<?php echo getURLDir(); ?>'+a.file_path : '<?php echo getURLDir(); ?>assets/img/team/avatar.webp'; assignees += `<img src="${pic}" class="avatar avatar-m me-1 rounded-circle" title="${a.name}" alt="${a.name}" />`; }); }
     if(!assignees){ assignees = '<span class="fa-regular fa-user text-body-tertiary me-1"></span>'; }
     var due = t.due_date ? new Date(t.due_date).toLocaleDateString('en-US',{day:'2-digit',month:'short',year:'numeric'}) : '';
     return `<div class="row justify-content-between align-items-md-center hover-actions-trigger btn-reveal-trigger border-translucent py-3 gx-0 border-top task-row" data-task-id="${t.id}">
@@ -632,7 +635,7 @@ document.addEventListener('DOMContentLoaded', function () {
   function renderNote(n){
     var files='';
     if(n.files){ n.files.forEach(function(f){ files += `<li class=\"mb-1\"><div class=\"d-flex mb-1\"><span class=\"fa-solid ${f.file_type.startsWith('image/')?'fa-image':'fa-file'} me-2 text-body-tertiary fs-9\"></span><p class=\"text-body-highlight mb-0 lh-1\"><a class=\"text-body-highlight\" href=\"#\" data-bs-toggle=\"modal\" data-bs-target=\"#imageModal\" data-img-src=\"<?php echo getURLDir(); ?>${f.file_path}\">${f.file_name}</a></p></div></li>`; }); if(files){ files = `<ul class=\"list-unstyled mt-2\">${files}</ul>`; } }
-    return `<div class=\"timeline-item position-relative\"><div class=\"row g-md-3 mb-4\"><div class=\"col-12 col-md-auto d-flex\"><div class=\"timeline-item-date order-1 order-md-0 me-md-4\"><p class=\"fs-10 fw-semibold text-body-tertiary text-opacity-85 text-end\">${n.date_created}</p></div><div class=\"timeline-item-bar position-md-relative me-3 me-md-0\"><div class=\"icon-item icon-item-sm rounded-7 shadow-none bg-primary-subtle\"><span class=\"fa-solid fa-note-sticky text-primary-dark fs-10\"></span></div><span class=\"timeline-bar border-end border-dashed\"></span></div></div><div class=\"col\"><div class=\"timeline-item-content ps-6 ps-md-3\"><div class=\"border rounded-2 p-3\"><div class=\"d-flex\"><p class=\"fs-9 lh-sm mb-1 flex-grow-1 note-text\" data-note-id=\"${n.id}\">${n.note_text.replace(/\n/g,'<br>')}</p></div>${files}<p class=\"fs-9 mb-0 d-flex align-items-center\"><img src=\"<?php echo getURLDir(); ?>module/users/uploads/${n.profile_pic??''}\" class=\"rounded-circle avatar avatar-m me-2\" alt=\"\" />by <a class=\"fw-semibold ms-1\" href=\"#!\">${n.user_name??''}</a></p></div></div></div></div></div>`;
+    return `<div class=\"timeline-item position-relative\"><div class=\"row g-md-3 mb-4\"><div class=\"col-12 col-md-auto d-flex\"><div class=\"timeline-item-date order-1 order-md-0 me-md-4\"><p class=\"fs-10 fw-semibold text-body-tertiary text-opacity-85 text-end\">${n.date_created}</p></div><div class=\"timeline-item-bar position-md-relative me-3 me-md-0\"><div class=\"icon-item icon-item-sm rounded-7 shadow-none bg-primary-subtle\"><span class=\"fa-solid fa-note-sticky text-primary-dark fs-10\"></span></div><span class=\"timeline-bar border-end border-dashed\"></span></div></div><div class=\"col\"><div class=\"timeline-item-content ps-6 ps-md-3\"><div class=\"border rounded-2 p-3\"><div class=\"d-flex\"><p class=\"fs-9 lh-sm mb-1 flex-grow-1 note-text\" data-note-id=\"${n.id}\">${n.note_text.replace(/\n/g,'<br>')}</p></div>${files}<p class=\"fs-9 mb-0 d-flex align-items-center\"><img src=\"${n.file_path ? '<?php echo getURLDir(); ?>'+n.file_path : '<?php echo getURLDir(); ?>assets/img/team/avatar.webp'}\" class=\"rounded-circle avatar avatar-m me-2\" alt=\"\" />by <a class=\"fw-semibold ms-1\" href=\"#!\">${n.user_name??''}</a></p></div></div></div></div></div>`;
   }
 
   document.querySelectorAll('.note-text').forEach(function(p){

--- a/module/project/include/list_view.php
+++ b/module/project/include/list_view.php
@@ -68,9 +68,9 @@
           <td class="align-middle white-space-nowrap assignees ps-3">
             <div class="avatar-group avatar-group-dense">
               <?php foreach ($project['assignees'] as $assignee): ?>
-                <?php $pic = !empty($assignee['profile_pic']) ? 'module/users/uploads/' . $assignee['profile_pic'] : '../../assets/img/team/avatar.webp'; ?>
+                <?php $pic = !empty($assignee['file_path']) ? $assignee['file_path'] : 'assets/img/team/avatar.webp'; ?>
                 <div class="avatar avatar-s rounded-circle">
-                  <img class="rounded-circle" src="<? echo getURLDir(); ?><?= h($pic); ?>" alt="<?= h($assignee['name']); ?>" />
+                  <img class="rounded-circle" src="<?php echo getURLDir() . h($pic); ?>" alt="<?= h($assignee['name']); ?>" />
                 </div>
               <?php endforeach; ?>
             </div>

--- a/module/task/functions/toggle_complete.php
+++ b/module/task/functions/toggle_complete.php
@@ -52,9 +52,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $taskRow = $taskStmt->fetch(PDO::FETCH_ASSOC) ?: [];
     if($taskRow){
       $assignStmt = $pdo->prepare(
-        'SELECT ta.assigned_user_id AS user_id, u.profile_pic, CONCAT(p.first_name, " ", p.last_name) AS name '
+        'SELECT ta.assigned_user_id AS user_id, upp.file_path, CONCAT(p.first_name, " ", p.last_name) AS name '
         . 'FROM module_task_assignments ta '
         . 'LEFT JOIN users u ON ta.assigned_user_id = u.id '
+        . 'LEFT JOIN users_profile_pics upp ON u.current_profile_pic_id = upp.id AND upp.is_active = 1 '
         . 'LEFT JOIN person p ON u.id = p.user_id '
         . 'WHERE ta.task_id = :id'
       );

--- a/module/task/include/details_view.php
+++ b/module/task/include/details_view.php
@@ -50,7 +50,8 @@ require_once __DIR__ . '/../../../includes/functions.php';
                 <?php foreach ($assignedUsers as $au): ?>
                   <li class="d-flex align-items-center mb-2">
                     <div class="avatar avatar-xl me-2">
-                      <img class="rounded-circle" src="<?php echo getURLDir(); ?>module/users/uploads/<?php echo h($au['profile_pic'] ?? ''); ?>" alt="<?php echo h($au['name']); ?>" />
+                      <?php $dpic = !empty($au['file_path']) ? $au['file_path'] : 'assets/img/team/avatar.webp'; ?>
+                      <img class="rounded-circle" src="<?php echo getURLDir() . h($dpic); ?>" alt="<?php echo h($au['name']); ?>" />
                     </div>
                     <div class="flex-grow-1">
                       <h6 class="mb-0"><?php echo h($au['name']); ?></h6>

--- a/module/task/include/list_view.php
+++ b/module/task/include/list_view.php
@@ -33,7 +33,8 @@
                 <span class="me-2 badge badge-phoenix fs-10 task-priority badge-phoenix-<?= h($t['priority_color']) ?>" data-value="<?= (int)$t['priority'] ?>"><?= h($t['priority_label']) ?></span>
                 <?php if (!empty($t['assignees'])): ?>
                   <?php foreach ($t['assignees'] as $a): ?>
-                    <img src="<?php echo getURLDir(); ?>module/users/uploads/<?= h($a['profile_pic']) ?>" class="avatar avatar-m me-1 rounded-circle" title="<?= h($a['name']) ?>" alt="<?= h($a['name']) ?>" />
+                    <?php $tpic = !empty($a['file_path']) ? $a['file_path'] : 'assets/img/team/avatar.webp'; ?>
+                    <img src="<?php echo getURLDir() . h($tpic); ?>" class="avatar avatar-m me-1 rounded-circle" title="<?= h($a['name']) ?>" alt="<?= h($a['name']) ?>" />
                   <?php endforeach; ?>
                 <?php else: ?>
                   <span class="fa-regular fa-user text-body-tertiary me-1"></span>
@@ -78,7 +79,7 @@ document.addEventListener('DOMContentLoaded', function () {
   function renderTask(t){
     var overdue = t.due_date && !t.completed && new Date(t.due_date) < new Date();
     var assignees = '';
-    if(t.assignees){ t.assignees.forEach(function(a){ assignees += `<img src="<?php echo getURLDir(); ?>module/users/uploads/${a.profile_pic}" class="avatar avatar-m me-1 rounded-circle" title="${a.name}" alt="${a.name}" />`; }); }
+    if(t.assignees){ t.assignees.forEach(function(a){ var pic = a.file_path ? '<?php echo getURLDir(); ?>'+a.file_path : '<?php echo getURLDir(); ?>assets/img/team/avatar.webp'; assignees += `<img src="${pic}" class="avatar avatar-m me-1 rounded-circle" title="${a.name}" alt="${a.name}" />`; }); }
     if(!assignees){ assignees = '<span class="fa-regular fa-user text-body-tertiary me-1"></span>'; }
     var due = t.due_date ? new Date(t.due_date).toLocaleDateString('en-US',{day:'2-digit',month:'short',year:'numeric'}) : '';
     return `<div class="row justify-content-between align-items-md-center hover-actions-trigger btn-reveal-trigger border-translucent py-3 gx-0 border-top task-row" data-task-id="${t.id}">

--- a/module/task/index.php
+++ b/module/task/index.php
@@ -121,21 +121,22 @@ $tasks = $stmt->fetchAll(PDO::FETCH_ASSOC);
 if ($tasks) {
   $taskIds = array_column($tasks, 'id');
   $placeholders = implode(',', array_fill(0, count($taskIds), '?'));
-  $taskAssignStmt = $pdo->prepare(
-    'SELECT ta.task_id, ta.assigned_user_id, u.profile_pic, CONCAT(per.first_name, " ", per.last_name) AS name '
-    . 'FROM module_task_assignments ta '
-    . 'LEFT JOIN users u ON ta.assigned_user_id = u.id '
-    . 'LEFT JOIN person per ON u.id = per.user_id '
-    . 'WHERE ta.task_id IN (' . $placeholders . ')'
-  );
+    $taskAssignStmt = $pdo->prepare(
+      'SELECT ta.task_id, ta.assigned_user_id, upp.file_path, CONCAT(per.first_name, " ", per.last_name) AS name '
+      . 'FROM module_task_assignments ta '
+      . 'LEFT JOIN users u ON ta.assigned_user_id = u.id '
+      . 'LEFT JOIN users_profile_pics upp ON u.current_profile_pic_id = upp.id AND upp.is_active = 1 '
+      . 'LEFT JOIN person per ON u.id = per.user_id '
+      . 'WHERE ta.task_id IN (' . $placeholders . ')'
+    );
   $taskAssignStmt->execute($taskIds);
   $taskAssignments = [];
   foreach ($taskAssignStmt as $row) {
-    $taskAssignments[$row['task_id']][] = [
-      'assigned_user_id' => $row['assigned_user_id'],
-      'profile_pic'      => $row['profile_pic'],
-      'name'             => $row['name']
-    ];
+      $taskAssignments[$row['task_id']][] = [
+        'assigned_user_id' => $row['assigned_user_id'],
+        'file_path'      => $row['file_path'],
+        'name'             => $row['name']
+      ];
   }
   foreach ($tasks as &$tTask) {
     $tTask['assignees'] = $taskAssignments[$tTask['id']] ?? [];
@@ -170,7 +171,7 @@ if ($action === 'details') {
   $availableUsers = [];
   if ($current_task) {
 
-    $assignedStmt = $pdo->prepare('SELECT mta.assigned_user_id AS user_id, u.profile_pic, CONCAT(p.first_name, " ", p.last_name) AS name FROM module_task_assignments mta JOIN users u ON mta.assigned_user_id = u.id LEFT JOIN person p ON u.id = p.user_id WHERE mta.task_id = :id');
+      $assignedStmt = $pdo->prepare('SELECT mta.assigned_user_id AS user_id, upp.file_path, CONCAT(p.first_name, " ", p.last_name) AS name FROM module_task_assignments mta JOIN users u ON mta.assigned_user_id = u.id LEFT JOIN users_profile_pics upp ON u.current_profile_pic_id = upp.id AND upp.is_active = 1 LEFT JOIN person p ON u.id = p.user_id WHERE mta.task_id = :id');
     $assignedStmt->execute([':id' => $task_id]);
     $assignedUsers = $assignedStmt->fetchAll(PDO::FETCH_ASSOC);
 


### PR DESCRIPTION
## Summary
- Retrieve current user's avatar from users_profile_pics via current_profile_pic_id
- Update navigation and module templates to use `file_path` with fallback avatar
- Replace `users.profile_pic` joins with `users_profile_pics` across project and task modules

## Testing
- `php -l includes/php_header.php includes/navigation.php module/project/index.php module/project/functions/add_note.php module/project/include/details_view.php module/project/include/list_view.php module/project/include/card_view.php module/task/index.php module/task/functions/toggle_complete.php module/task/include/details_view.php module/task/include/list_view.php`

------
https://chatgpt.com/codex/tasks/task_e_68a3f2f398d48333ab1f39c58a0cada6