### PR TITLE
Manage leads separately from user accounts

### DIFF
--- a/_SQL/atlis.sql
+++ b/_SQL/atlis.sql
@@ -1531,6 +1531,7 @@ CREATE TABLE `person` (
   `user_id` int(11) DEFAULT NULL,
   `first_name` varchar(100) DEFAULT NULL,
   `last_name` varchar(100) DEFAULT NULL,
+  `email` varchar(255) DEFAULT NULL,
   `gender_id` int(11) DEFAULT NULL,
   `phone` varchar(25) DEFAULT NULL,
   `dob` date DEFAULT NULL,
@@ -1545,10 +1546,10 @@ CREATE TABLE `person` (
 -- Dumping data for table `person`
 --
 
-INSERT INTO `person` (`id`, `user_id`, `first_name`, `last_name`, `gender_id`, `phone`, `dob`, `address`, `user_updated`, `date_created`, `date_updated`, `memo`) VALUES
-(1, 1, 'Dave', 'Wilkins', NULL, '', NULL, '', 1, '2025-08-08 21:52:52', '2025-08-18 22:25:13', NULL),
-(2, 2, 'Sean', 'Cadina', NULL, NULL, NULL, NULL, 1, '2025-08-15 00:11:11', '2025-08-15 00:12:39', NULL),
-(5, 4, 'Tyler', 'Jessop', NULL, '', NULL, '', 1, '2025-08-17 22:17:49', '2025-08-17 22:17:49', NULL);
+INSERT INTO `person` (`id`, `user_id`, `first_name`, `last_name`, `email`, `gender_id`, `phone`, `dob`, `address`, `user_updated`, `date_created`, `date_updated`, `memo`) VALUES
+(1, 1, 'Dave', 'Wilkins', '', NULL, '', NULL, '', 1, '2025-08-08 21:52:52', '2025-08-18 22:25:13', NULL),
+(2, 2, 'Sean', 'Cadina', '', NULL, NULL, NULL, NULL, 1, '2025-08-15 00:11:11', '2025-08-15 00:12:39', NULL),
+(5, 4, 'Tyler', 'Jessop', '', NULL, '', NULL, '', 1, '2025-08-17 22:17:49', '2025-08-17 22:17:49', NULL);
 
 -- --------------------------------------------------------
 

--- a/admin/navigation.php
+++ b/admin/navigation.php
@@ -10,7 +10,7 @@
   <div class="collapse navbar-collapse order-1 order-lg-0" id="navbarTopCollapse">
     <ul class="navbar-nav navbar-nav-top">
       <li class="nav-item"><a class="nav-link" href="<?php echo getURLDir(); ?>admin/users/index.php"><span class="uil fs-8 me-2 fas fa-users"></span>Users</a></li>
-      <li class="nav-item"><a class="nav-link" href="<?php echo getURLDir(); ?>admin/person/index.php"><span class="uil fs-8 me-2 fas fa-id-card"></span>Persons</a></li>
+      <li class="nav-item"><a class="nav-link" href="<?php echo getURLDir(); ?>apps/crm/leads.php"><span class="uil fs-8 me-2 fas fa-id-card"></span>Leads</a></li>
       <li class="nav-item"><a class="nav-link" href="<?php echo getURLDir(); ?>admin/contractors/index.php"><span class="uil fs-8 me-2 fas fa-user-tie"></span>Contractors</a></li>
       <li class="nav-item"><a class="nav-link" href="<?php echo getURLDir(); ?>admin/lookup-lists/index.php"><span class="uil fs-8 me-2 fas fa-list"></span>Lookup Lists</a></li>
       <li class="nav-item"><a class="nav-link" href="<?php echo getURLDir(); ?>admin/roles/index.php"><span class="uil fs-8 me-2 fas fa-user-shield"></span>Roles</a></li>

--- a/admin/person/edit.php
+++ b/admin/person/edit.php
@@ -2,20 +2,28 @@
 require '../admin_header.php';
 
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
-$first_name = $last_name = '';
-$user_id = null;
+$first_name = $last_name = $email = $phone = $dob = $address = '';
+$gender_id = null;
 $existing = null;
 $btnClass = $id ? 'btn-warning' : 'btn-success';
 
 if ($id) {
   require_permission('person','update');
-  $stmt = $pdo->prepare('SELECT user_id, first_name, last_name FROM person WHERE id = :id');
+  $stmt = $pdo->prepare('SELECT * FROM person WHERE id = :id');
   $stmt->execute([':id' => $id]);
   if ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+    if ($row['user_id']) {
+      header('Location: ../users/edit.php?id=' . $row['user_id']);
+      exit;
+    }
     $existing = $row;
-    $user_id = $row['user_id'];
-    $first_name = $row['first_name'];
-    $last_name = $row['last_name'];
+    $first_name = $row['first_name'] ?? '';
+    $last_name = $row['last_name'] ?? '';
+    $email = $row['email'] ?? '';
+    $phone = $row['phone'] ?? '';
+    $gender_id = $row['gender_id'] ?? null;
+    $dob = $row['dob'] ?? '';
+    $address = $row['address'] ?? '';
   }
 } else {
   require_permission('person','create');
@@ -24,14 +32,7 @@ if ($id) {
 $token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
 $_SESSION['csrf_token'] = $token;
 
-  if ($user_id) {
-    $userStmt = $pdo->prepare('SELECT id, email FROM users WHERE id = :id');
-    $userStmt->execute([':id' => $user_id]);
-    $userOptions = $userStmt->fetchAll(PDO::FETCH_KEY_PAIR);
-  } else {
-    $userStmt = $pdo->query('SELECT u.id, u.email FROM users u LEFT JOIN person p ON u.id = p.user_id WHERE p.user_id IS NULL ORDER BY u.email');
-    $userOptions = $userStmt->fetchAll(PDO::FETCH_KEY_PAIR);
-  }
+$genderItems = get_lookup_items($pdo, 'USER_GENDER');
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   if (!hash_equals($token, $_POST['csrf_token'] ?? '')) {
@@ -39,16 +40,20 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   }
   $first_name = trim($_POST['first_name'] ?? '');
   $last_name = trim($_POST['last_name'] ?? '');
-  $posted_user_id = $_POST['user_id'] !== '' ? (int)$_POST['user_id'] : null;
+  $email = trim($_POST['email'] ?? '');
+  $phone = trim($_POST['phone'] ?? '');
+  $gender_id = $_POST['gender_id'] !== '' ? (int)$_POST['gender_id'] : null;
+  $dob = $_POST['dob'] !== '' ? $_POST['dob'] : null;
+  $address = trim($_POST['address'] ?? '');
   if ($id) {
-    $stmt = $pdo->prepare('UPDATE person SET first_name=:first_name, last_name=:last_name, user_updated=:uid WHERE id=:id');
-    $stmt->execute([':first_name'=>$first_name, ':last_name'=>$last_name, ':uid'=>$this_user_id, ':id'=>$id]);
-    admin_audit_log($pdo, $this_user_id, 'person', $id, 'UPDATE', json_encode($existing), json_encode(['user_id'=>$user_id,'first_name'=>$first_name,'last_name'=>$last_name]), 'Updated person');
+    $stmt = $pdo->prepare('UPDATE person SET first_name=:first_name, last_name=:last_name, email=:email, phone=:phone, gender_id=:gender_id, dob=:dob, address=:address, user_updated=:uid WHERE id=:id');
+    $stmt->execute([':first_name'=>$first_name, ':last_name'=>$last_name, ':email'=>$email, ':phone'=>$phone, ':gender_id'=>$gender_id, ':dob'=>$dob, ':address'=>$address, ':uid'=>$this_user_id, ':id'=>$id]);
+    admin_audit_log($pdo, $this_user_id, 'person', $id, 'UPDATE', json_encode($existing), json_encode(['first_name'=>$first_name,'last_name'=>$last_name,'email'=>$email,'phone'=>$phone,'gender_id'=>$gender_id,'dob'=>$dob,'address'=>$address]), 'Updated person');
   } else {
-    $stmt = $pdo->prepare('INSERT INTO person (user_id, first_name, last_name, user_updated) VALUES (:user_id, :first_name, :last_name, :uid)');
-    $stmt->execute([':user_id'=>$posted_user_id, ':first_name'=>$first_name, ':last_name'=>$last_name, ':uid'=>$this_user_id]);
+    $stmt = $pdo->prepare('INSERT INTO person (first_name, last_name, email, phone, gender_id, dob, address, user_updated) VALUES (:first_name, :last_name, :email, :phone, :gender_id, :dob, :address, :uid)');
+    $stmt->execute([':first_name'=>$first_name, ':last_name'=>$last_name, ':email'=>$email, ':phone'=>$phone, ':gender_id'=>$gender_id, ':dob'=>$dob, ':address'=>$address, ':uid'=>$this_user_id]);
     $id = $pdo->lastInsertId();
-    admin_audit_log($pdo, $this_user_id, 'person', $id, 'CREATE', null, json_encode(['user_id'=>$posted_user_id,'first_name'=>$first_name,'last_name'=>$last_name]), 'Created person');
+    admin_audit_log($pdo, $this_user_id, 'person', $id, 'CREATE', null, json_encode(['first_name'=>$first_name,'last_name'=>$last_name,'email'=>$email,'phone'=>$phone,'gender_id'=>$gender_id,'dob'=>$dob,'address'=>$address]), 'Created person');
   }
   header('Location: index.php');
   exit;
@@ -58,22 +63,37 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <form method="post">
   <input type="hidden" name="csrf_token" value="<?= $token; ?>">
   <div class="mb-3">
-    <label class="form-label">User Account</label>
-    <select name="user_id" class="form-select" <?= $user_id ? 'disabled' : ''; ?>>
-      <option value="">-- None --</option>
-      <?php foreach($userOptions as $uid => $uname): ?>
-        <option value="<?= $uid; ?>" <?= (int)$uid === (int)$user_id ? 'selected' : ''; ?>><?= htmlspecialchars($uname); ?></option>
-      <?php endforeach; ?>
-    </select>
-    <?php if($user_id): ?><input type="hidden" name="user_id" value="<?= $user_id; ?>"><?php endif; ?>
-  </div>
-  <div class="mb-3">
     <label class="form-label">First Name</label>
     <input type="text" name="first_name" class="form-control" value="<?= htmlspecialchars($first_name); ?>" required>
   </div>
   <div class="mb-3">
     <label class="form-label">Last Name</label>
     <input type="text" name="last_name" class="form-control" value="<?= htmlspecialchars($last_name); ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Email</label>
+    <input type="email" name="email" class="form-control" value="<?= htmlspecialchars($email); ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Phone</label>
+    <input type="text" name="phone" class="form-control" value="<?= htmlspecialchars($phone); ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Gender</label>
+    <select name="gender_id" class="form-select">
+      <option value="">-- Select --</option>
+      <?php foreach($genderItems as $g): ?>
+        <option value="<?= $g['id']; ?>" <?= (int)$gender_id === (int)$g['id'] ? 'selected' : ''; ?>><?= htmlspecialchars($g['label']); ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Date of Birth</label>
+    <input type="date" name="dob" class="form-control" value="<?= htmlspecialchars($dob); ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Address</label>
+    <textarea name="address" class="form-control" rows="3"><?= htmlspecialchars($address); ?></textarea>
   </div>
   <button class="btn <?= $btnClass; ?>" type="submit">Save</button>
   <a href="index.php" class="btn btn-secondary">Cancel</a>

--- a/admin/person/index.php
+++ b/admin/person/index.php
@@ -18,13 +18,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete_id'])) {
   $message = 'Person deleted.';
 }
 
-$stmt = $pdo->query('SELECT p.id, p.first_name, p.last_name, u.email FROM person p LEFT JOIN users u ON p.user_id = u.id ORDER BY p.last_name, p.first_name');
+$stmt = $pdo->query('SELECT id, first_name, last_name, email FROM person WHERE user_id IS NULL ORDER BY last_name, first_name');
 $persons = $stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <h2 class="mb-4">Persons</h2>
 <?php if($message){ echo '<div class="alert alert-success">'.htmlspecialchars($message).'</div>'; } ?>
 <a href="edit.php" class="btn btn-sm btn-success mb-3">Add Person</a>
-<div id="persons" data-list='{"valueNames":["name","user"],"page":20,"pagination":true}'>
+<div id="persons" data-list='{"valueNames":["name","email"],"page":20,"pagination":true}'>
   <div class="row justify-content-between g-2 mb-3">
     <div class="col-auto">
       <input class="form-control form-control-sm search" placeholder="Search" />
@@ -38,7 +38,7 @@ $persons = $stmt->fetchAll(PDO::FETCH_ASSOC);
             <div>
               <h5 class="name mb-1"><?= htmlspecialchars(trim(($p['first_name'] ?? '').' '.($p['last_name'] ?? ''))); ?></h5>
               <?php if($p['email']): ?>
-                <p class="user text-muted small mb-2"><?= htmlspecialchars($p['email']); ?></p>
+                <p class="email text-muted small mb-2"><?= htmlspecialchars($p['email']); ?></p>
               <?php endif; ?>
             </div>
             <div>

--- a/apps/crm/leads.php
+++ b/apps/crm/leads.php
@@ -1,0 +1,48 @@
+<?php
+require '../../includes/php_header.php';
+require_permission('person','read');
+
+$stmt = $pdo->query('SELECT id, first_name, last_name, email FROM person WHERE user_id IS NULL ORDER BY last_name, first_name');
+$leads = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+require '../../includes/html_header.php';
+?>
+<main class="main" id="top">
+  <?php // require '../../includes/left_navigation.php'; ?>
+  <?php require '../../includes/navigation.php'; ?>
+  <div id="main_content" class="content">
+    <h2 class="mb-4">Leads</h2>
+    <div id="leads" data-list='{"valueNames":["name","email"],"page":20,"pagination":true}'>
+      <div class="row justify-content-between g-2 mb-3">
+        <div class="col-auto">
+          <input class="form-control form-control-sm search" placeholder="Search" />
+        </div>
+      </div>
+      <div class="row g-3 list">
+        <?php foreach($leads as $p): ?>
+        <div class="col-sm-6 col-md-4 col-lg-3">
+          <div class="card h-100 shadow-sm">
+            <div class="card-body d-flex flex-column justify-content-between">
+              <div>
+                <h5 class="name mb-1"><?= htmlspecialchars(trim(($p['first_name'] ?? '') . ' ' . ($p['last_name'] ?? ''))); ?></h5>
+                <?php if($p['email']): ?>
+                  <p class="email text-muted small mb-2"><?= htmlspecialchars($p['email']); ?></p>
+                <?php endif; ?>
+              </div>
+              <div>
+                <a class="btn btn-sm btn-warning" href="../../admin/person/edit.php?id=<?= $p['id']; ?>">Edit</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <?php endforeach; ?>
+      </div>
+      <div class="d-flex justify-content-between align-items-center mt-3">
+        <p class="mb-0" data-list-info></p>
+        <ul class="pagination mb-0"></ul>
+      </div>
+    </div>
+    <?php require '../../includes/html_footer.php'; ?>
+  </div>
+</main>
+<?php require '../../includes/js_footer.php'; ?>


### PR DESCRIPTION
## Summary
- capture lead contact details in person records and redirect account-linked records to user management
- list CRM leads and update admin navigation to point to the new leads page
- add email field to person schema

## Testing
- `php -l admin/person/index.php`
- `php -l admin/person/edit.php`
- `php -l admin/navigation.php`
- `php -l apps/crm/leads.php`


------
https://chatgpt.com/codex/tasks/task_e_68a405090ef88333ae34a8141d55715b