### PR TITLE
Add initial Kanban module skeleton

### DIFF
--- a/module/kanban/functions/kanban_crud.php
+++ b/module/kanban/functions/kanban_crud.php
@@ -1,0 +1,37 @@
+<?php
+function fetch_boards(PDO $pdo): array {
+    return $pdo->query('SELECT id, name FROM module_kanban_boards ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
+}
+
+function fetch_board(PDO $pdo, int $id): ?array {
+    $stmt = $pdo->prepare('SELECT id, name FROM module_kanban_boards WHERE id=?');
+    $stmt->execute([$id]);
+    return $stmt->fetch(PDO::FETCH_ASSOC) ?: null;
+}
+
+function save_board(PDO $pdo, ?int $id, string $name, int $user_id): int {
+    if ($id) {
+        $stmt = $pdo->prepare('UPDATE module_kanban_boards SET user_updated=?, name=? WHERE id=?');
+        $stmt->execute([$user_id, $name, $id]);
+        return $id;
+    }
+    $stmt = $pdo->prepare('INSERT INTO module_kanban_boards (user_id, name) VALUES (?,?)');
+    $stmt->execute([$user_id, $name]);
+    return (int)$pdo->lastInsertId();
+}
+
+function delete_board(PDO $pdo, int $id): void {
+    $pdo->prepare('DELETE FROM module_kanban_boards WHERE id=?')->execute([$id]);
+}
+
+function fetch_statuses(PDO $pdo, int $board_id): array {
+    $stmt = $pdo->prepare('SELECT id, name, sort_order FROM module_kanban_statuses WHERE board_id=? ORDER BY sort_order');
+    $stmt->execute([$board_id]);
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
+
+function fetch_tasks_for_status(PDO $pdo, string $status): array {
+    $stmt = $pdo->prepare('SELECT id, name FROM module_tasks WHERE status=? ORDER BY id');
+    $stmt->execute([$status]);
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}

--- a/module/kanban/functions/update_task_status.php
+++ b/module/kanban/functions/update_task_status.php
@@ -1,0 +1,18 @@
+<?php
+require '../../../includes/php_header.php';
+require_permission('kanban', 'update');
+
+header('Content-Type: application/json');
+
+$task_id = isset($_POST['task_id']) ? (int)$_POST['task_id'] : 0;
+$status  = $_POST['status'] ?? '';
+
+if ($task_id && $status) {
+    $stmt = $pdo->prepare('UPDATE module_tasks SET status=?, user_updated=? WHERE id=?');
+    $stmt->execute([$status, $this_user_id, $task_id]);
+    echo json_encode(['success' => true]);
+    exit;
+}
+
+http_response_code(400);
+echo json_encode(['success' => false]);

--- a/module/kanban/include/board_view.php
+++ b/module/kanban/include/board_view.php
@@ -1,0 +1,49 @@
+<?php
+// Expects $board and $statuses from index.php
+?>
+<div class="container py-4">
+  <h2 class="mb-4"><?= htmlspecialchars($board['name'] ?? 'Board') ?></h2>
+  <div class="row g-3 kanban-board" data-board-id="<?= $board['id'] ?>">
+    <?php foreach ($statuses as $st): 
+      $tasks = fetch_tasks_for_status($pdo, $st['name']);
+    ?>
+    <div class="col-md-3">
+      <div class="card h-100">
+        <div class="card-header">
+          <h5 class="mb-0"><?= htmlspecialchars($st['name']) ?></h5>
+        </div>
+        <div class="card-body min-vh-50 kanban-column" data-status="<?= htmlspecialchars($st['name']) ?>">
+          <?php foreach ($tasks as $t): ?>
+            <div class="card mb-2 p-2 kanban-item" data-task-id="<?= $t['id'] ?>" draggable="true">
+              <?= htmlspecialchars($t['name']) ?>
+            </div>
+          <?php endforeach; ?>
+        </div>
+      </div>
+    </div>
+    <?php endforeach; ?>
+  </div>
+</div>
+<script>
+document.querySelectorAll('.kanban-item').forEach(item => {
+  item.addEventListener('dragstart', e => {
+    e.dataTransfer.setData('text/plain', item.dataset.taskId);
+  });
+});
+
+document.querySelectorAll('.kanban-column').forEach(col => {
+  col.addEventListener('dragover', e => e.preventDefault());
+  col.addEventListener('drop', function(e) {
+    e.preventDefault();
+    const taskId = e.dataTransfer.getData('text/plain');
+    const status = this.dataset.status;
+    fetch('functions/update_task_status.php', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: `task_id=${taskId}&status=${encodeURIComponent(status)}`
+    });
+    const item = document.querySelector(`.kanban-item[data-task-id="${taskId}"]`);
+    if (item) this.appendChild(item);
+  });
+});
+</script>

--- a/module/kanban/include/form.php
+++ b/module/kanban/include/form.php
@@ -1,0 +1,17 @@
+<?php
+// Expects $board from index.php
+$board_id = $board['id'] ?? null;
+$name = $board['name'] ?? '';
+?>
+<div class="container py-4">
+  <h2 class="mb-4"><?= $board_id ? 'Edit Board' : 'Create Board' ?></h2>
+  <form method="post" action="index.php?action=save">
+    <input type="hidden" name="id" value="<?= htmlspecialchars($board_id) ?>">
+    <div class="mb-3">
+      <label class="form-label">Board Name</label>
+      <input class="form-control" name="name" value="<?= htmlspecialchars($name) ?>" required>
+    </div>
+    <button class="btn btn-falcon-primary" type="submit">Save</button>
+    <a class="btn btn-falcon-secondary" href="index.php">Cancel</a>
+  </form>
+</div>

--- a/module/kanban/include/list_view.php
+++ b/module/kanban/include/list_view.php
@@ -1,0 +1,25 @@
+<?php
+// Expects $boards from index.php
+?>
+<div class="container py-4">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h2 class="mb-0">Kanban Boards</h2>
+    <a class="btn btn-falcon-primary" href="index.php?action=create">Create Board</a>
+  </div>
+  <div class="row g-3">
+    <?php foreach ($boards as $b): ?>
+      <div class="col-md-4">
+        <div class="card h-100">
+          <div class="card-body d-flex flex-column">
+            <h5 class="card-title"><?= htmlspecialchars($b['name']) ?></h5>
+            <div class="mt-auto">
+              <a class="btn btn-sm btn-falcon-primary" href="index.php?action=board&id=<?= $b['id'] ?>">Open</a>
+              <a class="btn btn-sm btn-falcon-secondary" href="index.php?action=edit&id=<?= $b['id'] ?>">Edit</a>
+              <a class="btn btn-sm btn-falcon-danger" href="index.php?action=delete&id=<?= $b['id'] ?>" onclick="return confirm('Delete board?');">Delete</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    <?php endforeach; ?>
+  </div>
+</div>

--- a/module/kanban/index.php
+++ b/module/kanban/index.php
@@ -1,0 +1,52 @@
+<?php
+require '../../includes/php_header.php';
+$action = $_GET['action'] ?? 'list';
+require_permission('kanban', $action);
+require_once __DIR__.'/functions/kanban_crud.php';
+
+if ($action === 'save' && $_SERVER['REQUEST_METHOD'] === 'POST') {
+    $id   = $_POST['id'] ?? null;
+    $name = trim($_POST['name'] ?? '');
+    save_board($pdo, $id ? (int)$id : null, $name, $this_user_id);
+    header('Location: index.php');
+    exit;
+}
+
+if ($action === 'delete' && isset($_GET['id'])) {
+    delete_board($pdo, (int)$_GET['id']);
+    header('Location: index.php');
+    exit;
+}
+
+$board = null;
+$boards = [];
+$statuses = [];
+
+if ($action === 'list') {
+    $boards = fetch_boards($pdo);
+} elseif ($action === 'edit' || $action === 'board') {
+    $board_id = (int)($_GET['id'] ?? 0);
+    $board = fetch_board($pdo, $board_id);
+    $statuses = fetch_statuses($pdo, $board_id);
+}
+
+require '../../includes/html_header.php';
+?>
+<main class="main" id="top">
+  <?php // require '../../includes/left_navigation.php'; ?>
+  <?php require '../../includes/navigation.php'; ?>
+  <div id="main_content" class="content">
+    <?php
+      $viewMap = [
+        'list' => 'list_view.php',
+        'board' => 'board_view.php',
+        'create' => 'form.php',
+        'edit' => 'form.php'
+      ];
+      $viewFile = $viewMap[$action] ?? 'list_view.php';
+      require 'include/' . $viewFile;
+    ?>
+    <?php require '../../includes/html_footer.php'; ?>
+  </div>
+</main>
+<?php require '../../includes/js_footer.php'; ?>


### PR DESCRIPTION
## Summary
- scaffold Kanban module entrypoint with permission checks and view routing
- add basic CRUD helpers for boards and statuses
- implement board and list views with drag-and-drop status updates via AJAX

## Testing
- `php -l module/kanban/index.php module/kanban/functions/kanban_crud.php module/kanban/functions/update_task_status.php module/kanban/include/list_view.php module/kanban/include/form.php module/kanban/include/board_view.php`

------
https://chatgpt.com/codex/tasks/task_e_68a5490f1b74833382707a2829f0863d