### PR TITLE
Add error logging to admin catch blocks

### DIFF
--- a/admin/api/lookup-lists.php
+++ b/admin/api/lookup-lists.php
@@ -20,6 +20,7 @@ try {
       echo json_encode(['success'=>false,'error'=>'Invalid entity']);
   }
 } catch (Exception $e) {
+  error_log($e->getMessage());
   echo json_encode(['success'=>false,'error'=>'Server error']);
 }
 
@@ -51,6 +52,7 @@ function handleList($action){
       audit_log($pdo,$this_user_id,'lookup_lists',$id,'CREATE','Created lookup list');
       echo json_encode(['success'=>true,'message'=>'Lookup list created','list'=>['id'=>$id,'name'=>$name,'description'=>$description]]);
     }catch(PDOException $e){
+      error_log($e->getMessage());
       if($e->getCode()==='23000'){
         echo json_encode(['success'=>false,'error'=>'Name already exists']);
       }else{
@@ -75,6 +77,7 @@ function handleList($action){
       audit_log($pdo,$this_user_id,'lookup_lists',$id,'UPDATE','Updated lookup list');
       echo json_encode(['success'=>true,'message'=>'Lookup list updated','list'=>['id'=>$id,'name'=>$name,'description'=>$description]]);
     }catch(PDOException $e){
+      error_log($e->getMessage());
       if($e->getCode()==='23000'){
         echo json_encode(['success'=>false,'error'=>'Name already exists']);
       }else{
@@ -89,6 +92,7 @@ function handleList($action){
       audit_log($pdo,$this_user_id,'lookup_lists',$id,'DELETE','Deleted lookup list');
       echo json_encode(['success'=>true,'message'=>'Lookup list deleted']);
     }catch(PDOException $e){
+      error_log($e->getMessage());
       if($e->getCode()==='23000'){
         echo json_encode(['success'=>false,'error'=>'List is in use']);
       }else{
@@ -138,6 +142,7 @@ function handleItem($action){
       audit_log($pdo,$this_user_id,'lookup_list_items',$id,'CREATE','Created lookup list item');
       echo json_encode(['success'=>true,'message'=>'Item created','item'=>['id'=>$id,'label'=>$label,'code'=>$code,'sort_order'=>0,'active_from'=>$active_from,'active_to'=>$active_to]]);
     }catch(PDOException $e){
+      error_log($e->getMessage());
       if($e->getCode()==='23000'){
         echo json_encode(['success'=>false,'error'=>'Label or code already exists']);
       }else{
@@ -174,6 +179,7 @@ function handleItem($action){
       audit_log($pdo,$this_user_id,'lookup_list_items',$id,'UPDATE','Updated lookup list item');
       echo json_encode(['success'=>true,'message'=>'Item updated','item'=>['id'=>$id,'label'=>$label,'code'=>$code,'active_from'=>$active_from,'active_to'=>$active_to]]);
     }catch(PDOException $e){
+      error_log($e->getMessage());
       if($e->getCode()==='23000'){
         echo json_encode(['success'=>false,'error'=>'Label or code already exists']);
       }else{
@@ -196,6 +202,7 @@ function handleItem($action){
       audit_log($pdo,$this_user_id,'lookup_list_items',$id,'DELETE','Deleted lookup list item');
       echo json_encode(['success'=>true,'message'=>'Item deleted']);
     }catch(PDOException $e){
+      error_log($e->getMessage());
       if($e->getCode()==='23000'){
         echo json_encode(['success'=>false,'error'=>'Item is in use']);
       }else{
@@ -228,6 +235,7 @@ function handleAttr($action){
         audit_log($pdo,$this_user_id,'lookup_list_item_attributes',$id,'CREATE','Created item attribute');
         echo json_encode(['success'=>true,'message'=>'Attribute created','attr'=>['id'=>$id,'attr_code'=>$key,'attr_value'=>$value]]);
       }catch(PDOException $e){
+        error_log($e->getMessage());
         if($e->getCode()==='23000'){
           echo json_encode(['success'=>false,'error'=>'Attribute already exists for this item']);
         }else{
@@ -245,6 +253,7 @@ function handleAttr($action){
         audit_log($pdo,$this_user_id,'lookup_list_item_attributes',$id,'UPDATE','Updated item attribute');
         echo json_encode(['success'=>true,'message'=>'Attribute updated','attr'=>['id'=>$id,'attr_code'=>$key,'attr_value'=>$value]]);
       }catch(PDOException $e){
+        error_log($e->getMessage());
         if($e->getCode()==='23000'){
           echo json_encode(['success'=>false,'error'=>'Attribute already exists for this item']);
         }else{

--- a/admin/api/system-properties.php
+++ b/admin/api/system-properties.php
@@ -62,6 +62,7 @@ try{
       echo json_encode(['success'=>false,'error'=>'Invalid action']);
   }
 }catch(Exception $e){
+  error_log($e->getMessage());
   echo json_encode(['success'=>false,'error'=>'Server error']);
 }
 

--- a/admin/lookup-lists/items.php
+++ b/admin/lookup-lists/items.php
@@ -40,6 +40,7 @@ if($_SERVER['REQUEST_METHOD']==='POST'){
           audit_log($pdo,$this_user_id,'lookup_list_item_attributes',$attr_id,'UPDATE','Updated item attribute');
           $message='Attribute updated.';
         }catch(PDOException $e){
+          error_log($e->getMessage());
           if($e->getCode()==='23000'){
             $error='Attribute already exists for this item.';
           }else{
@@ -54,6 +55,7 @@ if($_SERVER['REQUEST_METHOD']==='POST'){
           audit_log($pdo,$this_user_id,'lookup_list_item_attributes',$attr_id,'CREATE','Created item attribute');
           $message='Attribute added.';
         }catch(PDOException $e){
+          error_log($e->getMessage());
           if($e->getCode()==='23000'){
             $error='Attribute already exists for this item.';
           }else{

--- a/admin/users/functions/save.php
+++ b/admin/users/functions/save.php
@@ -40,6 +40,8 @@ if ($reactivatePicId && $id) {
     if ($pdo->inTransaction()) {
       $pdo->rollBack();
     }
+    error_log($e->getMessage());
+    $_SESSION['error_message'] = substr($e->getMessage(), 0, 200);
     $_SESSION['message'] = 'Error updating profile picture.';
   }
   header('Location: ../edit.php?id=' . $id);
@@ -214,6 +216,8 @@ try {
   if ($pdo->inTransaction()) {
     $pdo->rollBack();
   }
+  error_log($e->getMessage());
+  $_SESSION['error_message'] = substr($e->getMessage(), 0, 200);
   $_SESSION['message'] = 'Error saving user.';
 }
 

--- a/includes/config.php
+++ b/includes/config.php
@@ -22,6 +22,7 @@ $pdo = "";
 try{
         $pdo = new PDO($dsn, DB_USER, DB_PASSWORD, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
 }catch (PDOException $e) {
+        error_log($e->getMessage());
         echo "Connection failed: " . $e->getMessage();
 }
 


### PR DESCRIPTION
## Summary
- log exceptions in user save flow and store truncated messages for admins
- add error logging to lookup list management endpoints
- log exceptions in system properties API and database config

## Testing
- `php -l admin/users/functions/save.php`
- `php -l admin/lookup-lists/items.php`
- `php -l admin/api/lookup-lists.php`
- `php -l admin/api/system-properties.php`
- `php -l includes/config.php`


------
https://chatgpt.com/codex/tasks/task_e_68a40e159d0883339c311744eb41daed