### PR TITLE
Add organization and contact management for people

### DIFF
--- a/_SQL/atlis.sql
+++ b/_SQL/atlis.sql
@@ -1913,30 +1913,94 @@ CREATE TABLE `person` (
   `last_name` varchar(100) DEFAULT NULL,
   `email` varchar(255) DEFAULT NULL,
   `gender_id` int(11) DEFAULT NULL,
-  `phone` varchar(25) DEFAULT NULL,
+  `organization_id` int(11) DEFAULT NULL,
+  `agency_id` int(11) DEFAULT NULL,
+  `division_id` int(11) DEFAULT NULL,
   `dob` date DEFAULT NULL,
-  `address` text DEFAULT NULL,
   `user_updated` int(11) DEFAULT NULL,
   `date_created` datetime DEFAULT current_timestamp(),
   `date_updated` datetime DEFAULT current_timestamp() ON UPDATE current_timestamp(),
   `memo` text DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
+
+INSERT INTO `person` (`id`, `user_id`, `first_name`, `last_name`, `email`, `gender_id`, `organization_id`, `agency_id`, `division_id`, `dob`, `user_updated`, `date_created`, `date_updated`, `memo`) VALUES
+(1, 1, 'Dave', 'Wilkins', NULL, 59, NULL, NULL, NULL, '1992-02-20', 1, '2025-08-08 21:52:52', '2025-08-19 23:03:53', NULL),
+(2, 2, 'Sean', 'Cadina', NULL, 59, NULL, NULL, NULL, NULL, 1, '2025-08-15 00:11:11', '2025-08-19 23:23:09', NULL),
+(5, 4, 'Tyler', 'Jessop', NULL, 59, NULL, NULL, NULL, NULL, 1, '2025-08-17 22:17:49', '2025-08-19 23:23:32', NULL),
+(12, 5, 'RJ', 'Calara', NULL, 59, NULL, NULL, NULL, NULL, 1, '2025-08-19 23:21:53', '2025-08-19 23:21:53', NULL),
+(13, 6, 'Kasper', 'Krynski', NULL, 59, NULL, NULL, NULL, NULL, 1, '2025-08-19 23:22:44', '2025-08-19 23:22:44', NULL),
+(14, 7, 'Mileny', 'Valdez', NULL, 60, NULL, NULL, NULL, NULL, 1, '2025-08-19 23:27:09', '2025-08-19 23:27:09', NULL),
+(23, 8, 'Kenny', 'Reynolds', NULL, 59, NULL, NULL, NULL, NULL, 1, '2025-08-20 14:44:46', '2025-08-20 14:44:46', NULL),
+(24, 9, 'Richard', 'Sprague', NULL, 59, NULL, NULL, NULL, NULL, 1, '2025-08-20 15:14:36', '2025-08-20 15:14:36', NULL),
+(27, 10, 'Emma', 'Baylor', NULL, 60, NULL, NULL, NULL, NULL, 1, '2025-08-20 20:47:24', '2025-08-20 20:47:24', NULL),
+(30, NULL, 'Keith', 'Grant', 'KGrant@lakecountyil.gov', 59, NULL, NULL, NULL, NULL, 1, '2025-08-20 21:03:51', '2025-08-20 21:03:51', NULL);
+
+-- --------------------------------------------------------
+
 --
--- Dumping data for table `person`
+-- Table structure for table `person_addresses`
 --
 
-INSERT INTO `person` (`id`, `user_id`, `first_name`, `last_name`, `email`, `gender_id`, `phone`, `dob`, `address`, `user_updated`, `date_created`, `date_updated`, `memo`) VALUES
-(1, 1, 'Dave', 'Wilkins', NULL, 59, '4357645615', '1992-02-20', '3124 S 340 W Nibley, UT 84321', 1, '2025-08-08 21:52:52', '2025-08-19 23:03:53', NULL),
-(2, 2, 'Sean', 'Cadina', NULL, 59, '', NULL, '', 1, '2025-08-15 00:11:11', '2025-08-19 23:23:09', NULL),
-(5, 4, 'Tyler', 'Jessop', NULL, 59, '', NULL, '', 1, '2025-08-17 22:17:49', '2025-08-19 23:23:32', NULL),
-(12, 5, 'RJ', 'Calara', NULL, 59, '', NULL, '', 1, '2025-08-19 23:21:53', '2025-08-19 23:21:53', NULL),
-(13, 6, 'Kasper', 'Krynski', NULL, 59, '', NULL, '', 1, '2025-08-19 23:22:44', '2025-08-19 23:22:44', NULL),
-(14, 7, 'Mileny', 'Valdez', NULL, 60, '', NULL, '', 1, '2025-08-19 23:27:09', '2025-08-19 23:27:09', NULL),
-(23, 8, 'Kenny', 'Reynolds', NULL, 59, '4357601327', NULL, 'kennydrenolds@gmail.com', 1, '2025-08-20 14:44:46', '2025-08-20 14:44:46', NULL),
-(24, 9, 'Richard', 'Sprague', NULL, 59, '4358902363', NULL, '', 1, '2025-08-20 15:14:36', '2025-08-20 15:14:36', NULL),
-(27, 10, 'Emma', 'Baylor', NULL, 60, '4436179726', NULL, '', 1, '2025-08-20 20:47:24', '2025-08-20 20:47:24', NULL),
-(30, NULL, 'Keith', 'Grant', 'KGrant@lakecountyil.gov', 59, '', NULL, '', 1, '2025-08-20 21:03:51', '2025-08-20 21:03:51', NULL);
+CREATE TABLE `person_addresses` (
+  `id` int(11) NOT NULL,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT current_timestamp(),
+  `date_updated` datetime DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  `memo` text DEFAULT NULL,
+  `person_id` int(11) NOT NULL,
+  `type_id` int(11) DEFAULT NULL,
+  `status_id` int(11) DEFAULT NULL,
+  `start_date` date DEFAULT NULL,
+  `end_date` date DEFAULT NULL,
+  `address_line1` varchar(255) DEFAULT NULL,
+  `address_line2` varchar(255) DEFAULT NULL,
+  `city` varchar(100) DEFAULT NULL,
+  `state` varchar(100) DEFAULT NULL,
+  `postal_code` varchar(20) DEFAULT NULL,
+  `country` varchar(100) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+--
+-- Dumping data for table `person_addresses`
+--
+
+INSERT INTO `person_addresses` (`id`, `user_id`, `user_updated`, `date_created`, `date_updated`, `memo`, `person_id`, `type_id`, `status_id`, `start_date`, `end_date`, `address_line1`, `address_line2`, `city`, `state`, `postal_code`, `country`) VALUES
+(1, 1, 1, '2025-08-08 21:52:52', '2025-08-08 21:52:52', NULL, 1, 111, 108, '2025-08-08', NULL, '3124 S 340 W Nibley, UT 84321', NULL, NULL, NULL, NULL, NULL),
+(2, 1, 1, '2025-08-20 14:44:46', '2025-08-20 14:44:46', NULL, 23, 111, 108, '2025-08-20', NULL, 'kennydrenolds@gmail.com', NULL, NULL, NULL, NULL, NULL);
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `person_phones`
+--
+
+CREATE TABLE `person_phones` (
+  `id` int(11) NOT NULL,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT current_timestamp(),
+  `date_updated` datetime DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  `memo` text DEFAULT NULL,
+  `person_id` int(11) NOT NULL,
+  `type_id` int(11) DEFAULT NULL,
+  `status_id` int(11) DEFAULT NULL,
+  `start_date` date DEFAULT NULL,
+  `end_date` date DEFAULT NULL,
+  `phone_number` varchar(25) DEFAULT NULL,
+  `extension` varchar(10) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+--
+-- Dumping data for table `person_phones`
+--
+
+INSERT INTO `person_phones` (`id`, `user_id`, `user_updated`, `date_created`, `date_updated`, `memo`, `person_id`, `type_id`, `status_id`, `start_date`, `end_date`, `phone_number`, `extension`) VALUES
+(1, 1, 1, '2025-08-08 21:52:52', '2025-08-08 21:52:52', NULL, 1, 115, 105, '2025-08-08', NULL, '4357645615', NULL),
+(2, 1, 1, '2025-08-20 14:44:46', '2025-08-20 14:44:46', NULL, 23, 115, 105, '2025-08-20', NULL, '4357601327', NULL),
+(3, 1, 1, '2025-08-20 15:14:36', '2025-08-20 15:14:36', NULL, 24, 115, 105, '2025-08-20', NULL, '4358902363', NULL),
+(4, 1, 1, '2025-08-20 20:47:24', '2025-08-20 20:47:24', NULL, 27, 115, 105, '2025-08-20', NULL, '4436179726', NULL);
 
 -- --------------------------------------------------------
 
@@ -2417,13 +2481,38 @@ ALTER TABLE `module_task_assignments`
   ADD KEY `fk_module_task_assignments_assigned_user_id` (`assigned_user_id`);
 
 --
+-- Indexes for table `person_addresses`
+--
+ALTER TABLE `person_addresses`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `fk_person_addresses_user_id` (`user_id`),
+  ADD KEY `fk_person_addresses_user_updated` (`user_updated`),
+  ADD KEY `fk_person_addresses_person_id` (`person_id`),
+  ADD KEY `fk_person_addresses_type_id` (`type_id`),
+  ADD KEY `fk_person_addresses_status_id` (`status_id`);
+
+--
+-- Indexes for table `person_phones`
+--
+ALTER TABLE `person_phones`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `fk_person_phones_user_id` (`user_id`),
+  ADD KEY `fk_person_phones_user_updated` (`user_updated`),
+  ADD KEY `fk_person_phones_person_id` (`person_id`),
+  ADD KEY `fk_person_phones_type_id` (`type_id`),
+  ADD KEY `fk_person_phones_status_id` (`status_id`);
+
+--
 -- Indexes for table `person`
 --
 ALTER TABLE `person`
   ADD PRIMARY KEY (`id`),
   ADD UNIQUE KEY `fk_person_user_id` (`user_id`),
   ADD KEY `fk_person_user_updated` (`user_updated`),
-  ADD KEY `fk_person_gender_id` (`gender_id`);
+  ADD KEY `fk_person_gender_id` (`gender_id`),
+  ADD KEY `fk_person_organization_id` (`organization_id`),
+  ADD KEY `fk_person_agency_id` (`agency_id`),
+  ADD KEY `fk_person_division_id` (`division_id`);
 
 --
 -- Indexes for table `system_properties`
@@ -2675,6 +2764,18 @@ ALTER TABLE `module_tasks_notes`
 --
 ALTER TABLE `module_task_assignments`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=4;
+
+--
+-- AUTO_INCREMENT for table `person_addresses`
+--
+ALTER TABLE `person_addresses`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=3;
+
+--
+-- AUTO_INCREMENT for table `person_phones`
+--
+ALTER TABLE `person_phones`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=5;
 
 --
 -- AUTO_INCREMENT for table `person`
@@ -2940,12 +3041,35 @@ ALTER TABLE `module_task_assignments`
   ADD CONSTRAINT `fk_module_task_assignments_task_id` FOREIGN KEY (`task_id`) REFERENCES `module_tasks` (`id`);
 
 --
+-- Constraints for table `person_addresses`
+--
+ALTER TABLE `person_addresses`
+  ADD CONSTRAINT `fk_person_addresses_person_id` FOREIGN KEY (`person_id`) REFERENCES `person` (`id`) ON DELETE CASCADE,
+  ADD CONSTRAINT `fk_person_addresses_type_id` FOREIGN KEY (`type_id`) REFERENCES `lookup_list_items` (`id`),
+  ADD CONSTRAINT `fk_person_addresses_status_id` FOREIGN KEY (`status_id`) REFERENCES `lookup_list_items` (`id`),
+  ADD CONSTRAINT `fk_person_addresses_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  ADD CONSTRAINT `fk_person_addresses_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`) ON DELETE SET NULL;
+
+--
+-- Constraints for table `person_phones`
+--
+ALTER TABLE `person_phones`
+  ADD CONSTRAINT `fk_person_phones_person_id` FOREIGN KEY (`person_id`) REFERENCES `person` (`id`) ON DELETE CASCADE,
+  ADD CONSTRAINT `fk_person_phones_type_id` FOREIGN KEY (`type_id`) REFERENCES `lookup_list_items` (`id`),
+  ADD CONSTRAINT `fk_person_phones_status_id` FOREIGN KEY (`status_id`) REFERENCES `lookup_list_items` (`id`),
+  ADD CONSTRAINT `fk_person_phones_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  ADD CONSTRAINT `fk_person_phones_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`) ON DELETE SET NULL;
+
+--
 -- Constraints for table `person`
 --
 ALTER TABLE `person`
   ADD CONSTRAINT `fk_person_gender_id` FOREIGN KEY (`gender_id`) REFERENCES `lookup_list_items` (`id`),
   ADD CONSTRAINT `fk_person_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
-  ADD CONSTRAINT `fk_person_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`) ON DELETE SET NULL;
+  ADD CONSTRAINT `fk_person_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  ADD CONSTRAINT `fk_person_organization_id` FOREIGN KEY (`organization_id`) REFERENCES `module_organization` (`id`) ON DELETE SET NULL,
+  ADD CONSTRAINT `fk_person_agency_id` FOREIGN KEY (`agency_id`) REFERENCES `module_agency` (`id`) ON DELETE SET NULL,
+  ADD CONSTRAINT `fk_person_division_id` FOREIGN KEY (`division_id`) REFERENCES `module_division` (`id`) ON DELETE SET NULL;
 
 --
 -- Constraints for table `users`

--- a/admin/person/_address_row.php
+++ b/admin/person/_address_row.php
@@ -1,0 +1,69 @@
+<?php
+$addrRow = $addrRow ?? [];
+$index = $index ?? 0;
+$selType = $addrRow['type_id'] ?? $defaultAddressTypeId;
+$selStatus = $addrRow['status_id'] ?? $defaultAddressStatusId;
+$typeColor = 'secondary';
+foreach ($addressTypeItems as $it) { if ($it['id']==$selType) { $typeColor=$it['color_class']; break; } }
+$statusColor = 'secondary';
+foreach ($addressStatusItems as $it) { if ($it['id']==$selStatus) { $statusColor=$it['color_class']; break; } }
+?>
+<div class="address-item border p-2 mb-2">
+  <input type="hidden" name="addresses[<?= $index; ?>][id]" value="<?= h($addrRow['id'] ?? ''); ?>">
+  <div class="row g-2">
+    <div class="col-md-2">
+      <label class="form-label mb-0">Type</label>
+      <select name="addresses[<?= $index; ?>][type_id]" class="form-select form-select-sm address-type">
+        <?php foreach($addressTypeItems as $pt): $selected = ($selType == $pt['id']) ? 'selected' : ''; ?>
+          <option value="<?= h($pt['id']); ?>" data-color="<?= h($pt['color_class']); ?>" <?= $selected; ?>><?= h($pt['label']); ?></option>
+        <?php endforeach; ?>
+      </select>
+      <span class="badge badge-phoenix fs-10 ms-1 lookup-badge badge-phoenix-<?= h($typeColor); ?>"></span>
+    </div>
+    <div class="col-md-2">
+      <label class="form-label mb-0">Status</label>
+      <select name="addresses[<?= $index; ?>][status_id]" class="form-select form-select-sm address-status">
+        <?php foreach($addressStatusItems as $ps): $selected = ($selStatus == $ps['id']) ? 'selected' : ''; ?>
+          <option value="<?= h($ps['id']); ?>" data-color="<?= h($ps['color_class']); ?>" <?= $selected; ?>><?= h($ps['label']); ?></option>
+        <?php endforeach; ?>
+      </select>
+      <span class="badge badge-phoenix fs-10 ms-1 lookup-badge badge-phoenix-<?= h($statusColor); ?>"></span>
+    </div>
+    <div class="col-md-4">
+      <label class="form-label mb-0">Line 1</label>
+      <input type="text" name="addresses[<?= $index; ?>][address_line1]" class="form-control form-control-sm" value="<?= h($addrRow['address_line1'] ?? ''); ?>">
+    </div>
+    <div class="col-md-3">
+      <label class="form-label mb-0">City</label>
+      <input type="text" name="addresses[<?= $index; ?>][city]" class="form-control form-control-sm" value="<?= h($addrRow['city'] ?? ''); ?>">
+    </div>
+    <div class="col-md-1 d-flex align-items-end">
+      <button type="button" class="btn btn-danger btn-sm remove-address">X</button>
+    </div>
+    <div class="col-md-4 mt-2">
+      <label class="form-label mb-0">Line 2</label>
+      <input type="text" name="addresses[<?= $index; ?>][address_line2]" class="form-control form-control-sm" value="<?= h($addrRow['address_line2'] ?? ''); ?>">
+    </div>
+    <div class="col-md-2 mt-2">
+      <label class="form-label mb-0">State</label>
+      <input type="text" name="addresses[<?= $index; ?>][state]" class="form-control form-control-sm" value="<?= h($addrRow['state'] ?? ''); ?>">
+    </div>
+    <div class="col-md-2 mt-2">
+      <label class="form-label mb-0">Postal</label>
+      <input type="text" name="addresses[<?= $index; ?>][postal_code]" class="form-control form-control-sm" value="<?= h($addrRow['postal_code'] ?? ''); ?>">
+    </div>
+    <div class="col-md-2 mt-2">
+      <label class="form-label mb-0">Country</label>
+      <input type="text" name="addresses[<?= $index; ?>][country]" class="form-control form-control-sm" value="<?= h($addrRow['country'] ?? ''); ?>">
+    </div>
+    <div class="col-md-2 mt-2">
+      <label class="form-label mb-0">Start</label>
+      <input type="date" name="addresses[<?= $index; ?>][start_date]" class="form-control form-control-sm" value="<?= h($addrRow['start_date'] ?? ''); ?>">
+    </div>
+    <div class="col-md-2 mt-2">
+      <label class="form-label mb-0">End</label>
+      <input type="date" name="addresses[<?= $index; ?>][end_date]" class="form-control form-control-sm" value="<?= h($addrRow['end_date'] ?? ''); ?>">
+    </div>
+  </div>
+</div>
+

--- a/admin/person/_phone_row.php
+++ b/admin/person/_phone_row.php
@@ -1,0 +1,53 @@
+<?php
+$phRow = $phRow ?? [];
+$index = $index ?? 0;
+$selType = $phRow['type_id'] ?? $defaultPhoneTypeId;
+$selStatus = $phRow['status_id'] ?? $defaultPhoneStatusId;
+$typeColor = 'secondary';
+foreach ($phoneTypeItems as $it) { if ($it['id']==$selType) { $typeColor=$it['color_class']; break; } }
+$statusColor = 'secondary';
+foreach ($phoneStatusItems as $it) { if ($it['id']==$selStatus) { $statusColor=$it['color_class']; break; } }
+?>
+<div class="phone-item border p-2 mb-2">
+  <input type="hidden" name="phones[<?= $index; ?>][id]" value="<?= h($phRow['id'] ?? ''); ?>">
+  <div class="row g-2 align-items-end">
+    <div class="col-md-2">
+      <label class="form-label mb-0">Type</label>
+      <select name="phones[<?= $index; ?>][type_id]" class="form-select form-select-sm phone-type">
+        <?php foreach($phoneTypeItems as $pt): $selected = ($selType == $pt['id']) ? 'selected' : ''; ?>
+          <option value="<?= h($pt['id']); ?>" data-color="<?= h($pt['color_class']); ?>" <?= $selected; ?>><?= h($pt['label']); ?></option>
+        <?php endforeach; ?>
+      </select>
+      <span class="badge badge-phoenix fs-10 ms-1 lookup-badge badge-phoenix-<?= h($typeColor); ?>"></span>
+    </div>
+    <div class="col-md-2">
+      <label class="form-label mb-0">Status</label>
+      <select name="phones[<?= $index; ?>][status_id]" class="form-select form-select-sm phone-status">
+        <?php foreach($phoneStatusItems as $ps): $selected = ($selStatus == $ps['id']) ? 'selected' : ''; ?>
+          <option value="<?= h($ps['id']); ?>" data-color="<?= h($ps['color_class']); ?>" <?= $selected; ?>><?= h($ps['label']); ?></option>
+        <?php endforeach; ?>
+      </select>
+      <span class="badge badge-phoenix fs-10 ms-1 lookup-badge badge-phoenix-<?= h($statusColor); ?>"></span>
+    </div>
+    <div class="col-md-3">
+      <label class="form-label mb-0">Number</label>
+      <input type="text" name="phones[<?= $index; ?>][phone_number]" class="form-control form-control-sm" value="<?= h($phRow['phone_number'] ?? ''); ?>">
+    </div>
+    <div class="col-md-1">
+      <label class="form-label mb-0">Ext</label>
+      <input type="text" name="phones[<?= $index; ?>][extension]" class="form-control form-control-sm" value="<?= h($phRow['extension'] ?? ''); ?>">
+    </div>
+    <div class="col-md-2">
+      <label class="form-label mb-0">Start</label>
+      <input type="date" name="phones[<?= $index; ?>][start_date]" class="form-control form-control-sm" value="<?= h($phRow['start_date'] ?? ''); ?>">
+    </div>
+    <div class="col-md-2">
+      <label class="form-label mb-0">End</label>
+      <input type="date" name="phones[<?= $index; ?>][end_date]" class="form-control form-control-sm" value="<?= h($phRow['end_date'] ?? ''); ?>">
+    </div>
+    <div class="col-md-2 d-flex justify-content-end">
+      <button type="button" class="btn btn-danger btn-sm remove-phone">X</button>
+    </div>
+  </div>
+</div>
+

--- a/admin/person/edit.php
+++ b/admin/person/edit.php
@@ -2,15 +2,17 @@
 require '../admin_header.php';
 
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
-$first_name = $last_name = $email = $phone = $dob = $address = '';
-$gender_id = null;
+$first_name = $last_name = $email = $dob = '';
+$gender_id = $organization_id = $agency_id = $division_id = null;
 $existing = null;
+$addresses = [];
+$phones = [];
 $btnClass = $id ? 'btn-warning' : 'btn-success';
 
 if ($id) {
   require_permission('person','update');
   $stmt = $pdo->prepare('SELECT * FROM person WHERE id = :id');
-  $stmt->execute([':id' => $id]);
+  $stmt->execute([':id'=>$id]);
   if ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
     if ($row['user_id']) {
       header('Location: ../users/edit.php?id=' . $row['user_id']);
@@ -18,12 +20,21 @@ if ($id) {
     }
     $existing = $row;
     $first_name = $row['first_name'] ?? '';
-    $last_name = $row['last_name'] ?? '';
-    $email = $row['email'] ?? '';
-    $phone = $row['phone'] ?? '';
-    $gender_id = $row['gender_id'] ?? null;
-    $dob = $row['dob'] ?? '';
-    $address = $row['address'] ?? '';
+    $last_name  = $row['last_name'] ?? '';
+    $email      = $row['email'] ?? '';
+    $gender_id  = $row['gender_id'] ?? null;
+    $dob        = $row['dob'] ?? '';
+    $organization_id = $row['organization_id'] ?? null;
+    $agency_id       = $row['agency_id'] ?? null;
+    $division_id     = $row['division_id'] ?? null;
+
+    $stmt = $pdo->prepare('SELECT * FROM person_addresses WHERE person_id = :id');
+    $stmt->execute([':id'=>$id]);
+    $addresses = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    $stmt = $pdo->prepare('SELECT * FROM person_phones WHERE person_id = :id');
+    $stmt->execute([':id'=>$id]);
+    $phones = $stmt->fetchAll(PDO::FETCH_ASSOC);
   }
 } else {
   require_permission('person','create');
@@ -32,31 +43,139 @@ if ($id) {
 $token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
 $_SESSION['csrf_token'] = $token;
 
-$genderItems = get_lookup_items($pdo, 'USER_GENDER');
+$genderItems        = get_lookup_items($pdo, 'USER_GENDER');
+$orgItems           = $pdo->query('SELECT id, name FROM module_organization ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
+$agencyItems        = $pdo->query('SELECT id, name FROM module_agency ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
+$divisionItems      = $pdo->query('SELECT id, name FROM module_division ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
+$addressTypeItems   = get_lookup_items($pdo, 'PERSON_ADDRESS_TYPE');
+$addressStatusItems = get_lookup_items($pdo, 'PERSON_ADDRESS_STATUS');
+$phoneTypeItems     = get_lookup_items($pdo, 'PERSON_PHONE_TYPE');
+$phoneStatusItems   = get_lookup_items($pdo, 'PERSON_PHONE_STATUS');
+
+function get_default_id(array $items) {
+  foreach ($items as $i) { if (!empty($i['is_default'])) return $i['id']; }
+  return null;
+}
+$defaultAddressTypeId   = get_default_id($addressTypeItems);
+$defaultAddressStatusId = get_default_id($addressStatusItems);
+$defaultPhoneTypeId     = get_default_id($phoneTypeItems);
+$defaultPhoneStatusId   = get_default_id($phoneStatusItems);
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   if (!hash_equals($token, $_POST['csrf_token'] ?? '')) {
     die('Invalid CSRF token');
   }
   $first_name = trim($_POST['first_name'] ?? '');
-  $last_name = trim($_POST['last_name'] ?? '');
-  $email = trim($_POST['email'] ?? '');
-  $phone = trim($_POST['phone'] ?? '');
-  $gender_id = $_POST['gender_id'] !== '' ? (int)$_POST['gender_id'] : null;
-  $dob = $_POST['dob'] !== '' ? $_POST['dob'] : null;
-  $address = trim($_POST['address'] ?? '');
-  if ($id) {
-    $stmt = $pdo->prepare('UPDATE person SET first_name=:first_name, last_name=:last_name, email=:email, phone=:phone, gender_id=:gender_id, dob=:dob, address=:address, user_updated=:uid WHERE id=:id');
-    $stmt->execute([':first_name'=>$first_name, ':last_name'=>$last_name, ':email'=>$email, ':phone'=>$phone, ':gender_id'=>$gender_id, ':dob'=>$dob, ':address'=>$address, ':uid'=>$this_user_id, ':id'=>$id]);
-    admin_audit_log($pdo, $this_user_id, 'person', $id, 'UPDATE', json_encode($existing), json_encode(['first_name'=>$first_name,'last_name'=>$last_name,'email'=>$email,'phone'=>$phone,'gender_id'=>$gender_id,'dob'=>$dob,'address'=>$address]), 'Updated person');
-  } else {
-    $stmt = $pdo->prepare('INSERT INTO person (first_name, last_name, email, phone, gender_id, dob, address, user_updated) VALUES (:first_name, :last_name, :email, :phone, :gender_id, :dob, :address, :uid)');
-    $stmt->execute([':first_name'=>$first_name, ':last_name'=>$last_name, ':email'=>$email, ':phone'=>$phone, ':gender_id'=>$gender_id, ':dob'=>$dob, ':address'=>$address, ':uid'=>$this_user_id]);
-    $id = $pdo->lastInsertId();
-    admin_audit_log($pdo, $this_user_id, 'person', $id, 'CREATE', null, json_encode(['first_name'=>$first_name,'last_name'=>$last_name,'email'=>$email,'phone'=>$phone,'gender_id'=>$gender_id,'dob'=>$dob,'address'=>$address]), 'Created person');
+  $last_name  = trim($_POST['last_name'] ?? '');
+  $email      = trim($_POST['email'] ?? '');
+  $gender_id  = $_POST['gender_id'] !== '' ? (int)$_POST['gender_id'] : null;
+  $dob        = $_POST['dob'] !== '' ? $_POST['dob'] : null;
+  $organization_id = $_POST['organization_id'] !== '' ? (int)$_POST['organization_id'] : null;
+  $agency_id       = $_POST['agency_id'] !== '' ? (int)$_POST['agency_id'] : null;
+  $division_id     = $_POST['division_id'] !== '' ? (int)$_POST['division_id'] : null;
+  $addresses = $_POST['addresses'] ?? [];
+  $phones    = $_POST['phones'] ?? [];
+
+  $pdo->beginTransaction();
+  try {
+    if ($id) {
+      $stmt = $pdo->prepare('UPDATE person SET first_name=:first_name,last_name=:last_name,email=:email,gender_id=:gender_id,organization_id=:organization_id,agency_id=:agency_id,division_id=:division_id,dob=:dob,user_updated=:uid WHERE id=:id');
+      $stmt->execute([':first_name'=>$first_name,':last_name'=>$last_name,':email'=>$email,':gender_id'=>$gender_id,':organization_id'=>$organization_id,':agency_id'=>$agency_id,':division_id'=>$division_id,':dob'=>$dob,':uid'=>$this_user_id,':id'=>$id]);
+      admin_audit_log($pdo,$this_user_id,'person',$id,'UPDATE',json_encode($existing),json_encode(['first_name'=>$first_name,'last_name'=>$last_name,'email'=>$email,'gender_id'=>$gender_id,'organization_id'=>$organization_id,'agency_id'=>$agency_id,'division_id'=>$division_id,'dob'=>$dob]),'Updated person');
+    } else {
+      $stmt = $pdo->prepare('INSERT INTO person (first_name,last_name,email,gender_id,organization_id,agency_id,division_id,dob,user_updated) VALUES (:first_name,:last_name,:email,:gender_id,:organization_id,:agency_id,:division_id,:dob,:uid)');
+      $stmt->execute([':first_name'=>$first_name,':last_name'=>$last_name,':email'=>$email,':gender_id'=>$gender_id,':organization_id'=>$organization_id,':agency_id'=>$agency_id,':division_id'=>$division_id,':dob'=>$dob,':uid'=>$this_user_id]);
+      $id = $pdo->lastInsertId();
+      admin_audit_log($pdo,$this_user_id,'person',$id,'CREATE',null,json_encode(['first_name'=>$first_name,'last_name'=>$last_name,'email'=>$email,'gender_id'=>$gender_id,'organization_id'=>$organization_id,'agency_id'=>$agency_id,'division_id'=>$division_id,'dob'=>$dob]),'Created person');
+    }
+
+    $stmt = $pdo->prepare('SELECT id FROM person_addresses WHERE person_id = :id');
+    $stmt->execute([':id'=>$id]);
+    $existingAddrIds = $stmt->fetchAll(PDO::FETCH_COLUMN);
+    $submittedAddrIds = [];
+    foreach ($addresses as $addr) {
+      $addrId = !empty($addr['id']) ? (int)$addr['id'] : 0;
+      $data = [
+        ':pid'=>$id,
+        ':type_id'=>$addr['type_id'] !== '' ? (int)$addr['type_id'] : null,
+        ':status_id'=>$addr['status_id'] !== '' ? (int)$addr['status_id'] : null,
+        ':start_date'=>$addr['start_date'] !== '' ? $addr['start_date'] : null,
+        ':end_date'=>$addr['end_date'] !== '' ? $addr['end_date'] : null,
+        ':line1'=>trim($addr['address_line1'] ?? ''),
+        ':line2'=>trim($addr['address_line2'] ?? ''),
+        ':city'=>trim($addr['city'] ?? ''),
+        ':state'=>trim($addr['state'] ?? ''),
+        ':postal'=>trim($addr['postal_code'] ?? ''),
+        ':country'=>trim($addr['country'] ?? ''),
+        ':uid'=>$this_user_id
+      ];
+      if ($addrId) {
+        $data[':id']=$addrId;
+        $stmt = $pdo->prepare('UPDATE person_addresses SET type_id=:type_id,status_id=:status_id,start_date=:start_date,end_date=:end_date,address_line1=:line1,address_line2=:line2,city=:city,state=:state,postal_code=:postal,country=:country,user_updated=:uid WHERE id=:id AND person_id=:pid');
+        $stmt->execute($data);
+        admin_audit_log($pdo,$this_user_id,'person_addresses',$addrId,'UPDATE',null,json_encode($data),'Updated address');
+        $submittedAddrIds[] = $addrId;
+      } else {
+        $stmt = $pdo->prepare('INSERT INTO person_addresses (person_id,type_id,status_id,start_date,end_date,address_line1,address_line2,city,state,postal_code,country,user_updated) VALUES (:pid,:type_id,:status_id,:start_date,:end_date,:line1,:line2,:city,:state,:postal,:country,:uid)');
+        $stmt->execute($data);
+        $newId = $pdo->lastInsertId();
+        admin_audit_log($pdo,$this_user_id,'person_addresses',$newId,'CREATE',null,json_encode($data),'Added address');
+        $submittedAddrIds[] = $newId;
+      }
+    }
+    foreach ($existingAddrIds as $eid) {
+      if (!in_array($eid,$submittedAddrIds)) {
+        $stmt = $pdo->prepare('DELETE FROM person_addresses WHERE id=:id');
+        $stmt->execute([':id'=>$eid]);
+        admin_audit_log($pdo,$this_user_id,'person_addresses',$eid,'DELETE',null,null,'Deleted address');
+      }
+    }
+
+    $stmt = $pdo->prepare('SELECT id FROM person_phones WHERE person_id = :id');
+    $stmt->execute([':id'=>$id]);
+    $existingPhoneIds = $stmt->fetchAll(PDO::FETCH_COLUMN);
+    $submittedPhoneIds = [];
+    foreach ($phones as $ph) {
+      $phId = !empty($ph['id']) ? (int)$ph['id'] : 0;
+      $data = [
+        ':pid'=>$id,
+        ':type_id'=>$ph['type_id'] !== '' ? (int)$ph['type_id'] : null,
+        ':status_id'=>$ph['status_id'] !== '' ? (int)$ph['status_id'] : null,
+        ':start_date'=>$ph['start_date'] !== '' ? $ph['start_date'] : null,
+        ':end_date'=>$ph['end_date'] !== '' ? $ph['end_date'] : null,
+        ':number'=>trim($ph['phone_number'] ?? ''),
+        ':ext'=>trim($ph['extension'] ?? ''),
+        ':uid'=>$this_user_id
+      ];
+      if ($phId) {
+        $data[':id']=$phId;
+        $stmt = $pdo->prepare('UPDATE person_phones SET type_id=:type_id,status_id=:status_id,start_date=:start_date,end_date=:end_date,phone_number=:number,extension=:ext,user_updated=:uid WHERE id=:id AND person_id=:pid');
+        $stmt->execute($data);
+        admin_audit_log($pdo,$this_user_id,'person_phones',$phId,'UPDATE',null,json_encode($data),'Updated phone');
+        $submittedPhoneIds[] = $phId;
+      } else {
+        $stmt = $pdo->prepare('INSERT INTO person_phones (person_id,type_id,status_id,start_date,end_date,phone_number,extension,user_updated) VALUES (:pid,:type_id,:status_id,:start_date,:end_date,:number,:ext,:uid)');
+        $stmt->execute($data);
+        $newId = $pdo->lastInsertId();
+        admin_audit_log($pdo,$this_user_id,'person_phones',$newId,'CREATE',null,json_encode($data),'Added phone');
+        $submittedPhoneIds[] = $newId;
+      }
+    }
+    foreach ($existingPhoneIds as $eid) {
+      if (!in_array($eid,$submittedPhoneIds)) {
+        $stmt = $pdo->prepare('DELETE FROM person_phones WHERE id=:id');
+        $stmt->execute([':id'=>$eid]);
+        admin_audit_log($pdo,$this_user_id,'person_phones',$eid,'DELETE',null,null,'Deleted phone');
+      }
+    }
+
+    $pdo->commit();
+    header('Location: index.php');
+    exit;
+  } catch (Exception $e) {
+    $pdo->rollBack();
+    throw $e;
   }
-  header('Location: index.php');
-  exit;
 }
 ?>
 <h2 class="mb-4"><?= $id ? 'Edit' : 'Add'; ?> Person</h2>
@@ -64,38 +183,114 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   <input type="hidden" name="csrf_token" value="<?= $token; ?>">
   <div class="mb-3">
     <label class="form-label">First Name</label>
-    <input type="text" name="first_name" class="form-control" value="<?= htmlspecialchars($first_name); ?>" required>
+    <input type="text" name="first_name" class="form-control" value="<?= h($first_name); ?>" required>
   </div>
   <div class="mb-3">
     <label class="form-label">Last Name</label>
-    <input type="text" name="last_name" class="form-control" value="<?= htmlspecialchars($last_name); ?>" required>
+    <input type="text" name="last_name" class="form-control" value="<?= h($last_name); ?>" required>
   </div>
   <div class="mb-3">
     <label class="form-label">Email</label>
-    <input type="email" name="email" class="form-control" value="<?= htmlspecialchars($email); ?>">
+    <input type="email" name="email" class="form-control" value="<?= h($email); ?>">
   </div>
   <div class="mb-3">
-    <label class="form-label">Phone</label>
-    <input type="text" name="phone" class="form-control" value="<?= htmlspecialchars($phone); ?>">
+    <label class="form-label">Organization</label>
+    <select name="organization_id" class="form-select">
+      <option value="">-- Select --</option>
+      <?php foreach($orgItems as $o): ?>
+        <option value="<?= h($o['id']); ?>" <?= (int)$organization_id === (int)$o['id'] ? 'selected' : ''; ?>><?= h($o['name']); ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Agency</label>
+    <select name="agency_id" class="form-select">
+      <option value="">-- Select --</option>
+      <?php foreach($agencyItems as $o): ?>
+        <option value="<?= h($o['id']); ?>" <?= (int)$agency_id === (int)$o['id'] ? 'selected' : ''; ?>><?= h($o['name']); ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Division</label>
+    <select name="division_id" class="form-select">
+      <option value="">-- Select --</option>
+      <?php foreach($divisionItems as $o): ?>
+        <option value="<?= h($o['id']); ?>" <?= (int)$division_id === (int)$o['id'] ? 'selected' : ''; ?>><?= h($o['name']); ?></option>
+      <?php endforeach; ?>
+    </select>
   </div>
   <div class="mb-3">
     <label class="form-label">Gender</label>
     <select name="gender_id" class="form-select">
       <option value="">-- Select --</option>
       <?php foreach($genderItems as $g): ?>
-        <option value="<?= $g['id']; ?>" <?= (int)$gender_id === (int)$g['id'] ? 'selected' : ''; ?>><?= htmlspecialchars($g['label']); ?></option>
+        <option value="<?= h($g['id']); ?>" <?= (int)$gender_id === (int)$g['id'] ? 'selected' : ''; ?>><?= h($g['label']); ?></option>
       <?php endforeach; ?>
     </select>
   </div>
   <div class="mb-3">
     <label class="form-label">Date of Birth</label>
-    <input type="date" name="dob" class="form-control" value="<?= htmlspecialchars($dob); ?>">
+    <input type="date" name="dob" class="form-control" value="<?= h($dob); ?>">
   </div>
-  <div class="mb-3">
-    <label class="form-label">Address</label>
-    <textarea name="address" class="form-control" rows="3"><?= htmlspecialchars($address); ?></textarea>
+
+  <h5 class="mt-4">Phone Numbers</h5>
+  <div id="phones-container">
+    <?php foreach($phones as $i=>$ph){ $index=$i; $phRow=$ph; include __DIR__.'/_phone_row.php'; } ?>
   </div>
+  <button type="button" class="btn btn-sm btn-secondary mb-3" id="add-phone">Add Phone</button>
+
+  <h5>Addresses</h5>
+  <div id="addresses-container">
+    <?php foreach($addresses as $i=>$addr){ $index=$i; $addrRow=$addr; include __DIR__.'/_address_row.php'; } ?>
+  </div>
+  <button type="button" class="btn btn-sm btn-secondary mb-3" id="add-address">Add Address</button>
+
   <button class="btn <?= $btnClass; ?>" type="submit">Save</button>
   <a href="index.php" class="btn btn-secondary">Cancel</a>
 </form>
+
+<template id="phone-template">
+<?php $index='__INDEX__'; $phRow=[]; include __DIR__.'/_phone_row.php'; ?>
+</template>
+<template id="address-template">
+<?php $index='__INDEX__'; $addrRow=[]; include __DIR__.'/_address_row.php'; ?>
+</template>
+
+<script>
+(function(){
+  function updateBadges(container){
+    container.querySelectorAll('select').forEach(function(sel){
+      var badge = sel.parentElement.querySelector('.lookup-badge');
+      if(badge){
+        var color = sel.options[sel.selectedIndex].dataset.color || 'secondary';
+        badge.className = 'badge badge-phoenix fs-10 ms-1 lookup-badge badge-phoenix-' + color;
+      }
+    });
+  }
+  document.querySelectorAll('.address-item,.phone-item').forEach(updateBadges);
+  document.addEventListener('change', function(e){
+    if(e.target.matches('.address-type, .address-status, .phone-type, .phone-status')){
+      updateBadges(e.target.closest('.address-item, .phone-item'));
+    }
+  });
+  document.getElementById('add-phone').addEventListener('click', function(){
+    var tpl = document.getElementById('phone-template').innerHTML.replace(/__INDEX__/g, document.querySelectorAll('#phones-container .phone-item').length);
+    var div = document.createElement('div'); div.innerHTML = tpl.trim();
+    var item = div.firstElementChild; document.getElementById('phones-container').appendChild(item); updateBadges(item);
+  });
+  document.getElementById('phones-container').addEventListener('click', function(e){
+    if(e.target.classList.contains('remove-phone')){ e.target.closest('.phone-item').remove(); }
+  });
+  document.getElementById('add-address').addEventListener('click', function(){
+    var tpl = document.getElementById('address-template').innerHTML.replace(/__INDEX__/g, document.querySelectorAll('#addresses-container .address-item').length);
+    var div = document.createElement('div'); div.innerHTML = tpl.trim();
+    var item = div.firstElementChild; document.getElementById('addresses-container').appendChild(item); updateBadges(item);
+  });
+  document.getElementById('addresses-container').addEventListener('click', function(e){
+    if(e.target.classList.contains('remove-address')){ e.target.closest('.address-item').remove(); }
+  });
+})();
+</script>
 <?php require '../admin_footer.php'; ?>
+

--- a/admin/users/functions/save.php
+++ b/admin/users/functions/save.php
@@ -16,9 +16,7 @@ if (!hash_equals($_SESSION['csrf_token'] ?? '', $_POST['csrf_token'] ?? '')) {
 $id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
 $reactivatePicId = isset($_POST['reactivate_pic_id']) ? (int)$_POST['reactivate_pic_id'] : 0;
 $gender_id = isset($_POST['gender_id']) && $_POST['gender_id'] !== '' ? (int)$_POST['gender_id'] : null;
-$phone = preg_replace('/[^0-9]/', '', $_POST['phone'] ?? '');
 $dob = $_POST['dob'] ?? '';
-$address = trim($_POST['address'] ?? '');
 
 function get_status_id(PDO $pdo, string $code): int {
   $stmt = $pdo->prepare("SELECT li.id FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'USER_PROFILE_PIC_STATUS' AND li.code = :code LIMIT 1");
@@ -36,15 +34,13 @@ if ($reactivatePicId && $id) {
     $personParams = [
       ':uid_fk' => $id,
       ':gender_id' => $gender_id,
-      ':phone' => $phone,
       ':dob' => $dob ?: null,
-      ':address' => $address,
       ':uid_update' => $this_user_id
     ];
-    $pstmt = $pdo->prepare('UPDATE person SET gender_id = :gender_id, phone = :phone, dob = :dob, address = :address, user_updated = :uid_update WHERE user_id = :uid_fk');
+    $pstmt = $pdo->prepare('UPDATE person SET gender_id = :gender_id, dob = :dob, user_updated = :uid_update WHERE user_id = :uid_fk');
     $pstmt->execute($personParams);
     if ($pstmt->rowCount() === 0) {
-      $pdo->prepare('INSERT INTO person (user_id, gender_id, phone, dob, address, user_updated) VALUES (:uid_fk, :gender_id, :phone, :dob, :address, :uid_update)')
+      $pdo->prepare('INSERT INTO person (user_id, gender_id, dob, user_updated) VALUES (:uid_fk, :gender_id, :dob, :uid_update)')
           ->execute($personParams);
     }
 
@@ -170,16 +166,14 @@ try {
       ':fn' => $first_name,
       ':ln' => $last_name,
       ':gender_id' => $gender_id,
-      ':phone' => $phone,
       ':dob' => $dob ?: null,
-      ':address' => $address,
       ':uid_update' => $this_user_id
     ];
     if ($personExists->fetchColumn()) {
-      $pstmt = $pdo->prepare('UPDATE person SET first_name = :fn, last_name = :ln, gender_id = :gender_id, phone = :phone, dob = :dob, address = :address, user_updated = :uid_update WHERE user_id = :uid_fk');
+      $pstmt = $pdo->prepare('UPDATE person SET first_name = :fn, last_name = :ln, gender_id = :gender_id, dob = :dob, user_updated = :uid_update WHERE user_id = :uid_fk');
       $pstmt->execute($personParams);
     } else {
-      $pstmt = $pdo->prepare('INSERT INTO person (user_id, first_name, last_name, gender_id, phone, dob, address, user_updated) VALUES (:uid_fk, :fn, :ln, :gender_id, :phone, :dob, :address, :uid_update)');
+      $pstmt = $pdo->prepare('INSERT INTO person (user_id, first_name, last_name, gender_id, dob, user_updated) VALUES (:uid_fk, :fn, :ln, :gender_id, :dob, :uid_update)');
       $pstmt->execute($personParams);
     }
   } else {
@@ -192,15 +186,13 @@ try {
     ]);
     $id = (int)$pdo->lastInsertId();
 
-    $pstmt = $pdo->prepare('INSERT INTO person (user_id, first_name, last_name, gender_id, phone, dob, address, user_updated) VALUES (:uid_fk, :fn, :ln, :gender_id, :phone, :dob, :address, :uid_update)');
+    $pstmt = $pdo->prepare('INSERT INTO person (user_id, first_name, last_name, gender_id, dob, user_updated) VALUES (:uid_fk, :fn, :ln, :gender_id, :dob, :uid_update)');
     $pstmt->execute([
       ':uid_fk' => $id,
       ':fn' => $first_name,
       ':ln' => $last_name,
       ':gender_id' => $gender_id,
-      ':phone' => $phone,
       ':dob' => $dob ?: null,
-      ':address' => $address,
       ':uid_update' => $this_user_id
     ]);
   }


### PR DESCRIPTION
## Summary
- Link people to organizations, agencies, and divisions
- Replace single phone/address fields with relational tables and dynamic forms
- Update user save logic to accommodate new person schema

## Testing
- `php -l admin/person/edit.php`
- `php -l admin/person/index.php`
- `php -l admin/person/_phone_row.php`
- `php -l admin/person/_address_row.php`
- `php -l admin/users/functions/save.php`


------
https://chatgpt.com/codex/tasks/task_e_68a6c8c977108333a4616af1282ef5c1