### PR TITLE
feat(task): allow inline status and priority changes

### DIFF
--- a/module/task/index.php
+++ b/module/task/index.php
@@ -158,6 +158,9 @@ if ($tasks) {
 if ($action === 'details') {
   $task_id = (int)($_GET['id'] ?? 0);
 
+  $statusMap   = get_lookup_items($pdo, 'TASK_STATUS');
+  $priorityMap = get_lookup_items($pdo, 'TASK_PRIORITY');
+
   $stmt = $pdo->prepare(
     'SELECT t.id, t.name, t.description, t.status, t.priority,
             t.project_id, t.division_id, t.agency_id, t.completed, t.completed_by,


### PR DESCRIPTION
## Summary
- expose status and priority lookup values to task details view
- add inline form to update task status/priority and refresh badges via AJAX
- guard updates with task.update permission

## Testing
- `php -l module/task/index.php`
- `php -l module/task/include/details_view.php`
- `php -l module/task/functions/update.php`


------
https://chatgpt.com/codex/tasks/task_e_68a548f1dc548333a50e738f031dda72