### PR TITLE
Display user avatars and full names on admin list

### DIFF
--- a/admin/users/index.php
+++ b/admin/users/index.php
@@ -3,7 +3,7 @@ require '../admin_header.php';
 
 require_permission('users','view');
 
-$users = $pdo->query('SELECT u.id, u.email, p.first_name, p.last_name FROM users u LEFT JOIN person p ON p.user_id = u.id ORDER BY u.email')->fetchAll(PDO::FETCH_ASSOC);
+$users = $pdo->query("SELECT u.id, u.email, CONCAT(p.first_name, ' ', p.last_name) AS name, upp.file_path FROM users u LEFT JOIN person p ON p.user_id = u.id LEFT JOIN users_profile_pics upp ON u.current_profile_pic_id = upp.id ORDER BY u.email")->fetchAll(PDO::FETCH_ASSOC);
 $message = $_SESSION['message'] ?? '';
 unset($_SESSION['message']);
 ?>
@@ -11,13 +11,13 @@ unset($_SESSION['message']);
 <?php if($message){ echo '<div class="alert alert-success">'.htmlspecialchars($message).'</div>'; } ?>
 <a href="edit.php" class="btn btn-success mb-3">Add User</a>
 <table class="table table-striped">
-  <thead><tr><th>Email</th><th>First Name</th><th>Last Name</th><th></th></tr></thead>
+  <thead><tr><th>Email</th><th>Name</th><th>Avatar</th><th></th></tr></thead>
   <tbody>
     <?php foreach ($users as $u): ?>
     <tr>
       <td><?php echo htmlspecialchars($u['email']); ?></td>
-      <td><?php echo htmlspecialchars($u['first_name']); ?></td>
-      <td><?php echo htmlspecialchars($u['last_name']); ?></td>
+      <td><?php echo htmlspecialchars($u['name']); ?></td>
+      <td><img src="<?= getURLDir() . $u['file_path'] ?>" class="img-thumbnail" style="width:40px;height:40px;"></td>
       <td><a href="edit.php?id=<?php echo $u['id']; ?>" class="btn btn-sm btn-primary">Edit</a></td>
     </tr>
     <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- join `users_profile_pics` to fetch avatar file paths
- show full names via `CONCAT` and replace separate name columns
- display user avatars beside names in admin user table

## Testing
- `php -l admin/users/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68a55e57f8748333a63aaf32fe0e9b4a