### PR TITLE
Fix profile pic status updates to avoid duplicate keys

### DIFF
--- a/admin/users/functions/save.php
+++ b/admin/users/functions/save.php
@@ -28,8 +28,8 @@ $inactiveStatusId = get_status_id($pdo, 'INACTIVE');
 if ($reactivatePicId && $id) {
   try {
     $pdo->beginTransaction();
-    $pdo->prepare('UPDATE users_profile_pics SET status_id = :inactive, user_updated = :uid WHERE user_id = :user')
-        ->execute([':inactive' => $inactiveStatusId, ':uid' => $this_user_id, ':user' => $id]);
+    $pdo->prepare('UPDATE users_profile_pics SET status_id = :inactive, user_updated = :uid WHERE user_id = :user AND status_id = :active')
+        ->execute([':inactive' => $inactiveStatusId, ':uid' => $this_user_id, ':user' => $id, ':active' => $activeStatusId]);
     $pdo->prepare('UPDATE users_profile_pics SET status_id = :active, user_updated = :uid WHERE id = :pic')
         ->execute([':active' => $activeStatusId, ':uid' => $this_user_id, ':pic' => $reactivatePicId]);
     $pdo->prepare('UPDATE users SET current_profile_pic_id = :pic, user_updated = :uid WHERE id = :user')
@@ -186,8 +186,8 @@ try {
 
   if ($profilePath) {
     $pdo->beginTransaction();
-    $pdo->prepare('UPDATE users_profile_pics SET status_id = :inactive, user_updated = :uid WHERE user_id = :user')
-        ->execute([':inactive' => $inactiveStatusId, ':uid' => $this_user_id, ':user' => $id]);
+    $pdo->prepare('UPDATE users_profile_pics SET status_id = :inactive, user_updated = :uid WHERE user_id = :user AND status_id = :active')
+        ->execute([':inactive' => $inactiveStatusId, ':uid' => $this_user_id, ':user' => $id, ':active' => $activeStatusId]);
     $pstmt = $pdo->prepare('INSERT INTO users_profile_pics (user_id, uploaded_by, file_name, file_path, file_size, file_type, width, height, file_hash, status_id, user_updated) VALUES (:user_id, :uploaded_by, :file_name, :file_path, :file_size, :file_type, :width, :height, :file_hash, :status_id, :uid)');
     $pstmt->execute([
       ':user_id' => $id,


### PR DESCRIPTION
## Summary
- update profile picture queries to only deactivate active images
- bind `:active` parameter for status filtering

## Testing
- `php -l admin/users/functions/save.php`
- `sqlite3 /tmp/test.db <<'EOF'
CREATE TABLE users_profile_pics(
  id INTEGER PRIMARY KEY AUTOINCREMENT,
  user_id INTEGER,
  status_id INTEGER,
  is_active BOOLEAN GENERATED ALWAYS AS (status_id = 82) STORED
);
CREATE UNIQUE INDEX uq_users_profile_pics_user_active ON users_profile_pics(user_id) WHERE is_active=1;
INSERT INTO users_profile_pics (user_id,status_id) VALUES (1,82);
INSERT INTO users_profile_pics (user_id,status_id) VALUES (1,83);
SELECT id,user_id,status_id,is_active FROM users_profile_pics;
BEGIN TRANSACTION;
UPDATE users_profile_pics SET status_id=83 WHERE user_id=1 AND status_id=82;
UPDATE users_profile_pics SET status_id=82 WHERE id=2;
COMMIT;
SELECT id,user_id,status_id,is_active FROM users_profile_pics;
BEGIN TRANSACTION;
UPDATE users_profile_pics SET status_id=83 WHERE user_id=1 AND status_id=82;
INSERT INTO users_profile_pics (user_id,status_id) VALUES (1,82);
COMMIT;
SELECT id,user_id,status_id,is_active FROM users_profile_pics;
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68a40e13870c833397df5d176361fe2d