### PR TITLE
Fix profile pic reactivation query

### DIFF
--- a/admin/users/functions/save.php
+++ b/admin/users/functions/save.php
@@ -48,8 +48,8 @@ if ($reactivatePicId && $id) {
           ->execute($personParams);
     }
 
-    $pdo->prepare('UPDATE users_profile_pics SET status_id = :inactive, user_updated = :uid WHERE user_id = :user')
-        ->execute([':inactive' => $inactiveStatusId, ':uid' => $this_user_id, ':user' => $id]);
+    $pdo->prepare('UPDATE users_profile_pics SET status_id = :inactive, user_updated = :uid WHERE user_id = :user AND status_id = :active')
+        ->execute([':inactive' => $inactiveStatusId, ':uid' => $this_user_id, ':user' => $id, ':active' => $activeStatusId]);
 
     $pdo->prepare('UPDATE users_profile_pics SET status_id = :active, user_updated = :uid WHERE id = :pic')
         ->execute([':active' => $activeStatusId, ':uid' => $this_user_id, ':pic' => $reactivatePicId]);


### PR DESCRIPTION
## Summary
- ensure profile picture reactivation only deactivates currently active records

## Testing
- `php -l admin/users/functions/save.php`
- `php <<'PHP'
<?php
$pdo = new PDO('sqlite::memory:');
$pdo->exec('CREATE TABLE users_profile_pics (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INT, status_id INT, user_updated INT)');
$pdo->exec('INSERT INTO users_profile_pics (user_id, status_id, user_updated) VALUES (1,1,1),(1,2,1),(1,1,1)');
$inactive=2; $active=1; $uid=99; $id=1;
$pdo->prepare('UPDATE users_profile_pics SET status_id = :inactive, user_updated = :uid WHERE user_id = :user AND status_id = :active')
    ->execute([':inactive'=>$inactive, ':uid'=>$uid, ':user'=>$id, ':active'=>$active]);
$rows = $pdo->query('SELECT id, status_id FROM users_profile_pics ORDER BY id')->fetchAll(PDO::FETCH_ASSOC);
print_r($rows);
?>
PHP`

------
https://chatgpt.com/codex/tasks/task_e_68a5491979ec83339142351fc3ace4bf