### PR TITLE
Add Kanban navigation links with permission checks

### DIFF
--- a/includes/left_navigation.php
+++ b/includes/left_navigation.php
@@ -38,11 +38,13 @@
                     </a>
                   </li>
                   <?php endif; ?>
-                <li class="nav-item"><a class="nav-link" href="<?php echo getURLDir(); ?>/module/kanban">
-                    <div class="d-flex align-items-center"><span class="nav-link-text">Kanban</span>
-                    </div>
-                  </a>
-                </li>
+                  <?php if (user_has_permission('kanban','read')): ?>
+                  <li class="nav-item"><a class="nav-link" href="<?php echo getURLDir(); ?>/module/kanban/">
+                      <div class="d-flex align-items-center"><span class="nav-link-icon"><span class="fas fa-columns"></span></span><span class="nav-link-text">Kanban</span>
+                      </div>
+                    </a>
+                  </li>
+                  <?php endif; ?>
                 <?php // Add future module links below ?>
               </ul>
             </div>

--- a/includes/navigation.php
+++ b/includes/navigation.php
@@ -58,14 +58,16 @@
         <?php // ================ ?>
 
 
-      <?php // KANBAN NAV LINK ?>
-      <li class="nav-item dropdown">
-        <a class="nav-link dropdown-toggle lh-1" href="<?php echo getURLDir(); ?>#">
-          <span class="uil fs-8 me-2 fas fa-columns"></span>Kanban</a>
-      </li>
-      <?php // ================ ?>
-      <?php // END KANBAN NAV LINK ?>
-      <?php // ================ ?>
+        <?php // KANBAN NAV LINK ?>
+        <?php if (user_has_permission('kanban','read')): ?>
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle lh-1" href="<?php echo getURLDir(); ?>/module/kanban/">
+            <span class="uil fs-8 me-2 fas fa-columns"></span>Kanban</a>
+        </li>
+        <?php endif; ?>
+        <?php // ================ ?>
+        <?php // END KANBAN NAV LINK ?>
+        <?php // ================ ?>
 
     </ul>
   </div>


### PR DESCRIPTION
## Summary
- add Kanban link with permission gate to top navigation
- add Kanban link with icon and permission gate to left navigation

## Testing
- `php -l includes/navigation.php`
- `php -l includes/left_navigation.php`


------
https://chatgpt.com/codex/tasks/task_e_68a5490dae1c8333a325a2994e14f7b9