### PR TITLE
Preserve personal info when reactivating profile pictures

### DIFF
--- a/admin/users/edit.php
+++ b/admin/users/edit.php
@@ -129,10 +129,14 @@ $_SESSION['csrf_token'] = $token;
                           <td><?php echo htmlspecialchars($pic['width']); ?>x<?php echo htmlspecialchars($pic['height']); ?></td>
                           <td>
                             <?php if ($pic['status_code'] !== 'ACTIVE'): ?>
-                              <form method="post" action="functions/save.php" class="d-inline">
+                              <form method="post" action="functions/save.php" class="d-inline reactivate-form">
                                 <input type="hidden" name="csrf_token" value="<?php echo $token; ?>">
                                 <input type="hidden" name="id" value="<?php echo $id; ?>">
                                 <input type="hidden" name="reactivate_pic_id" value="<?php echo $pic['id']; ?>">
+                                <input type="hidden" name="gender_id" value="<?php echo htmlspecialchars($gender_id ?? ''); ?>">
+                                <input type="hidden" name="phone" value="<?php echo htmlspecialchars($phone); ?>">
+                                <input type="hidden" name="dob" value="<?php echo htmlspecialchars($dob); ?>">
+                                <input type="hidden" name="address" value="<?php echo htmlspecialchars($address); ?>">
                                 <button type="submit" class="btn btn-sm btn-primary">Reactivate</button>
                               </form>
                             <?php endif; ?>
@@ -187,5 +191,20 @@ $_SESSION['csrf_token'] = $token;
     </div>
   </div>
 </form>
+
+<script>
+document.querySelectorAll('.reactivate-form').forEach(function(form){
+  form.addEventListener('submit', function(){
+    var gender = document.querySelector('select[name="gender_id"]');
+    var phone = document.querySelector('input[name="phone"]');
+    var dob = document.querySelector('input[name="dob"]');
+    var address = document.querySelector('textarea[name="address"]');
+    if (gender) form.querySelector('input[name="gender_id"]').value = gender.value;
+    if (phone) form.querySelector('input[name="phone"]').value = phone.value;
+    if (dob) form.querySelector('input[name="dob"]').value = dob.value;
+    if (address) form.querySelector('input[name="address"]').value = address.value;
+  });
+});
+</script>
 
 <?php require '../admin_footer.php'; ?>

--- a/admin/users/functions/save.php
+++ b/admin/users/functions/save.php
@@ -15,6 +15,10 @@ if (!hash_equals($_SESSION['csrf_token'] ?? '', $_POST['csrf_token'] ?? '')) {
 
 $id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
 $reactivatePicId = isset($_POST['reactivate_pic_id']) ? (int)$_POST['reactivate_pic_id'] : 0;
+$gender_id = isset($_POST['gender_id']) && $_POST['gender_id'] !== '' ? (int)$_POST['gender_id'] : null;
+$phone = preg_replace('/[^0-9]/', '', $_POST['phone'] ?? '');
+$dob = $_POST['dob'] ?? '';
+$address = trim($_POST['address'] ?? '');
 
 function get_status_id(PDO $pdo, string $code): int {
   $stmt = $pdo->prepare("SELECT li.id FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'USER_PROFILE_PIC_STATUS' AND li.code = :code LIMIT 1");
@@ -28,6 +32,22 @@ $inactiveStatusId = get_status_id($pdo, 'INACTIVE');
 if ($reactivatePicId && $id) {
   try {
     $pdo->beginTransaction();
+
+    $personParams = [
+      ':uid_fk' => $id,
+      ':gender_id' => $gender_id,
+      ':phone' => $phone,
+      ':dob' => $dob ?: null,
+      ':address' => $address,
+      ':uid_update' => $this_user_id
+    ];
+    $pstmt = $pdo->prepare('UPDATE person SET gender_id = :gender_id, phone = :phone, dob = :dob, address = :address, user_updated = :uid_update WHERE user_id = :uid_fk');
+    $pstmt->execute($personParams);
+    if ($pstmt->rowCount() === 0) {
+      $pdo->prepare('INSERT INTO person (user_id, gender_id, phone, dob, address, user_updated) VALUES (:uid_fk, :gender_id, :phone, :dob, :address, :uid_update)')
+          ->execute($personParams);
+    }
+
     $pdo->prepare('UPDATE users_profile_pics SET status_id = :inactive, user_updated = :uid WHERE user_id = :user')
         ->execute([':inactive' => $inactiveStatusId, ':uid' => $this_user_id, ':user' => $id]);
     $pdo->prepare('UPDATE users_profile_pics SET status_id = :active, user_updated = :uid WHERE id = :pic')
@@ -52,10 +72,6 @@ $password = $_POST['password'] ?? '';
 $confirm = $_POST['confirmPassword'] ?? '';
 $first_name = trim($_POST['first_name'] ?? '');
 $last_name = trim($_POST['last_name'] ?? '');
-$gender_id = isset($_POST['gender_id']) && $_POST['gender_id'] !== '' ? (int)$_POST['gender_id'] : null;
-$phone = preg_replace('/[^0-9]/', '', $_POST['phone'] ?? '');
-$dob = $_POST['dob'] ?? '';
-$address = trim($_POST['address'] ?? '');
 $memo = $_POST['memo'] ?? null;
 
  $errors = [];


### PR DESCRIPTION
## Summary
- Include current personal details as hidden fields in the profile picture reactivation form
- Populate hidden fields from visible inputs before submitting
- Update save handler to persist personal fields prior to reactivating a profile picture

## Testing
- `php -l admin/users/edit.php`
- `php -l admin/users/functions/save.php`


------
https://chatgpt.com/codex/tasks/task_e_68a40e152f948333b0567237990faf3a