### PR TITLE
Redirect to edit page after updating user profile image

### DIFF
--- a/admin/users/functions/save.php
+++ b/admin/users/functions/save.php
@@ -239,6 +239,11 @@ try {
   $_SESSION['error_message'] = substr($e->getMessage(), 0, 200);
   $_SESSION['message'] = 'Error saving user.';
 }
+// Redirect differently if updating and a new profile picture was uploaded
+if ($isUpdate && $profilePath) {
+  header('Location: ../edit.php?id=' . $id);
+  exit;
+}
 
 header('Location: ../index.php');
 exit;


### PR DESCRIPTION
## Summary
- Redirect to the edit page when an existing user uploads a new profile picture
- Preserve default redirect to index for all other save operations

## Testing
- `php -l admin/users/functions/save.php`


------
https://chatgpt.com/codex/tasks/task_e_68a63698c4d0833381d0d6e779875cf2