### PR TITLE
Add task edit modal and expanded form

### DIFF
--- a/module/task/include/details_view.php
+++ b/module/task/include/details_view.php
@@ -14,8 +14,11 @@ require_once __DIR__ . '/../../../includes/functions.php';
 
   ?>
   <div class="mb-5">
-    <div class="d-flex justify-content-between">
+    <div class="d-flex justify-content-between align-items-center">
       <h2 class="text-body-emphasis fw-bolder mb-2"><?php echo h($current_task['name'] ?? ''); ?></h2>
+      <?php if (user_has_permission('task','update')): ?>
+      <button class="btn btn-warning btn-sm" id="editTaskBtn">Edit</button>
+      <?php endif; ?>
     </div>
     <?php if ($hierarchyParts): ?>
       <p class="text-body-secondary mb-0"><?php echo implode(' / ', array_map('h', $hierarchyParts)); ?></p>
@@ -237,6 +240,13 @@ require_once __DIR__ . '/../../../includes/functions.php';
       </div>
     </div>
   </div>
+  <?php if (user_has_permission('task','update')): ?>
+  <div class="modal fade" id="taskEditModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-centered">
+      <div class="modal-content"></div>
+    </div>
+  </div>
+  <?php endif; ?>
   <div class="modal fade" id="imageModal" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog modal-lg modal-dialog-centered">
       <div class="modal-content">
@@ -289,6 +299,33 @@ require_once __DIR__ . '/../../../includes/functions.php';
             }
           }
         });
+      });
+    }
+
+    var editBtn = document.getElementById('editTaskBtn');
+    if (editBtn) {
+      editBtn.addEventListener('click', function () {
+        fetch('index.php?action=create-edit&id=<?php echo (int)$current_task['id']; ?>&modal=1')
+          .then(function (res) { return res.text(); })
+          .then(function (html) {
+            var modalContent = document.querySelector('#taskEditModal .modal-content');
+            if (modalContent) {
+              modalContent.innerHTML = html;
+              var modal = new bootstrap.Modal(document.getElementById('taskEditModal'));
+              modal.show();
+              var form = modalContent.querySelector('form');
+              if (form) {
+                form.addEventListener('submit', function (ev) {
+                  ev.preventDefault();
+                  var fd = new FormData(form);
+                  fetch('index.php?action=save', {
+                    method: 'POST',
+                    body: fd
+                  }).then(function () { location.reload(); });
+                });
+              }
+            }
+          });
       });
     }
   });

--- a/module/task/include/form.php
+++ b/module/task/include/form.php
@@ -3,7 +3,7 @@
 ?>
 <?php $isEdit = !empty($task['id']); ?>
 <?php if (!empty($isModal)): ?>
-<form class="row g-3" method="post" action="index.php?action=save">
+<form id="taskForm" class="row g-3" method="post" action="index.php?action=save">
   <input type="hidden" name="id" value="<?php echo h($task['id'] ?? ''); ?>">
   <div class="modal-header">
     <h5 class="modal-title"><?php echo $isEdit ? 'Edit Task' : 'Create Task'; ?></h5>
@@ -17,11 +17,30 @@
           <label for="taskName">Task name</label>
         </div>
       </div>
+      <div class="col-12">
+        <div class="form-floating">
+          <textarea class="form-control" id="taskDescription" name="description" placeholder="Description" style="height:100px"><?php echo h($task['description'] ?? ''); ?></textarea>
+          <label for="taskDescription">Description</label>
+        </div>
+      </div>
+      <div class="col-12">
+        <div class="form-floating">
+          <textarea class="form-control" id="taskRequirements" name="requirements" placeholder="Requirements" style="height:100px"><?php echo h($task['requirements'] ?? ''); ?></textarea>
+          <label for="taskRequirements">Requirements</label>
+        </div>
+      </div>
+      <div class="col-12">
+        <div class="form-floating">
+          <textarea class="form-control" id="taskSpecifications" name="specifications" placeholder="Specifications" style="height:100px"><?php echo h($task['specifications'] ?? ''); ?></textarea>
+          <label for="taskSpecifications">Specifications</label>
+        </div>
+      </div>
       <div class="col-sm-6 col-md-4">
         <div class="form-floating">
           <select class="form-select" id="taskStatus" name="status" required>
             <?php foreach ($statusMap as $s): ?>
-              <option value="<?php echo $s['id']; ?>" data-color="<?php echo h($s['color_class']); ?>" <?php if (($task['status'] ?? '') == $s['id']) echo 'selected'; ?>><?php echo h($s['label']); ?></option>
+              <?php $sel = (($task['status'] ?? null) == $s['id']) || (empty($task['status']) && !empty($s['is_default'])); ?>
+              <option value="<?php echo $s['id']; ?>" data-color="<?php echo h($s['color_class']); ?>" <?php echo $sel ? 'selected' : ''; ?>><?php echo h($s['label']); ?></option>
             <?php endforeach; ?>
           </select>
           <label for="taskStatus">Status</label>
@@ -31,7 +50,8 @@
         <div class="form-floating">
           <select class="form-select" id="taskPriority" name="priority" required>
             <?php foreach ($priorityMap as $p): ?>
-              <option value="<?php echo $p['id']; ?>" data-color="<?php echo h($p['color_class']); ?>" <?php if (($task['priority'] ?? '') == $p['id']) echo 'selected'; ?>><?php echo h($p['label']); ?></option>
+              <?php $sel = (($task['priority'] ?? null) == $p['id']) || (empty($task['priority']) && !empty($p['is_default'])); ?>
+              <option value="<?php echo $p['id']; ?>" data-color="<?php echo h($p['color_class']); ?>" <?php echo $sel ? 'selected' : ''; ?>><?php echo h($p['label']); ?></option>
             <?php endforeach; ?>
           </select>
           <label for="taskPriority">Priority</label>
@@ -78,6 +98,48 @@
               <option value="<?php echo $u['id']; ?>" <?php if (in_array($u['id'], $assignedUsers)) echo 'selected'; ?>><?php echo h($u['email']); ?></option>
             <?php endforeach; ?>
           </select>
+        </div>
+      </div>
+      <div class="col-sm-6 col-md-4">
+        <div class="flatpickr-input-container">
+          <div class="form-floating">
+            <input class="form-control datetimepicker" id="startDate" type="text" name="start_date" placeholder="Start date" value="<?php echo h($task['start_date'] ?? ''); ?>" data-options='{"disableMobile":true}'>
+            <label class="ps-6" for="startDate">Start date</label><span class="uil uil-calendar-alt flatpickr-icon text-body-tertiary"></span>
+          </div>
+        </div>
+      </div>
+      <div class="col-sm-6 col-md-4">
+        <div class="flatpickr-input-container">
+          <div class="form-floating">
+            <input class="form-control datetimepicker" id="dueDate" type="text" name="due_date" placeholder="Due date" value="<?php echo h($task['due_date'] ?? ''); ?>" data-options='{"disableMobile":true}'>
+            <label class="ps-6" for="dueDate">Due date</label><span class="uil uil-calendar-alt flatpickr-icon text-body-tertiary"></span>
+          </div>
+        </div>
+      </div>
+      <div class="col-sm-6 col-md-4">
+        <div class="flatpickr-input-container">
+          <div class="form-floating">
+            <input class="form-control datetimepicker" id="completeDate" type="text" name="complete_date" placeholder="Complete date" value="<?php echo h($task['complete_date'] ?? ''); ?>" data-options='{"disableMobile":true}'>
+            <label class="ps-6" for="completeDate">Complete date</label><span class="uil uil-calendar-alt flatpickr-icon text-body-tertiary"></span>
+          </div>
+        </div>
+      </div>
+      <div class="col-sm-6 col-md-4">
+        <div class="form-check form-switch mt-4">
+          <input class="form-check-input" id="completedCheck" type="checkbox" name="completed" value="1" <?php if (!empty($task['completed'])) echo 'checked'; ?>>
+          <label class="form-check-label" for="completedCheck">Completed</label>
+        </div>
+      </div>
+      <div class="col-sm-6 col-md-4">
+        <div class="form-floating">
+          <input class="form-control" id="progressPercent" type="number" name="progress_percent" min="0" max="100" placeholder="Progress %" value="<?php echo h($task['progress_percent'] ?? ''); ?>">
+          <label for="progressPercent">Progress %</label>
+        </div>
+      </div>
+      <div class="col-12">
+        <div class="form-floating">
+          <textarea class="form-control" id="taskMemo" name="memo" placeholder="Memo" style="height:100px"><?php echo h($task['memo'] ?? ''); ?></textarea>
+          <label for="taskMemo">Memo</label>
         </div>
       </div>
     </div>
@@ -97,7 +159,7 @@
 <h2 class="mb-4"><?php echo $isEdit ? 'Edit Task' : 'Create Task'; ?></h2>
 <div class="row">
   <div class="col-xl-9">
-    <form class="row g-3 mb-6" method="post" action="index.php?action=save">
+    <form id="taskForm" class="row g-3 mb-6" method="post" action="index.php?action=save">
       <input type="hidden" name="id" value="<?php echo h($task['id'] ?? ''); ?>">
       <div class="col-12">
         <div class="form-floating">
@@ -105,11 +167,30 @@
           <label for="taskName">Task name</label>
         </div>
       </div>
+      <div class="col-12">
+        <div class="form-floating">
+          <textarea class="form-control" id="taskDescription" name="description" placeholder="Description" style="height:100px"><?php echo h($task['description'] ?? ''); ?></textarea>
+          <label for="taskDescription">Description</label>
+        </div>
+      </div>
+      <div class="col-12">
+        <div class="form-floating">
+          <textarea class="form-control" id="taskRequirements" name="requirements" placeholder="Requirements" style="height:100px"><?php echo h($task['requirements'] ?? ''); ?></textarea>
+          <label for="taskRequirements">Requirements</label>
+        </div>
+      </div>
+      <div class="col-12">
+        <div class="form-floating">
+          <textarea class="form-control" id="taskSpecifications" name="specifications" placeholder="Specifications" style="height:100px"><?php echo h($task['specifications'] ?? ''); ?></textarea>
+          <label for="taskSpecifications">Specifications</label>
+        </div>
+      </div>
       <div class="col-sm-6 col-md-4">
         <div class="form-floating">
           <select class="form-select" id="taskStatus" name="status" required>
             <?php foreach ($statusMap as $s): ?>
-              <option value="<?php echo $s['id']; ?>" data-color="<?php echo h($s['color_class']); ?>" <?php if (($task['status'] ?? '') == $s['id']) echo 'selected'; ?>><?php echo h($s['label']); ?></option>
+              <?php $sel = (($task['status'] ?? null) == $s['id']) || (empty($task['status']) && !empty($s['is_default'])); ?>
+              <option value="<?php echo $s['id']; ?>" data-color="<?php echo h($s['color_class']); ?>" <?php echo $sel ? 'selected' : ''; ?>><?php echo h($s['label']); ?></option>
             <?php endforeach; ?>
           </select>
           <label for="taskStatus">Status</label>
@@ -119,7 +200,8 @@
         <div class="form-floating">
           <select class="form-select" id="taskPriority" name="priority" required>
             <?php foreach ($priorityMap as $p): ?>
-              <option value="<?php echo $p['id']; ?>" data-color="<?php echo h($p['color_class']); ?>" <?php if (($task['priority'] ?? '') == $p['id']) echo 'selected'; ?>><?php echo h($p['label']); ?></option>
+              <?php $sel = (($task['priority'] ?? null) == $p['id']) || (empty($task['priority']) && !empty($p['is_default'])); ?>
+              <option value="<?php echo $p['id']; ?>" data-color="<?php echo h($p['color_class']); ?>" <?php echo $sel ? 'selected' : ''; ?>><?php echo h($p['label']); ?></option>
             <?php endforeach; ?>
           </select>
           <label for="taskPriority">Priority</label>
@@ -166,6 +248,48 @@
               <option value="<?php echo $u['id']; ?>" <?php if (in_array($u['id'], $assignedUsers)) echo 'selected'; ?>><?php echo h($u['email']); ?></option>
             <?php endforeach; ?>
           </select>
+        </div>
+      </div>
+      <div class="col-sm-6 col-md-4">
+        <div class="flatpickr-input-container">
+          <div class="form-floating">
+            <input class="form-control datetimepicker" id="startDate" type="text" name="start_date" placeholder="Start date" value="<?php echo h($task['start_date'] ?? ''); ?>" data-options='{"disableMobile":true}'>
+            <label class="ps-6" for="startDate">Start date</label><span class="uil uil-calendar-alt flatpickr-icon text-body-tertiary"></span>
+          </div>
+        </div>
+      </div>
+      <div class="col-sm-6 col-md-4">
+        <div class="flatpickr-input-container">
+          <div class="form-floating">
+            <input class="form-control datetimepicker" id="dueDate" type="text" name="due_date" placeholder="Due date" value="<?php echo h($task['due_date'] ?? ''); ?>" data-options='{"disableMobile":true}'>
+            <label class="ps-6" for="dueDate">Due date</label><span class="uil uil-calendar-alt flatpickr-icon text-body-tertiary"></span>
+          </div>
+        </div>
+      </div>
+      <div class="col-sm-6 col-md-4">
+        <div class="flatpickr-input-container">
+          <div class="form-floating">
+            <input class="form-control datetimepicker" id="completeDate" type="text" name="complete_date" placeholder="Complete date" value="<?php echo h($task['complete_date'] ?? ''); ?>" data-options='{"disableMobile":true}'>
+            <label class="ps-6" for="completeDate">Complete date</label><span class="uil uil-calendar-alt flatpickr-icon text-body-tertiary"></span>
+          </div>
+        </div>
+      </div>
+      <div class="col-sm-6 col-md-4">
+        <div class="form-check form-switch mt-4">
+          <input class="form-check-input" id="completedCheck" type="checkbox" name="completed" value="1" <?php if (!empty($task['completed'])) echo 'checked'; ?>>
+          <label class="form-check-label" for="completedCheck">Completed</label>
+        </div>
+      </div>
+      <div class="col-sm-6 col-md-4">
+        <div class="form-floating">
+          <input class="form-control" id="progressPercent" type="number" name="progress_percent" min="0" max="100" placeholder="Progress %" value="<?php echo h($task['progress_percent'] ?? ''); ?>">
+          <label for="progressPercent">Progress %</label>
+        </div>
+      </div>
+      <div class="col-12">
+        <div class="form-floating">
+          <textarea class="form-control" id="taskMemo" name="memo" placeholder="Memo" style="height:100px"><?php echo h($task['memo'] ?? ''); ?></textarea>
+          <label for="taskMemo">Memo</label>
         </div>
       </div>
       <div class="col-12 gy-6">


### PR DESCRIPTION
## Summary
- Add RBAC-protected edit button and modal loader in task details view
- Expand task form to cover all task fields with date pickers and defaults
- Wire client-side fetch logic for opening and submitting the edit modal

## Testing
- `php -l module/task/include/form.php`
- `php -l module/task/include/details_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68a5631dd2488333aef12b995d705d5f