### PR TITLE
Add inline project date editing and task filters

### DIFF
--- a/module/project/functions/update_field.php
+++ b/module/project/functions/update_field.php
@@ -7,9 +7,12 @@ header('Content-Type: application/json');
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $projectId = (int)($_POST['project_id'] ?? 0);
     $field = $_POST['field'] ?? '';
-    $value = (int)($_POST['value'] ?? 0);
-    $allowed = ['status','priority'];
+    $value = $_POST['value'] ?? '';
+    $allowed = ['status','priority','start_date','complete_date'];
     if ($projectId > 0 && in_array($field, $allowed, true)) {
+        if (in_array($field, ['status','priority'], true)) {
+            $value = (int)$value;
+        }
         $stmt = $pdo->prepare("UPDATE module_projects SET $field = :val, user_updated = :uid WHERE id = :id");
         $stmt->execute([
             ':val' => $value,

--- a/module/project/index.php
+++ b/module/project/index.php
@@ -173,6 +173,12 @@ if ($action === 'create-edit') {
   }
 }
 
+// Ensure variables are defined for included views
+$tasks = $tasks ?? [];
+$assignedUsers = $assignedUsers ?? [];
+$taskStatusItems = $taskStatusItems ?? [];
+$taskPriorityItems = $taskPriorityItems ?? [];
+
 require '../../includes/html_header.php';
 ?>
 <main class="main" id="top">


### PR DESCRIPTION
## Summary
- enable inline editing of project start/deadline dates with Flatpickr and AJAX saves
- add assignee & status filters for tasks and timeline filter controls
- allow project date fields to be updated via backend API

## Testing
- `php -l module/project/index.php`
- `php -l module/project/functions/update_field.php`
- `php -l module/project/include/details_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68a3fec96dc08333a7037031cb203fd9