### PR TITLE
Add contractor action toast notifications and hash redirects

### DIFF
--- a/admin/contractors/contractor.php
+++ b/admin/contractors/contractor.php
@@ -30,6 +30,13 @@ if ($id) {
   $existingFiles = $stmt->fetchAll(PDO::FETCH_ASSOC);
 }
 
+$messages = [
+  'note-added'    => 'Note added',
+  'contact-added' => 'Contact added',
+  'comp-saved'    => 'Compensation saved',
+  'file-uploaded' => 'File uploaded'
+];
+
 $defaultCompTypeId = null;
 foreach ($payTypes as $p) {
   if (!empty($p['is_default'])) {
@@ -366,4 +373,28 @@ $_SESSION['csrf_token'] = $token;
     <?php endif; ?>
   </div>
 </div>
+<div class="position-fixed bottom-0 end-0 p-3" style="z-index: 1050">
+  <div id="action-toast" class="toast text-bg-success" role="alert" aria-live="assertive" aria-atomic="true">
+    <div class="d-flex">
+      <div class="toast-body"></div>
+      <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+    </div>
+  </div>
+</div>
+<script>
+const messages = <?= json_encode($messages); ?>;
+document.addEventListener('DOMContentLoaded', () => {
+  const hash = window.location.hash;
+  if (hash) {
+    const tabTrigger = document.querySelector(`[data-bs-target="${hash}"]`);
+    tabTrigger && new bootstrap.Tab(tabTrigger).show();
+  }
+  const msg = new URLSearchParams(window.location.search).get('msg');
+  const toastEl = document.getElementById('action-toast');
+  if (msg && toastEl) {
+    toastEl.querySelector('.toast-body').textContent = messages[msg] || 'Saved successfully';
+    new bootstrap.Toast(toastEl).show();
+  }
+});
+</script>
 <?php require '../admin_footer.php'; ?>

--- a/admin/contractors/functions/add_compensation.php
+++ b/admin/contractors/functions/add_compensation.php
@@ -16,6 +16,7 @@ $notes = trim($_POST['notes'] ?? '');
 
 $file_id = $existing_file_id ?: null;
 
+$ok = false;
 if($cid && $comp_type_id && $payment_method_id && $title !== '' && $pay_date !== '' && $amount !== '' && $start !== ''){
   if(isset($_FILES['attachment']) && $_FILES['attachment']['error'] === UPLOAD_ERR_OK){
     $max = (int)get_system_property($pdo,'contractor_file_max_size');
@@ -85,6 +86,9 @@ if($cid && $comp_type_id && $payment_method_id && $title !== '' && $pay_date !==
   ]);
   $compId = $pdo->lastInsertId();
   admin_audit_log($pdo,$this_user_id,'module_contractors_compensation',$compId,'CREATE','',json_encode(['amount'=>$amount,'type'=>$comp_type_id,'title'=>$title]),'Added compensation');
+  $ok = true;
 }
-header('Location: ../contractor.php?id='.$cid.'#compensation');
+$loc = '../contractor.php?id='.$cid;
+$loc .= $ok ? '&msg=comp-saved#compensation' : '#compensation';
+header('Location: '.$loc);
 exit;

--- a/admin/contractors/functions/add_contact.php
+++ b/admin/contractors/functions/add_contact.php
@@ -11,6 +11,7 @@ $contact_result = trim($_POST['contact_result'] ?? '');
 $related_module = trim($_POST['related_module'] ?? '');
 $related_id = $_POST['related_id'] !== '' ? (int)$_POST['related_id'] : null;
 
+$ok = false;
 if($cid && $contact_type_id && $summary !== ''){
   $cdate = $contact_date !== '' ? date('Y-m-d H:i:s', strtotime($contact_date)) : null;
   $stmt = $pdo->prepare('INSERT INTO module_contractors_contacts (user_id,user_updated,contractor_id,contact_type_id,contact_date,summary,contact_duration,contact_result,related_module,related_id) VALUES (:uid,:uid,:cid,:type,:cdate,:summary,:duration,:result,:rmod,:rid)');
@@ -27,6 +28,9 @@ if($cid && $contact_type_id && $summary !== ''){
   ]);
   $contactId = $pdo->lastInsertId();
   admin_audit_log($pdo,$this_user_id,'module_contractors_contacts',$contactId,'CREATE','',json_encode(['contact_type_id'=>$contact_type_id,'summary'=>$summary]),'Added contact');
+  $ok = true;
 }
-header('Location: ../contractor.php?id='.$cid.'#contacts');
+$loc = '../contractor.php?id='.$cid;
+$loc .= $ok ? '&msg=contact-added#contacts' : '#contacts';
+header('Location: '.$loc);
 exit;

--- a/admin/contractors/functions/add_note.php
+++ b/admin/contractors/functions/add_note.php
@@ -4,11 +4,15 @@ require_permission('contractors','update');
 
 $cid  = (int)($_POST['contractor_id'] ?? 0);
 $note = trim($_POST['note_text'] ?? '');
+$ok = false;
 if($cid && $note !== ''){
   $stmt = $pdo->prepare('INSERT INTO module_contractors_notes (user_id,user_updated,contractor_id,note_text) VALUES (:uid,:uid,:cid,:note)');
   $stmt->execute([':uid'=>$this_user_id, ':cid'=>$cid, ':note'=>$note]);
   $nid = $pdo->lastInsertId();
   admin_audit_log($pdo,$this_user_id,'module_contractors_notes',$nid,'NOTE','', $note);
+  $ok = true;
 }
-header('Location: ../contractor.php?id='.$cid.'#notes');
+$loc = '../contractor.php?id='.$cid;
+$loc .= $ok ? '&msg=note-added#notes' : '#notes';
+header('Location: '.$loc);
 exit;

--- a/admin/contractors/functions/upload_file.php
+++ b/admin/contractors/functions/upload_file.php
@@ -6,6 +6,7 @@ require_permission('contractors','update');
 $cid = (int)($_POST['contractor_id'] ?? 0);
 $file_type_id = (int)($_POST['file_type_id'] ?? 0);
 $description = trim($_POST['description'] ?? '');
+$ok = false;
 if($cid && $file_type_id && isset($_FILES['file']) && $_FILES['file']['error'] === UPLOAD_ERR_OK){
   $max = (int)get_system_property($pdo,'contractor_file_max_size');
   if(!$max){ $max = 10 * 1024 * 1024; }
@@ -49,7 +50,10 @@ if($cid && $file_type_id && isset($_FILES['file']) && $_FILES['file']['error'] =
     ]);
     $fid = $pdo->lastInsertId();
     admin_audit_log($pdo,$this_user_id,'module_contractors_files',$fid,'UPLOAD','',json_encode(['file'=>$fileName,'version'=>$version]));
+    $ok = true;
   }
 }
-header('Location: ../contractor.php?id='.$cid.'#files');
+$loc = '../contractor.php?id='.$cid;
+$loc .= $ok ? '&msg=file-uploaded#files' : '#files';
+header('Location: '.$loc);
 exit;


### PR DESCRIPTION
## Summary
- Redirect contractor actions with hash and message codes
- Show success toast messages and activate tabs based on URL hash

## Testing
- `php -l admin/contractors/functions/add_note.php && php -l admin/contractors/functions/add_contact.php && php -l admin/contractors/functions/add_compensation.php && php -l admin/contractors/functions/upload_file.php && php -l admin/contractors/contractor.php`

------
https://chatgpt.com/codex/tasks/task_e_68a660811a608333b26c9dd9c8540f54