### PR TITLE
Fix footer placement to avoid overlap on admin pages

### DIFF
--- a/admin/admin_footer.php
+++ b/admin/admin_footer.php
@@ -1,4 +1,4 @@
-<?php require __DIR__ . '/../includes/html_footer.php'; ?>
-  </div>
+</div><!-- end content -->
 </main>
-<?php require __DIR__ . '/../includes/js_footer.php'; ?>
+<?php require __DIR__.'/../includes/html_footer.php'; ?>
+<?php require __DIR__.'/../includes/js_footer.php'; ?>

--- a/includes/html_footer.php
+++ b/includes/html_footer.php
@@ -6,7 +6,7 @@
     </div>
   </div>
 </div>
-<footer class="footer position-absolute">
+<footer class="footer mt-4">
   <div class="row g-0 justify-content-between align-items-center h-100">
     <div class="col-12 col-sm-auto text-center">
       <p class="mb-0 mt-2 mt-sm-0 text-body">Atlis Technologies<span class="d-none d-sm-inline-block"></span><span class="d-none d-sm-inline-block mx-1">|</span><br class="d-sm-none" />2025 &copy;<a class="mx-1 text-atlis font-weight-bold" href="#">Atlisware</a></p>


### PR DESCRIPTION
## Summary
- move html footer outside main content in admin footer template
- drop absolute positioning from HTML footer so it flows after content

## Testing
- `php -l admin/admin_footer.php`
- `php -l includes/html_footer.php`
- `php -l admin/users/edit.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4045548488333b947add23b809332