### PR TITLE
Add database-driven admin navigation menu

### DIFF
--- a/_SQL/atlis.sql
+++ b/_SQL/atlis.sql
@@ -502,6 +502,38 @@ INSERT INTO `admin_user_roles` (`id`, `user_id`, `user_updated`, `date_created`,
 -- --------------------------------------------------------
 
 --
+-- Table structure for table `admin_navigation_links`
+--
+
+CREATE TABLE `admin_navigation_links` (
+  `id` int(11) NOT NULL,
+  `title` varchar(255) NOT NULL,
+  `path` varchar(255) NOT NULL,
+  `icon` varchar(50) DEFAULT NULL,
+  `sort_order` int(11) NOT NULL,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT current_timestamp(),
+  `date_updated` datetime DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  `memo` text DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+--
+-- Dumping data for table `admin_navigation_links`
+--
+
+INSERT INTO `admin_navigation_links` (`id`, `title`, `path`, `icon`, `sort_order`, `user_id`, `user_updated`, `date_created`, `date_updated`, `memo`) VALUES
+(1, 'Dashboard', 'index.php', 'home', 1, 1, 1, '2025-08-20 00:00:00', '2025-08-20 00:00:00', NULL),
+(2, 'Users', 'users/index.php', 'user', 2, 1, 1, '2025-08-20 00:00:00', '2025-08-20 00:00:00', NULL),
+(3, 'Persons', 'person/index.php', 'users', 3, 1, 1, '2025-08-20 00:00:00', '2025-08-20 00:00:00', NULL),
+(4, 'Contractors', 'contractors/index.php', 'briefcase', 4, 1, 1, '2025-08-20 00:00:00', '2025-08-20 00:00:00', NULL),
+(5, 'Lookup Lists', 'lookup-lists/index.php', 'list', 5, 1, 1, '2025-08-20 00:00:00', '2025-08-20 00:00:00', NULL),
+(6, 'Roles', 'roles/index.php', 'shield', 6, 1, 1, '2025-08-20 00:00:00', '2025-08-20 00:00:00', NULL),
+(7, 'System Properties', 'system-properties/index.php', 'sliders', 7, 1, 1, '2025-08-20 00:00:00', '2025-08-20 00:00:00', NULL);
+
+-- --------------------------------------------------------
+
+--
 -- Table structure for table `audit_log`
 --
 
@@ -1858,6 +1890,14 @@ ALTER TABLE `admin_user_roles`
   ADD KEY `fk_admin_user_roles_user_account_id` (`user_account_id`);
 
 --
+-- Indexes for table `admin_navigation_links`
+--
+ALTER TABLE `admin_navigation_links`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `fk_admin_navigation_links_user_id` (`user_id`),
+  ADD KEY `fk_admin_navigation_links_user_updated` (`user_updated`);
+
+--
 -- Indexes for table `audit_log`
 --
 ALTER TABLE `audit_log`
@@ -2212,6 +2252,12 @@ ALTER TABLE `admin_user_roles`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=19;
 
 --
+-- AUTO_INCREMENT for table `admin_navigation_links`
+--
+ALTER TABLE `admin_navigation_links`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=8;
+
+--
 -- AUTO_INCREMENT for table `audit_log`
 --
 ALTER TABLE `audit_log`
@@ -2433,6 +2479,13 @@ ALTER TABLE `admin_role_permission_groups`
 ALTER TABLE `admin_user_roles`
   ADD CONSTRAINT `fk_admin_user_roles_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
   ADD CONSTRAINT `fk_admin_user_roles_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`) ON DELETE SET NULL;
+
+--
+-- Constraints for table `admin_navigation_links`
+--
+ALTER TABLE `admin_navigation_links`
+  ADD CONSTRAINT `fk_admin_navigation_links_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  ADD CONSTRAINT `fk_admin_navigation_links_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`) ON DELETE SET NULL;
 
 --
 -- Constraints for table `lookup_lists`

--- a/admin/left_navigation.php
+++ b/admin/left_navigation.php
@@ -1,40 +1,18 @@
-<?php $modules = require __DIR__ . '/modules.php'; ?>
+<?php
+$stmt = $pdo->query('SELECT title, path, icon FROM admin_navigation_links ORDER BY sort_order');
+$navLinks = $stmt->fetchAll(PDO::FETCH_ASSOC);
+?>
 <nav class="navbar navbar-vertical navbar-expand-lg">
   <div class="collapse navbar-collapse" id="navbarVerticalCollapse">
     <div class="navbar-vertical-content">
       <ul class="navbar-nav flex-column" id="navbarVerticalNav">
+        <?php foreach ($navLinks as $link): ?>
         <li class="nav-item">
-          <a class="nav-link" href="<?php echo getURLDir(); ?>admin/index.php">
-            <div class="d-flex align-items-center"><span class="nav-link-icon"><span data-feather="home"></span></span><span class="nav-link-text">Dashboard</span></div>
-          </a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="<?php echo getURLDir(); ?>admin/users/index.php">
-            <div class="d-flex align-items-center"><span class="nav-link-icon"><span data-feather="user"></span></span><span class="nav-link-text">Users</span></div>
-          </a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="<?php echo getURLDir(); ?>admin/person/index.php">
-            <div class="d-flex align-items-center"><span class="nav-link-icon"><span data-feather="users"></span></span><span class="nav-link-text">Persons</span></div>
-          </a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="<?php echo getURLDir(); ?>admin/contractors/index.php">
-            <div class="d-flex align-items-center"><span class="nav-link-icon"><span data-feather="briefcase"></span></span><span class="nav-link-text">Contractors</span></div>
-          </a>
-        </li>
-        <?php foreach ($modules as $module): ?>
-        <li class="nav-item">
-          <a class="nav-link" href="<?php echo getURLDir(); ?>admin/<?= htmlspecialchars($module['path']); ?>">
-            <div class="d-flex align-items-center"><span class="nav-link-icon"><span data-feather="<?= htmlspecialchars($module['icon']); ?>"></span></span><span class="nav-link-text"><?= htmlspecialchars($module['title']); ?></span></div>
+          <a class="nav-link" href="<?php echo getURLDir(); ?>admin/<?= htmlspecialchars($link['path']); ?>">
+            <div class="d-flex align-items-center"><span class="nav-link-icon"><span data-feather="<?= htmlspecialchars($link['icon']); ?>"></span></span><span class="nav-link-text"><?= htmlspecialchars($link['title']); ?></span></div>
           </a>
         </li>
         <?php endforeach; ?>
-        <li class="nav-item">
-          <a class="nav-link" href="<?php echo getURLDir(); ?>admin/system-properties/index.php">
-            <div class="d-flex align-items-center"><span class="nav-link-icon"><span data-feather="sliders"></span></span><span class="nav-link-text">System Properties</span></div>
-          </a>
-        </li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Create `admin_navigation_links` table to manage admin menu items and seed with core links
- Render admin left navigation from database instead of static list

## Testing
- `php -l admin/left_navigation.php`


------
https://chatgpt.com/codex/tasks/task_e_68a564122a6c83339a52c6f9cf49dc86