### PR TITLE
Add admin navigation link ordering module

### DIFF
--- a/admin/modules.php
+++ b/admin/modules.php
@@ -17,6 +17,12 @@ return [
     'path' => 'roles/index.php',
     'icon' => 'shield',
     'description' => 'Manage user roles and permissions.'
+  ],
+  [
+    'title' => 'Navigation Links',
+    'path' => 'navigation.php',
+    'icon' => 'menu',
+    'description' => 'Manage site navigation links.'
   ]
 ];
 ?>


### PR DESCRIPTION
## Summary
- Add admin page to reorder navigation links with drag-and-drop
- Persist new order to `admin_navigation_links` and guard with permissions
- Expose navigation link manager in admin module list

## Testing
- `php -l admin/navigation.php`
- `php -l admin/modules.php`


------
https://chatgpt.com/codex/tasks/task_e_68a56413e2d88333853476ffc9176cc2