### PR TITLE
Add profile picture versioning

### DIFF
--- a/_SQL/atlis.sql
+++ b/_SQL/atlis.sql
@@ -1590,6 +1590,7 @@ CREATE TABLE `users` (
   `password` varchar(255) NOT NULL,
   `email_verified` tinyint(1) DEFAULT 0,
   `profile_pic` varchar(255) DEFAULT NULL,
+  `current_profile_pic_id` int(11) DEFAULT NULL,
   `type` enum('ADMIN','USER') DEFAULT 'USER',
   `status` tinyint(1) DEFAULT 1,
   `last_login` datetime DEFAULT NULL
@@ -1599,11 +1600,39 @@ CREATE TABLE `users` (
 -- Dumping data for table `users`
 --
 
-INSERT INTO `users` (`id`, `user_id`, `user_updated`, `date_created`, `date_updated`, `memo`, `email`, `password`, `email_verified`, `profile_pic`, `type`, `status`, `last_login`) VALUES
-(1, 1, 1, '2025-08-06 16:08:42', '2025-08-17 11:15:50', NULL, 'Dave@AtlisTechnologies.com', '$2y$10$jN1XBh3o8MrgbwhNU9Q4ze68Fh6B/Mv1UO8GXAgBjLchYF0.YpK/q', 1, 'dave_2.JPG', 'ADMIN', 1, '2025-08-16 17:30:14'),
-(2, 1, 1, '2025-08-15 00:11:11', '2025-08-15 00:13:55', NULL, 'Sean@AtlisTechnologies.com', '$2y$10$Bk4sqfPb4G49fa9HepMbBOfOjz/wEtvFJBSHIz9HFMO0nzOFeeJ3u', 0, 'sean.jpg', 'USER', 1, NULL),
-(4, 1, 1, '2025-08-17 22:17:49', '2025-08-17 22:17:49', NULL, 'soup@atlistechnologies.com', '$2y$10$RIcmMSjwTvMljhHAoEaJVuxVyUnxzYTE9RJehqRaTxj7aRyA4gaq2', 0, NULL, 'USER', 1, NULL);
+INSERT INTO `users` (`id`, `user_id`, `user_updated`, `date_created`, `date_updated`, `memo`, `email`, `password`, `email_verified`, `profile_pic`, `current_profile_pic_id`, `type`, `status`, `last_login`) VALUES
+(1, 1, 1, '2025-08-06 16:08:42', '2025-08-17 11:15:50', NULL, 'Dave@AtlisTechnologies.com', '$2y$10$jN1XBh3o8MrgbwhNU9Q4ze68Fh6B/Mv1UO8GXAgBjLchYF0.YpK/q', 1, 'dave_2.JPG', NULL, 'ADMIN', 1, '2025-08-16 17:30:14'),
+(2, 1, 1, '2025-08-15 00:11:11', '2025-08-15 00:13:55', NULL, 'Sean@AtlisTechnologies.com', '$2y$10$Bk4sqfPb4G49fa9HepMbBOfOjz/wEtvFJBSHIz9HFMO0nzOFeeJ3u', 0, 'sean.jpg', NULL, 'USER', 1, NULL),
+(4, 1, 1, '2025-08-17 22:17:49', '2025-08-17 22:17:49', NULL, 'soup@atlistechnologies.com', '$2y$10$RIcmMSjwTvMljhHAoEaJVuxVyUnxzYTE9RJehqRaTxj7aRyA4gaq2', 0, NULL, NULL, 'USER', 1, NULL);
 
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `users_profile_pics`
+--
+
+CREATE TABLE `users_profile_pics` (
+  `id` int(11) NOT NULL,
+  `user_id` int(11) DEFAULT NULL,
+  `uploaded_by` int(11) DEFAULT NULL,
+  `file_path` varchar(255) NOT NULL,
+  `file_size` int(11) DEFAULT NULL,
+  `mime_type` varchar(100) DEFAULT NULL,
+  `width` int(11) DEFAULT NULL,
+  `height` int(11) DEFAULT NULL,
+  `hash` varchar(64) DEFAULT NULL,
+  `status_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT current_timestamp(),
+  `date_updated` datetime DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  `memo` text DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+--
+-- Dumping data for table `users_profile_pics`
+--
+
+--
 -- --------------------------------------------------------
 
 --
@@ -1957,7 +1986,18 @@ ALTER TABLE `system_properties_versions`
 ALTER TABLE `users`
   ADD PRIMARY KEY (`id`),
   ADD KEY `fk_users_user_id` (`user_id`),
-  ADD KEY `fk_users_user_updated` (`user_updated`);
+  ADD KEY `fk_users_user_updated` (`user_updated`),
+  ADD KEY `fk_users_current_profile_pic_id` (`current_profile_pic_id`);
+
+--
+-- Indexes for table `users_profile_pics`
+--
+ALTER TABLE `users_profile_pics`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `fk_users_profile_pics_user_id` (`user_id`),
+  ADD KEY `fk_users_profile_pics_uploaded_by` (`uploaded_by`),
+  ADD KEY `fk_users_profile_pics_status_id` (`status_id`),
+  ADD KEY `fk_users_profile_pics_user_updated` (`user_updated`);
 
 --
 -- Indexes for table `users_2fa`
@@ -2164,6 +2204,12 @@ ALTER TABLE `system_properties_versions`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=2;
 
 --
+-- AUTO_INCREMENT for table `users_profile_pics`
+--
+ALTER TABLE `users_profile_pics`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
 -- AUTO_INCREMENT for table `users`
 --
 ALTER TABLE `users`
@@ -2302,6 +2348,21 @@ ALTER TABLE `module_tasks_notes`
 ALTER TABLE `module_task_assignments`
   ADD CONSTRAINT `fk_module_task_assignments_assigned_user_id` FOREIGN KEY (`assigned_user_id`) REFERENCES `users` (`id`),
   ADD CONSTRAINT `fk_module_task_assignments_task_id` FOREIGN KEY (`task_id`) REFERENCES `module_tasks` (`id`);
+
+--
+-- Constraints for table `users`
+--
+ALTER TABLE `users`
+  ADD CONSTRAINT `fk_users_current_profile_pic_id` FOREIGN KEY (`current_profile_pic_id`) REFERENCES `users_profile_pics` (`id`) ON DELETE SET NULL;
+
+--
+-- Constraints for table `users_profile_pics`
+--
+ALTER TABLE `users_profile_pics`
+  ADD CONSTRAINT `fk_users_profile_pics_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE,
+  ADD CONSTRAINT `fk_users_profile_pics_uploaded_by` FOREIGN KEY (`uploaded_by`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  ADD CONSTRAINT `fk_users_profile_pics_status_id` FOREIGN KEY (`status_id`) REFERENCES `lookup_list_items` (`id`),
+  ADD CONSTRAINT `fk_users_profile_pics_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`) ON DELETE SET NULL;
 COMMIT;
 
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;

--- a/admin/users/functions/save.php
+++ b/admin/users/functions/save.php
@@ -13,18 +13,46 @@ if (!hash_equals($_SESSION['csrf_token'] ?? '', $_POST['csrf_token'] ?? '')) {
   die('Invalid CSRF token');
 }
 
- $id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
- $isUpdate = $id > 0;
- $email = filter_var(trim($_POST['email'] ?? ''), FILTER_VALIDATE_EMAIL) ?: '';
- $password = $_POST['password'] ?? '';
- $confirm = $_POST['confirmPassword'] ?? '';
- $first_name = trim($_POST['first_name'] ?? '');
- $last_name = trim($_POST['last_name'] ?? '');
- $gender_id = isset($_POST['gender_id']) && $_POST['gender_id'] !== '' ? (int)$_POST['gender_id'] : null;
- $phone = preg_replace('/[^0-9]/', '', $_POST['phone'] ?? '');
- $dob = $_POST['dob'] ?? '';
- $address = trim($_POST['address'] ?? '');
- $memo = $_POST['memo'] ?? null;
+$id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+$reactivatePicId = isset($_POST['reactivate_pic_id']) ? (int)$_POST['reactivate_pic_id'] : 0;
+
+function get_status_id(PDO $pdo, string $code): int {
+  $stmt = $pdo->prepare("SELECT li.id FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'USER_STATUS' AND li.code = :code LIMIT 1");
+  $stmt->execute([':code' => $code]);
+  return (int)$stmt->fetchColumn();
+}
+
+$activeStatusId = get_status_id($pdo, 'ACTIVE');
+$inactiveStatusId = get_status_id($pdo, 'INACTIVE');
+
+if ($reactivatePicId && $id) {
+  $pdo->beginTransaction();
+  $pdo->prepare('UPDATE users_profile_pics SET status_id = :inactive, user_updated = :uid WHERE user_id = :user')
+      ->execute([':inactive' => $inactiveStatusId, ':uid' => $this_user_id, ':user' => $id]);
+  $pdo->prepare('UPDATE users_profile_pics SET status_id = :active, user_updated = :uid WHERE id = :pic')
+      ->execute([':active' => $activeStatusId, ':uid' => $this_user_id, ':pic' => $reactivatePicId]);
+  $picStmt = $pdo->prepare('SELECT file_path FROM users_profile_pics WHERE id = :pic');
+  $picStmt->execute([':pic' => $reactivatePicId]);
+  $picFile = basename((string)$picStmt->fetchColumn());
+  $pdo->prepare('UPDATE users SET current_profile_pic_id = :pic, profile_pic = :file, user_updated = :uid WHERE id = :user')
+      ->execute([':pic' => $reactivatePicId, ':file' => $picFile, ':uid' => $this_user_id, ':user' => $id]);
+  $pdo->commit();
+  $_SESSION['message'] = 'Profile picture updated.';
+  header('Location: ../edit.php?id=' . $id);
+  exit;
+}
+
+$isUpdate = $id > 0;
+$email = filter_var(trim($_POST['email'] ?? ''), FILTER_VALIDATE_EMAIL) ?: '';
+$password = $_POST['password'] ?? '';
+$confirm = $_POST['confirmPassword'] ?? '';
+$first_name = trim($_POST['first_name'] ?? '');
+$last_name = trim($_POST['last_name'] ?? '');
+$gender_id = isset($_POST['gender_id']) && $_POST['gender_id'] !== '' ? (int)$_POST['gender_id'] : null;
+$phone = preg_replace('/[^0-9]/', '', $_POST['phone'] ?? '');
+$dob = $_POST['dob'] ?? '';
+$address = trim($_POST['address'] ?? '');
+$memo = $_POST['memo'] ?? null;
 
  $errors = [];
  if ($email === '') {
@@ -63,12 +91,9 @@ if ($password !== '' && $password !== $confirm) {
 $hash = $password !== '' ? password_hash($password, PASSWORD_DEFAULT) : null;
 
 $profilePath = null;
-$oldProfile = null;
-if ($isUpdate) {
-  $stmt = $pdo->prepare('SELECT profile_pic FROM users WHERE id = :id');
-  $stmt->execute([':id' => $id]);
-  $oldProfile = $stmt->fetchColumn();
-}
+$fileSize = $mime = $hashFile = null;
+$width = $height = null;
+$filename = null;
 if (!empty($_FILES['profile_pic']['name']) && $_FILES['profile_pic']['error'] === UPLOAD_ERR_OK) {
   $file = $_FILES['profile_pic'];
   if ($file['size'] <= 10 * 1024 * 1024) {
@@ -87,75 +112,100 @@ if (!empty($_FILES['profile_pic']['name']) && $_FILES['profile_pic']['error'] ==
       $dest = $destDir . $filename;
       if (move_uploaded_file($file['tmp_name'], $dest)) {
         $profilePath = 'module/users/uploads/' . $filename;
-        if ($oldProfile && file_exists('../../../' . $oldProfile)) {
-          @unlink('../../../' . $oldProfile);
+        $fileSize = $file['size'];
+        $hashFile = hash_file('sha256', $dest);
+        $img = getimagesize($dest);
+        if ($img) {
+          $width = $img[0];
+          $height = $img[1];
         }
       }
     }
   }
 }
 
- try {
-   if ($isUpdate) {
-     $fields = 'email = :email, memo = :memo, user_updated = :uid';
-     $params = [
-       ':email' => $email,
-       ':memo' => $memo,
-       ':uid' => $this_user_id,
-       ':id' => $id
-     ];
-     if ($hash) { $fields .= ', password = :password'; $params[':password'] = $hash; }
-     if ($profilePath) { $fields .= ', profile_pic = :pic'; $params[':pic'] = $profilePath; }
-     $stmt = $pdo->prepare('UPDATE users SET ' . $fields . ' WHERE id = :id');
-     $stmt->execute($params);
+try {
+  if ($isUpdate) {
+    $fields = 'email = :email, memo = :memo, user_updated = :uid';
+    $params = [
+      ':email' => $email,
+      ':memo' => $memo,
+      ':uid' => $this_user_id,
+      ':id' => $id
+    ];
+    if ($hash) { $fields .= ', password = :password'; $params[':password'] = $hash; }
+    $stmt = $pdo->prepare('UPDATE users SET ' . $fields . ' WHERE id = :id');
+    $stmt->execute($params);
 
-     $personExists = $pdo->prepare('SELECT id FROM person WHERE user_id = :uid_fk');
-     $personExists->execute([':uid_fk' => $id]);
-     $personParams = [
-       ':uid_fk' => $id,
-       ':fn' => $first_name,
-       ':ln' => $last_name,
-       ':gender_id' => $gender_id,
-       ':phone' => $phone,
-       ':dob' => $dob ?: null,
-       ':address' => $address,
-       ':uid_update' => $this_user_id
-     ];
-     if ($personExists->fetchColumn()) {
-       $pstmt = $pdo->prepare('UPDATE person SET first_name = :fn, last_name = :ln, gender_id = :gender_id, phone = :phone, dob = :dob, address = :address, user_updated = :uid_update WHERE user_id = :uid_fk');
-       $pstmt->execute($personParams);
-     } else {
-       $pstmt = $pdo->prepare('INSERT INTO person (user_id, first_name, last_name, gender_id, phone, dob, address, user_updated) VALUES (:uid_fk, :fn, :ln, :gender_id, :phone, :dob, :address, :uid_update)');
-       $pstmt->execute($personParams);
-     }
-   } else {
-     $stmt = $pdo->prepare('INSERT INTO users (user_id, user_updated, email, password, profile_pic, memo) VALUES (:uid, :uid, :email, :password, :pic, :memo)');
-     $stmt->execute([
-       ':uid' => $this_user_id,
-       ':email' => $email,
-       ':password' => $hash,
-       ':pic' => $profilePath,
-       ':memo' => $memo
-     ]);
-     $id = (int)$pdo->lastInsertId();
+    $personExists = $pdo->prepare('SELECT id FROM person WHERE user_id = :uid_fk');
+    $personExists->execute([':uid_fk' => $id]);
+    $personParams = [
+      ':uid_fk' => $id,
+      ':fn' => $first_name,
+      ':ln' => $last_name,
+      ':gender_id' => $gender_id,
+      ':phone' => $phone,
+      ':dob' => $dob ?: null,
+      ':address' => $address,
+      ':uid_update' => $this_user_id
+    ];
+    if ($personExists->fetchColumn()) {
+      $pstmt = $pdo->prepare('UPDATE person SET first_name = :fn, last_name = :ln, gender_id = :gender_id, phone = :phone, dob = :dob, address = :address, user_updated = :uid_update WHERE user_id = :uid_fk');
+      $pstmt->execute($personParams);
+    } else {
+      $pstmt = $pdo->prepare('INSERT INTO person (user_id, first_name, last_name, gender_id, phone, dob, address, user_updated) VALUES (:uid_fk, :fn, :ln, :gender_id, :phone, :dob, :address, :uid_update)');
+      $pstmt->execute($personParams);
+    }
+  } else {
+    $stmt = $pdo->prepare('INSERT INTO users (user_id, user_updated, email, password, memo) VALUES (:uid, :uid, :email, :password, :memo)');
+    $stmt->execute([
+      ':uid' => $this_user_id,
+      ':email' => $email,
+      ':password' => $hash,
+      ':memo' => $memo
+    ]);
+    $id = (int)$pdo->lastInsertId();
 
-     $pstmt = $pdo->prepare('INSERT INTO person (user_id, first_name, last_name, gender_id, phone, dob, address, user_updated) VALUES (:uid_fk, :fn, :ln, :gender_id, :phone, :dob, :address, :uid_update)');
-     $pstmt->execute([
-       ':uid_fk' => $id,
-       ':fn' => $first_name,
-       ':ln' => $last_name,
-       ':gender_id' => $gender_id,
-       ':phone' => $phone,
-       ':dob' => $dob ?: null,
-       ':address' => $address,
-       ':uid_update' => $this_user_id
-     ]);
-   }
+    $pstmt = $pdo->prepare('INSERT INTO person (user_id, first_name, last_name, gender_id, phone, dob, address, user_updated) VALUES (:uid_fk, :fn, :ln, :gender_id, :phone, :dob, :address, :uid_update)');
+    $pstmt->execute([
+      ':uid_fk' => $id,
+      ':fn' => $first_name,
+      ':ln' => $last_name,
+      ':gender_id' => $gender_id,
+      ':phone' => $phone,
+      ':dob' => $dob ?: null,
+      ':address' => $address,
+      ':uid_update' => $this_user_id
+    ]);
+  }
 
-   $_SESSION['message'] = $isUpdate ? 'User updated.' : 'User created.';
- } catch (Exception $e) {
-   $_SESSION['message'] = 'Error saving user.';
- }
+  if ($profilePath) {
+    $pdo->beginTransaction();
+    $pdo->prepare('UPDATE users_profile_pics SET status_id = :inactive, user_updated = :uid WHERE user_id = :user')
+        ->execute([':inactive' => $inactiveStatusId, ':uid' => $this_user_id, ':user' => $id]);
+    $pstmt = $pdo->prepare('INSERT INTO users_profile_pics (user_id, uploaded_by, file_path, file_size, mime_type, width, height, hash, status_id, user_updated) VALUES (:user_id, :uploaded_by, :file_path, :file_size, :mime_type, :width, :height, :hash, :status_id, :uid)');
+    $pstmt->execute([
+      ':user_id' => $id,
+      ':uploaded_by' => $this_user_id,
+      ':file_path' => $profilePath,
+      ':file_size' => $fileSize,
+      ':mime_type' => $mime,
+      ':width' => $width,
+      ':height' => $height,
+      ':hash' => $hashFile,
+      ':status_id' => $activeStatusId,
+      ':uid' => $this_user_id
+    ]);
+    $picId = (int)$pdo->lastInsertId();
+    $pdo->prepare('UPDATE users SET current_profile_pic_id = :pic, profile_pic = :file, user_updated = :uid WHERE id = :user')
+        ->execute([':pic' => $picId, ':file' => $filename, ':uid' => $this_user_id, ':user' => $id]);
+    $pdo->commit();
+  }
 
- header('Location: ../index.php');
- exit;
+  $_SESSION['message'] = $isUpdate ? 'User updated.' : 'User created.';
+} catch (Exception $e) {
+  $_SESSION['message'] = 'Error saving user.';
+}
+
+header('Location: ../index.php');
+exit;


### PR DESCRIPTION
## Summary
- track profile picture history in new `users_profile_pics` table linked by `current_profile_pic_id`
- save handler records uploads, updates user record, and keeps previous images inactive

## Testing
- `php -l admin/users/functions/save.php`
- `php -l admin/users/edit.php`


------
https://chatgpt.com/codex/tasks/task_e_68a3f2f618408333a82412bc3f5f22b7