### PR TITLE
Refactor kanban board to support project-specific statuses

### DIFF
--- a/module/kanban/functions/update_task_status.php
+++ b/module/kanban/functions/update_task_status.php
@@ -4,12 +4,12 @@ require_permission('kanban', 'update');
 
 header('Content-Type: application/json');
 
-$task_id = isset($_POST['task_id']) ? (int)$_POST['task_id'] : 0;
-$status  = $_POST['status'] ?? '';
+$task_id   = isset($_POST['task_id']) ? (int)$_POST['task_id'] : 0;
+$status_id = isset($_POST['status_id']) ? (int)$_POST['status_id'] : 0;
 
-if ($task_id && $status) {
+if ($task_id && $status_id) {
     $stmt = $pdo->prepare('UPDATE module_tasks SET status=?, user_updated=? WHERE id=?');
-    $stmt->execute([$status, $this_user_id, $task_id]);
+    $stmt->execute([$status_id, $this_user_id, $task_id]);
     echo json_encode(['success' => true]);
     exit;
 }

--- a/module/kanban/include/board_view.php
+++ b/module/kanban/include/board_view.php
@@ -4,15 +4,15 @@
 <div class="container py-4">
   <h2 class="mb-4"><?= htmlspecialchars($board['name'] ?? 'Board') ?></h2>
   <div class="row g-3 kanban-board" data-board-id="<?= $board['id'] ?>">
-    <?php foreach ($statuses as $st): 
-      $tasks = fetch_tasks_for_status($pdo, $st['name']);
+    <?php foreach ($statuses as $st):
+      $tasks = fetch_tasks_for_status($pdo, $board['id'], $st['status_id']);
     ?>
     <div class="col-md-3">
       <div class="card h-100">
         <div class="card-header">
-          <h5 class="mb-0"><?= htmlspecialchars($st['name']) ?></h5>
+          <h5 class="mb-0"><?= htmlspecialchars($st['label']) ?></h5>
         </div>
-        <div class="card-body min-vh-50 kanban-column" data-status="<?= htmlspecialchars($st['name']) ?>">
+        <div class="card-body min-vh-50 kanban-column" data-status-id="<?= $st['status_id'] ?>">
           <?php foreach ($tasks as $t): ?>
             <div class="card mb-2 p-2 kanban-item" data-task-id="<?= $t['id'] ?>" draggable="true">
               <?= htmlspecialchars($t['name']) ?>
@@ -36,11 +36,11 @@ document.querySelectorAll('.kanban-column').forEach(col => {
   col.addEventListener('drop', function(e) {
     e.preventDefault();
     const taskId = e.dataTransfer.getData('text/plain');
-    const status = this.dataset.status;
+    const statusId = this.dataset.statusId;
     fetch('functions/update_task_status.php', {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: `task_id=${taskId}&status=${encodeURIComponent(status)}`
+      body: `task_id=${taskId}&status_id=${encodeURIComponent(statusId)}`
     });
     const item = document.querySelector(`.kanban-item[data-task-id="${taskId}"]`);
     if (item) this.appendChild(item);

--- a/module/kanban/include/form.php
+++ b/module/kanban/include/form.php
@@ -1,7 +1,8 @@
 <?php
-// Expects $board from index.php
+// Expects $board, $projects, $selectedProjects from index.php
 $board_id = $board['id'] ?? null;
 $name = $board['name'] ?? '';
+$selProjects = $selectedProjects ?? [];
 ?>
 <div class="container py-4">
   <h2 class="mb-4"><?= $board_id ? 'Edit Board' : 'Create Board' ?></h2>
@@ -10,6 +11,14 @@ $name = $board['name'] ?? '';
     <div class="mb-3">
       <label class="form-label">Board Name</label>
       <input class="form-control" name="name" value="<?= htmlspecialchars($name) ?>" required>
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Projects</label>
+      <select class="form-select" name="projects[]" multiple>
+        <?php foreach ($projects as $p): ?>
+          <option value="<?= $p['id'] ?>" <?= in_array($p['id'], $selProjects) ? 'selected' : '' ?>><?= htmlspecialchars($p['name']) ?></option>
+        <?php endforeach; ?>
+      </select>
     </div>
     <button class="btn btn-falcon-primary" type="submit">Save</button>
     <a class="btn btn-falcon-secondary" href="index.php">Cancel</a>

--- a/module/kanban/index.php
+++ b/module/kanban/index.php
@@ -1,13 +1,23 @@
 <?php
 require '../../includes/php_header.php';
 $action = $_GET['action'] ?? 'list';
-require_permission('kanban', $action);
+$permMap = [
+  'list'  => 'read',
+  'board' => 'read',
+  'create'=> 'create',
+  'edit'  => 'update',
+  'save'  => 'update',
+  'delete'=> 'delete'
+];
+require_permission('kanban', $permMap[$action] ?? 'read');
 require_once __DIR__.'/functions/kanban_crud.php';
 
 if ($action === 'save' && $_SERVER['REQUEST_METHOD'] === 'POST') {
-    $id   = $_POST['id'] ?? null;
-    $name = trim($_POST['name'] ?? '');
-    save_board($pdo, $id ? (int)$id : null, $name, $this_user_id);
+    $id        = $_POST['id'] ?? null;
+    $name      = trim($_POST['name'] ?? '');
+    $projects  = array_map('intval', $_POST['projects'] ?? []);
+    $boardId   = save_board($pdo, $id ? (int)$id : null, $name, $this_user_id);
+    save_board_projects($pdo, $boardId, $projects, $this_user_id);
     header('Location: index.php');
     exit;
 }
@@ -21,6 +31,8 @@ if ($action === 'delete' && isset($_GET['id'])) {
 $board = null;
 $boards = [];
 $statuses = [];
+$projects = [];
+$selectedProjects = [];
 
 if ($action === 'list') {
     $boards = fetch_boards($pdo);
@@ -28,6 +40,10 @@ if ($action === 'list') {
     $board_id = (int)($_GET['id'] ?? 0);
     $board = fetch_board($pdo, $board_id);
     $statuses = fetch_statuses($pdo, $board_id);
+    $selectedProjects = fetch_board_projects($pdo, $board_id);
+}
+if ($action === 'create' || $action === 'edit') {
+    $projects = $pdo->query('SELECT id, name FROM module_projects ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
 }
 
 require '../../includes/html_header.php';


### PR DESCRIPTION
## Summary
- Seed kanban board statuses from TASK_STATUS lookup on creation
- Allow selecting projects per board and load tasks only from those projects
- Map kanban actions to CRUD permissions and wire status updates by ID

## Testing
- `php -l module/kanban/functions/kanban_crud.php`
- `php -l module/kanban/index.php`
- `php -l module/kanban/include/form.php`
- `php -l module/kanban/include/board_view.php`
- `php -l module/kanban/functions/update_task_status.php`


------
https://chatgpt.com/codex/tasks/task_e_68a563f3f8cc83339d5c8063e6c4a33d