### PR TITLE
Extend task update handler

### DIFF
--- a/module/task/functions/update.php
+++ b/module/task/functions/update.php
@@ -8,7 +8,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   $id = (int)($_POST['id'] ?? 0);
 
   if ($id) {
-    $origStmt = $pdo->prepare('SELECT name, status, priority, description FROM module_tasks WHERE id = :id');
+    $origStmt = $pdo->prepare('SELECT * FROM module_tasks WHERE id = :id');
     $origStmt->execute([':id' => $id]);
     $existing = $origStmt->fetch(PDO::FETCH_ASSOC);
     if (!$existing) {
@@ -19,24 +19,100 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $fields = [];
     $params = [
       ':uid' => $this_user_id,
-      ':id' => $id
+      ':id'  => $id
     ];
 
-    if (array_key_exists('name', $_POST)) {
-      $fields[] = 'name = :name';
-      $params[':name'] = $_POST['name'];
+    $validStatusIds   = array_column(get_lookup_items($pdo, 'TASK_STATUS'), 'id');
+    $validPriorityIds = array_column(get_lookup_items($pdo, 'TASK_PRIORITY'), 'id');
+
+    foreach (['name','description','requirements','specifications'] as $col) {
+      if (array_key_exists($col, $_POST)) {
+        $fields[] = "$col = :$col";
+        $params[":$col"] = $_POST[$col];
+      }
     }
-    if (array_key_exists('status', $_POST) && $_POST['status'] !== null && $_POST['status'] !== '') {
-      $fields[] = 'status = :status';
-      $params[':status'] = (int)$_POST['status'];
+
+    $fkTables = [
+      'project_id'  => 'module_projects',
+      'division_id' => 'module_division',
+      'agency_id'   => 'module_agency'
+    ];
+    foreach ($fkTables as $col => $table) {
+      if (array_key_exists($col, $_POST)) {
+        $val = $_POST[$col];
+        if ($val === '' || $val === null) {
+          $fields[] = "$col = NULL";
+        } else {
+          $chk = $pdo->prepare("SELECT id FROM $table WHERE id = :val");
+          $chk->execute([':val' => $val]);
+          if ($chk->fetchColumn()) {
+            $fields[] = "$col = :$col";
+            $params[":$col"] = $val;
+          }
+        }
+      }
     }
-    if (array_key_exists('priority', $_POST) && $_POST['priority'] !== null && $_POST['priority'] !== '') {
-      $fields[] = 'priority = :priority';
-      $params[':priority'] = (int)$_POST['priority'];
+
+    if (array_key_exists('status', $_POST)) {
+      $val = $_POST['status'];
+      if ($val === '' || $val === null) {
+        $fields[] = 'status = NULL';
+      } elseif (in_array($val, $validStatusIds)) {
+        $fields[] = 'status = :status';
+        $params[':status'] = $val;
+      }
     }
-    if (array_key_exists('description', $_POST)) {
-      $fields[] = 'description = :description';
-      $params[':description'] = $_POST['description'];
+
+    if (array_key_exists('priority', $_POST)) {
+      $val = $_POST['priority'];
+      if ($val === '' || $val === null) {
+        $fields[] = 'priority = NULL';
+      } elseif (in_array($val, $validPriorityIds)) {
+        $fields[] = 'priority = :priority';
+        $params[':priority'] = $val;
+      }
+    }
+
+    foreach (['start_date','due_date'] as $col) {
+      if (array_key_exists($col, $_POST)) {
+        $val = $_POST[$col];
+        if ($val === '' || $val === null) {
+          $fields[] = "$col = NULL";
+        } else {
+          $fields[] = "$col = :$col";
+          $params[":$col"] = $val;
+        }
+      }
+    }
+
+    if (array_key_exists('completed', $_POST)) {
+      $newCompleted = (int)($_POST['completed'] ? 1 : 0);
+      $oldCompleted = (int)($existing['completed'] ?? 0);
+      if ($newCompleted !== $oldCompleted) {
+        if ($newCompleted === 1) {
+          $fields[] = 'completed = 1';
+          $fields[] = 'complete_date = NOW()';
+          $fields[] = 'completed_by = :completed_by';
+          $params[':completed_by'] = $this_user_id;
+          $fields[] = 'progress_percent = 100';
+        } else {
+          $fields[] = 'completed = 0';
+          $fields[] = 'complete_date = NULL';
+          $fields[] = 'completed_by = NULL';
+          $fields[] = 'progress_percent = 0';
+        }
+      } else {
+        $fields[] = 'completed = :completed';
+        $params[':completed'] = $newCompleted;
+      }
+    }
+
+    if (array_key_exists('progress_percent', $_POST) && !array_key_exists('completed', $_POST)) {
+      $pp = (int)$_POST['progress_percent'];
+      if ($pp < 0) { $pp = 0; }
+      if ($pp > 100) { $pp = 100; }
+      $fields[] = 'progress_percent = :progress_percent';
+      $params[':progress_percent'] = $pp;
     }
 
     if ($fields) {
@@ -47,14 +123,23 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 
     $taskStmt = $pdo->prepare(
-      'SELECT t.id, t.name, t.status, t.previous_status, t.priority, t.due_date, t.completed, ' .
+      'SELECT t.*, ' .
       'ls.label AS status_label, COALESCE(lsattr.attr_value, "secondary") AS status_color, ' .
-      'lp.label AS priority_label, COALESCE(lpat.attr_value, "secondary") AS priority_color ' .
+      'lp.label AS priority_label, COALESCE(lpat.attr_value, "secondary") AS priority_color, ' .
+      'p.name AS project_name, d.name AS division_name, a.name AS agency_name, ' .
+      'o.name AS organization_name, ' .
+      'CONCAT(cbper.first_name, " ", cbper.last_name) AS completed_by_name ' .
       'FROM module_tasks t ' .
       'LEFT JOIN lookup_list_items ls ON t.status = ls.id ' .
       'LEFT JOIN lookup_list_item_attributes lsattr ON ls.id = lsattr.item_id AND lsattr.attr_code = "COLOR-CLASS" ' .
       'LEFT JOIN lookup_list_items lp ON t.priority = lp.id ' .
       'LEFT JOIN lookup_list_item_attributes lpat ON lp.id = lpat.item_id AND lpat.attr_code = "COLOR-CLASS" ' .
+      'LEFT JOIN module_projects p ON t.project_id = p.id ' .
+      'LEFT JOIN module_division d ON t.division_id = d.id ' .
+      'LEFT JOIN module_agency a ON t.agency_id = a.id ' .
+      'LEFT JOIN module_organization o ON a.organization_id = o.id ' .
+      'LEFT JOIN users cb ON t.completed_by = cb.id ' .
+      'LEFT JOIN person cbper ON cb.id = cbper.user_id ' .
       'WHERE t.id = :id'
     );
     $taskStmt->execute([':id' => $id]);
@@ -65,4 +150,3 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 
 echo json_encode(['success' => false]);
-

--- a/module/task/index.php
+++ b/module/task/index.php
@@ -86,23 +86,27 @@ if ($action === 'create-edit' && isset($_GET['modal'])) {
   $id = (int)($_GET['id'] ?? 0);
   if ($id) {
     require_permission('task', 'update');
-    $stmt = $pdo->prepare('SELECT * FROM module_tasks WHERE id=?');
-    $stmt->execute([$id]);
+    $stmt = $pdo->prepare(
+      'SELECT id, user_id, user_updated, date_created, date_updated, memo, project_id, agency_id, division_id, ' .
+      'name, description, requirements, specifications, status, previous_status, priority, start_date, due_date, ' .
+      'complete_date, completed, completed_by, progress_percent FROM module_tasks WHERE id = :id'
+    );
+    $stmt->execute([':id' => $id]);
     $task = $stmt->fetch(PDO::FETCH_ASSOC) ?: [];
-    $assignedUsers = $pdo->prepare('SELECT assigned_user_id FROM module_task_assignments WHERE task_id=?');
-    $assignedUsers->execute([$id]);
-    $assignedUsers = $assignedUsers->fetchAll(PDO::FETCH_COLUMN);
+    $assignedStmt = $pdo->prepare('SELECT assigned_user_id FROM module_task_assignments WHERE task_id = :id');
+    $assignedStmt->execute([':id' => $id]);
+    $assignedUsers = $assignedStmt->fetchAll(PDO::FETCH_COLUMN);
   } else {
     require_permission('task', 'create');
     $task = [];
     $assignedUsers = [];
   }
-  $statusMap = get_lookup_items($pdo, 'TASK_STATUS');
+  $statusMap   = get_lookup_items($pdo, 'TASK_STATUS');
   $priorityMap = get_lookup_items($pdo, 'TASK_PRIORITY');
-  $projects = $pdo->query('SELECT id,name FROM module_projects ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
-  $agencies = $pdo->query('SELECT id,name FROM module_agency ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
-  $divisions = $pdo->query('SELECT id,name FROM module_division ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
-  $users = $pdo->query('SELECT id,email FROM users ORDER BY email')->fetchAll(PDO::FETCH_ASSOC);
+  $projects    = $pdo->query('SELECT id,name FROM module_projects ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
+  $agencies    = $pdo->query('SELECT id,name FROM module_agency ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
+  $divisions   = $pdo->query('SELECT id,name FROM module_division ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
+  $users       = $pdo->query('SELECT id,email FROM users ORDER BY email')->fetchAll(PDO::FETCH_ASSOC);
 
   require 'include/form.php';
   exit;


### PR DESCRIPTION
## Summary
- Support dynamic updates for all task fields with validation and completion handling
- Load full task data and lookup lists in modal create-edit flow

## Testing
- `php -l module/task/functions/update.php`
- `php -l module/task/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68a563209a208333bd6be572dc0fecab