### PR TITLE
Refactor admin navigation to use shared table

### DIFF
--- a/admin/left_navigation.php
+++ b/admin/left_navigation.php
@@ -3,26 +3,6 @@
   <div class="collapse navbar-collapse" id="navbarVerticalCollapse">
     <div class="navbar-vertical-content">
       <ul class="navbar-nav flex-column" id="navbarVerticalNav">
-        <li class="nav-item">
-          <a class="nav-link" href="<?php echo getURLDir(); ?>admin/index.php">
-            <div class="d-flex align-items-center"><span class="nav-link-icon"><span data-feather="home"></span></span><span class="nav-link-text">Dashboard</span></div>
-          </a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="<?php echo getURLDir(); ?>admin/users/index.php">
-            <div class="d-flex align-items-center"><span class="nav-link-icon"><span data-feather="user"></span></span><span class="nav-link-text">Users</span></div>
-          </a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="<?php echo getURLDir(); ?>admin/person/index.php">
-            <div class="d-flex align-items-center"><span class="nav-link-icon"><span data-feather="users"></span></span><span class="nav-link-text">Persons</span></div>
-          </a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="<?php echo getURLDir(); ?>admin/contractors/index.php">
-            <div class="d-flex align-items-center"><span class="nav-link-icon"><span data-feather="briefcase"></span></span><span class="nav-link-text">Contractors</span></div>
-          </a>
-        </li>
         <?php foreach ($modules as $module): ?>
         <li class="nav-item">
           <a class="nav-link" href="<?php echo getURLDir(); ?>admin/<?= htmlspecialchars($module['path']); ?>">
@@ -30,11 +10,6 @@
           </a>
         </li>
         <?php endforeach; ?>
-        <li class="nav-item">
-          <a class="nav-link" href="<?php echo getURLDir(); ?>admin/system-properties/index.php">
-            <div class="d-flex align-items-center"><span class="nav-link-icon"><span data-feather="sliders"></span></span><span class="nav-link-text">System Properties</span></div>
-          </a>
-        </li>
       </ul>
     </div>
   </div>

--- a/admin/modules.php
+++ b/admin/modules.php
@@ -1,22 +1,14 @@
 <?php
-return [
-  [
-    'title' => 'Users',
-    'path' => 'users/index.php',
-    'icon' => 'users',
-    'description' => 'Manage system users.'
-  ],
-  [
-    'title' => 'Lookup Lists',
-    'path' => 'lookup-lists/index.php',
-    'icon' => 'list',
-    'description' => 'Manage lookup lists and items.'
-  ],
-  [
-    'title' => 'Roles',
-    'path' => 'roles/index.php',
-    'icon' => 'shield',
-    'description' => 'Manage user roles and permissions.'
-  ]
-];
+/**
+ * Fetch the admin navigation links from the shared table.
+ *
+ * @return array<int, array<string, mixed>> List of navigation links
+ */
+global $pdo;
+
+$sql = 'SELECT * FROM admin_navigation_links ORDER BY sort_order';
+$stmt = $pdo->prepare($sql);
+$stmt->execute();
+
+return $stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>


### PR DESCRIPTION
## Summary
- Remove hardcoded admin navigation items
- Load navigation links and module metadata from `admin_navigation_links` table

## Testing
- `php -l admin/modules.php`
- `php -l admin/left_navigation.php`


------
https://chatgpt.com/codex/tasks/task_e_68a56416d9308333a51e4feafcd5fc5e