### PR TITLE
Ensure reactivation forms capture latest user fields

### DIFF
--- a/admin/users/edit.php
+++ b/admin/users/edit.php
@@ -220,12 +220,9 @@ $_SESSION['csrf_token'] = $token;
 
 document.querySelectorAll('.reactivate-form').forEach(form => {
   form.addEventListener('submit', () => {
-    ['gender_id', 'phone', 'dob', 'address'].forEach(id => {
-      const hidden = form.querySelector(`[name="${id}"]`);
-      const source = document.getElementById(id);
-      if (hidden && source) {
-        hidden.value = source.value;
-      }
+    ['gender_id','phone','dob','address'].forEach(id => {
+      form.querySelector(`[name="${id}"]`).value =
+        document.getElementById(id).value;
     });
   });
 });


### PR DESCRIPTION
## Summary
- Sync gender, phone, DOB, and address fields into picture reactivation forms on submit to keep user data current

## Testing
- `php -l admin/users/edit.php`


------
https://chatgpt.com/codex/tasks/task_e_68a68c1007fc833390a098d358108831