### PR TITLE
Attach Dropzone params and validate project ID

### DIFF
--- a/module/project/functions/upload_file.php
+++ b/module/project/functions/upload_file.php
@@ -3,10 +3,16 @@ require '../../../includes/php_header.php';
 require_permission('project','update');
 
 $project_id = (int)($_POST['project_id'] ?? 0);
+if (!$project_id) {
+    http_response_code(400);
+    header('Content-Type: application/json');
+    echo json_encode(['error' => 'Missing project_id']);
+    exit;
+}
 $note_id = isset($_POST['note_id']) && $_POST['note_id'] !== '' ? (int)$_POST['note_id'] : null;
 $response = [];
 
-if ($project_id && !empty($_FILES['file'])) {
+if (!empty($_FILES['file'])) {
     $uploadDir = '../uploads/';
     if (!is_dir($uploadDir)) {
         mkdir($uploadDir, 0777, true);

--- a/module/project/include/details_view.php
+++ b/module/project/include/details_view.php
@@ -529,6 +529,22 @@ if (!empty($current_project)) {
 <script>
 document.addEventListener('DOMContentLoaded', function () {
   var projectId = <?= (int)$current_project['id'] ?>;
+  if (window.Dropzone) {
+    Dropzone.autoDiscover = false;
+    const dz = new Dropzone('#project-file-dropzone', {
+      url: 'functions/upload_file.php',
+      paramName: 'file',
+      init() {
+        this.on('sending', (file, xhr, formData) => {
+          formData.append('project_id', projectId);
+          formData.append('note_id', '');
+        });
+        this.on('queuecomplete', () => {
+          window.location.reload();
+        });
+      }
+    });
+  }
   var chartEl = document.querySelector('.echart-completed-task-chart');
   if (chartEl && window.echarts) {
     var chart = window.echarts.init(chartEl);


### PR DESCRIPTION
## Summary
- initialize Dropzone with project and note IDs and refresh files when uploads finish
- validate project_id on upload backend and return 400 on missing parameter

## Testing
- `php -l module/project/include/details_view.php`
- `php -l module/project/functions/upload_file.php`


------
https://chatgpt.com/codex/tasks/task_e_68a56be1aaf08333ad78d37385f4e528