### PR TITLE
feat: track and restore task status

### DIFF
--- a/_SQL/atlis.sql
+++ b/_SQL/atlis.sql
@@ -1362,6 +1362,7 @@ CREATE TABLE `module_tasks` (
   `requirements` text DEFAULT NULL,
   `specifications` text DEFAULT NULL,
   `status` varchar(11) DEFAULT NULL,
+  `previous_status` int(11) DEFAULT NULL,
   `priority` varchar(11) DEFAULT NULL,
   `start_date` date DEFAULT NULL,
   `due_date` date DEFAULT NULL,

--- a/module/task/functions/create.php
+++ b/module/task/functions/create.php
@@ -44,7 +44,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
   if($isAjax){
     $taskStmt = $pdo->prepare(
-      'SELECT t.id, t.name, t.status, t.priority, t.due_date, t.completed, ' .
+      'SELECT t.id, t.name, t.status, t.previous_status, t.priority, t.due_date, t.completed, ' .
       'ls.label AS status_label, COALESCE(lsattr.attr_value, "secondary") AS status_color, ' .
       'lp.label AS priority_label, COALESCE(lpat.attr_value, "secondary") AS priority_color ' .
       'FROM module_tasks t ' .

--- a/module/task/functions/update.php
+++ b/module/task/functions/update.php
@@ -8,6 +8,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   $id = (int)($_POST['id'] ?? 0);
 
   if ($id) {
+    $origStmt = $pdo->prepare('SELECT name, status, priority, description FROM module_tasks WHERE id = :id');
+    $origStmt->execute([':id' => $id]);
+    $existing = $origStmt->fetch(PDO::FETCH_ASSOC);
+    if (!$existing) {
+      echo json_encode(['success' => false]);
+      exit;
+    }
+
     $fields = [];
     $params = [
       ':uid' => $this_user_id,
@@ -39,7 +47,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 
     $taskStmt = $pdo->prepare(
-      'SELECT t.id, t.name, t.status, t.priority, t.due_date, t.completed, ' .
+      'SELECT t.id, t.name, t.status, t.previous_status, t.priority, t.due_date, t.completed, ' .
       'ls.label AS status_label, COALESCE(lsattr.attr_value, "secondary") AS status_color, ' .
       'lp.label AS priority_label, COALESCE(lpat.attr_value, "secondary") AS priority_color ' .
       'FROM module_tasks t ' .

--- a/module/task/functions/update_field.php
+++ b/module/task/functions/update_field.php
@@ -17,7 +17,7 @@ if ($id > 0 && in_array($field, ['status','priority'], true)) {
   audit_log($pdo, $this_user_id, 'module_tasks', $id, 'UPDATE', 'Updated task ' . $field);
 
   $taskStmt = $pdo->prepare(
-    'SELECT t.id, t.name, t.status, t.priority, t.due_date, t.completed, ' .
+    'SELECT t.id, t.name, t.status, t.previous_status, t.priority, t.due_date, t.completed, ' .
     'ls.label AS status_label, COALESCE(lsattr.attr_value, "secondary") AS status_color, ' .
     'lp.label AS priority_label, COALESCE(lpat.attr_value, "secondary") AS priority_color ' .
     'FROM module_tasks t ' .

--- a/module/task/include/list_view.php
+++ b/module/task/include/list_view.php
@@ -28,7 +28,7 @@
           <div class="col-12 col-md-auto flex-1">
             <div>
               <div class="form-check mb-1 mb-md-0 d-flex align-items-center lh-1 position-relative" style="z-index:1;">
-                <input class="form-check-input flex-shrink-0 form-check-line-through mt-0 me-2" type="checkbox" id="checkbox-todo-<?= (int)$t['id'] ?>" data-task-id="<?= (int)$t['id'] ?>" <?= !empty($t['completed']) ? 'checked' : '' ?> />
+                <input class="form-check-input flex-shrink-0 form-check-line-through mt-0 me-2" type="checkbox" id="checkbox-todo-<?= (int)$t['id'] ?>" data-task-id="<?= (int)$t['id'] ?>" data-prev-status="<?= (int)($t['previous_status'] ?? $t['status']) ?>" <?= !empty($t['completed']) ? 'checked' : '' ?> />
                 <span class="me-2 badge badge-phoenix fs-10 task-status badge-phoenix-<?= h($t['status_color']) ?>" data-value="<?= (int)$t['status'] ?>"><?= h($t['status_label']) ?></span>
                 <span class="me-2 badge badge-phoenix fs-10 task-priority badge-phoenix-<?= h($t['priority_color']) ?>" data-value="<?= (int)$t['priority'] ?>"><?= h($t['priority_label']) ?></span>
                 <?php if (!empty($t['assignees'])): ?>
@@ -86,7 +86,7 @@ document.addEventListener('DOMContentLoaded', function () {
       <div class="col-12 col-md-auto flex-1">
         <div>
           <div class="form-check mb-1 mb-md-0 d-flex align-items-center lh-1 position-relative" style="z-index:1;">
-            <input class="form-check-input flex-shrink-0 form-check-line-through mt-0 me-2" type="checkbox" data-task-id="${t.id}" ${t.completed ? 'checked' : ''} />
+            <input class="form-check-input flex-shrink-0 form-check-line-through mt-0 me-2" type="checkbox" data-task-id="${t.id}" data-prev-status="${t.previous_status ? t.previous_status : t.status}" ${t.completed ? 'checked' : ''} />
             <span class="me-2 badge badge-phoenix fs-10 task-status badge-phoenix-${t.status_color}" data-value="${t.status}">${t.status_label}</span>
             <span class="me-2 badge badge-phoenix fs-10 task-priority badge-phoenix-${t.priority_color}" data-value="${t.priority}">${t.priority_label}</span>
             ${assignees}
@@ -108,6 +108,9 @@ document.addEventListener('DOMContentLoaded', function () {
     if(cb){
       cb.addEventListener('change', function(){
         var params = new URLSearchParams({id: cb.dataset.taskId, completed: cb.checked ? 1 : 0});
+        if(!cb.checked && cb.dataset.prevStatus){
+          params.append('status', cb.dataset.prevStatus);
+        }
         fetch('functions/toggle_complete.php',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:params})
           .then(r=>r.json()).then(d=>{
             var isChecked = cb.checked;


### PR DESCRIPTION
## Summary
- persist each task's previous_status in the database
- restore or record previous status when toggling completion
- guard task save/update endpoints against missing fields

## Testing
- `php -l module/task/functions/toggle_complete.php`
- `php -l module/task/functions/create.php`
- `php -l module/task/functions/update.php`
- `php -l module/task/functions/update_field.php`
- `php -l module/task/index.php`
- `php -l module/task/include/list_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68a3f67e4300833382cc53d6f5f626d6