### PR TITLE
Add project file metadata and editing support

### DIFF
--- a/_SQL/atlis.sql
+++ b/_SQL/atlis.sql
@@ -1822,6 +1822,10 @@ CREATE TABLE `module_projects_files` (
   `memo` text DEFAULT NULL,
   `project_id` int(11) NOT NULL,
   `note_id` int(11) DEFAULT NULL,
+  `description` text DEFAULT NULL,
+  `file_type_id` int(11) DEFAULT NULL,
+  `status_id` int(11) DEFAULT NULL,
+  `sort_order` int(11) DEFAULT 0,
   `file_name` varchar(255) DEFAULT NULL,
   `file_path` varchar(255) DEFAULT NULL,
   `file_size` int(11) DEFAULT NULL,
@@ -1832,12 +1836,12 @@ CREATE TABLE `module_projects_files` (
 -- Dumping data for table `module_projects_files`
 --
 
-INSERT INTO `module_projects_files` (`id`, `user_id`, `user_updated`, `date_created`, `date_updated`, `memo`, `project_id`, `note_id`, `file_name`, `file_path`, `file_size`, `file_type`) VALUES
-(1, 1, 1, '2025-08-20 00:40:59', '2025-08-20 00:40:59', NULL, 3, NULL, 'Capture43434.PNG', '/module/project/uploads/project_3_1755672059_Capture43434.PNG', 136873, 'image/png'),
-(2, 1, 1, '2025-08-20 00:40:59', '2025-08-20 00:40:59', NULL, 3, NULL, 'DOCUMENT THIS WHAT I DID FOR LAKE FOR NEW ICON IN HEADER.txt', '/module/project/uploads/project_3_1755672059_DOCUMENT_THIS_WHAT_I_DID_FOR_LAKE_FOR_NEW_ICON_IN_HEADER.txt', 1910, 'text/plain'),
-(3, 1, 1, '2025-08-20 00:40:59', '2025-08-20 00:40:59', NULL, 3, NULL, 'Feedback from CC and Leah Balzer.txt', '/module/project/uploads/project_3_1755672059_Feedback_from_CC_and_Leah_Balzer.txt', 886, 'text/plain'),
-(4, 1, 1, '2025-08-20 00:40:59', '2025-08-20 00:40:59', NULL, 3, NULL, 'FeeWaiver Entity.PNG', '/module/project/uploads/project_3_1755672059_FeeWaiver_Entity.PNG', 291893, 'image/png'),
-(5, 1, 1, '2025-08-20 00:40:59', '2025-08-20 00:40:59', NULL, 3, NULL, 'unnamed (2).png', '/module/project/uploads/project_3_1755672059_unnamed__2_.png', 10562, 'image/png');
+INSERT INTO `module_projects_files` (`id`, `user_id`, `user_updated`, `date_created`, `date_updated`, `memo`, `project_id`, `note_id`, `description`, `file_type_id`, `status_id`, `sort_order`, `file_name`, `file_path`, `file_size`, `file_type`) VALUES
+(1, 1, 1, '2025-08-20 00:40:59', '2025-08-20 00:40:59', NULL, 3, NULL, NULL, NULL, NULL, 0, 'Capture43434.PNG', '/module/project/uploads/project_3_1755672059_Capture43434.PNG', 136873, 'image/png'),
+(2, 1, 1, '2025-08-20 00:40:59', '2025-08-20 00:40:59', NULL, 3, NULL, NULL, NULL, NULL, 0, 'DOCUMENT THIS WHAT I DID FOR LAKE FOR NEW ICON IN HEADER.txt', '/module/project/uploads/project_3_1755672059_DOCUMENT_THIS_WHAT_I_DID_FOR_LAKE_FOR_NEW_ICON_IN_HEADER.txt', 1910, 'text/plain'),
+(3, 1, 1, '2025-08-20 00:40:59', '2025-08-20 00:40:59', NULL, 3, NULL, NULL, NULL, NULL, 0, 'Feedback from CC and Leah Balzer.txt', '/module/project/uploads/project_3_1755672059_Feedback_from_CC_and_Leah_Balzer.txt', 886, 'text/plain'),
+(4, 1, 1, '2025-08-20 00:40:59', '2025-08-20 00:40:59', NULL, 3, NULL, NULL, NULL, NULL, 0, 'FeeWaiver Entity.PNG', '/module/project/uploads/project_3_1755672059_FeeWaiver_Entity.PNG', 291893, 'image/png'),
+(5, 1, 1, '2025-08-20 00:40:59', '2025-08-20 00:40:59', NULL, 3, NULL, NULL, NULL, NULL, 0, 'unnamed (2).png', '/module/project/uploads/project_3_1755672059_unnamed__2_.png', 10562, 'image/png');
 
 -- --------------------------------------------------------
 
@@ -2523,7 +2527,9 @@ ALTER TABLE `module_projects_files`
   ADD KEY `fk_module_projects_files_user_id` (`user_id`),
   ADD KEY `fk_module_projects_files_user_updated` (`user_updated`),
   ADD KEY `fk_module_projects_files_project_id` (`project_id`),
-  ADD KEY `fk_module_projects_files_note_id` (`note_id`);
+  ADD KEY `fk_module_projects_files_note_id` (`note_id`),
+  ADD KEY `fk_module_projects_files_file_type_id` (`file_type_id`),
+  ADD KEY `fk_module_projects_files_status_id` (`status_id`);
 
 --
 -- Indexes for table `module_projects_notes`
@@ -3100,7 +3106,9 @@ ALTER TABLE `module_projects_assignments`
 --
 ALTER TABLE `module_projects_files`
   ADD CONSTRAINT `fk_module_projects_files_note_id` FOREIGN KEY (`note_id`) REFERENCES `module_projects_notes` (`id`),
-  ADD CONSTRAINT `fk_module_projects_files_project_id` FOREIGN KEY (`project_id`) REFERENCES `module_projects` (`id`);
+  ADD CONSTRAINT `fk_module_projects_files_project_id` FOREIGN KEY (`project_id`) REFERENCES `module_projects` (`id`),
+  ADD CONSTRAINT `fk_module_projects_files_file_type_id` FOREIGN KEY (`file_type_id`) REFERENCES `lookup_list_items` (`id`),
+  ADD CONSTRAINT `fk_module_projects_files_status_id` FOREIGN KEY (`status_id`) REFERENCES `lookup_list_items` (`id`);
 
 --
 -- Constraints for table `module_projects_notes`

--- a/module/project/functions/edit_file.php
+++ b/module/project/functions/edit_file.php
@@ -1,0 +1,38 @@
+<?php
+require '../../../includes/php_header.php';
+
+$id         = (int)($_POST['id'] ?? 0);
+$project_id = (int)($_POST['project_id'] ?? 0);
+$description = trim($_POST['description'] ?? '');
+$file_type_id = (int)($_POST['file_type_id'] ?? 0);
+$status_id    = (int)($_POST['status_id'] ?? 0);
+$sort_order   = isset($_POST['sort_order']) ? (int)$_POST['sort_order'] : 0;
+
+if ($id && $project_id) {
+    $stmt = $pdo->prepare('SELECT user_id, description, file_type_id, status_id, sort_order FROM module_projects_files WHERE id = :id');
+    $stmt->execute([':id' => $id]);
+    $current = $stmt->fetch(PDO::FETCH_ASSOC);
+    if ($current && (user_has_permission('project','update') || $is_admin || $current['user_id'] == $this_user_id)) {
+        $pdo->prepare('UPDATE module_projects_files SET description = :description, file_type_id = :file_type_id, status_id = :status_id, sort_order = :sort_order, user_updated = :uid WHERE id = :id')
+            ->execute([
+                ':description' => $description !== '' ? $description : null,
+                ':file_type_id' => $file_type_id ?: null,
+                ':status_id' => $status_id ?: null,
+                ':sort_order' => $sort_order,
+                ':uid' => $this_user_id,
+                ':id' => $id
+            ]);
+        admin_audit_log($pdo, $this_user_id, 'module_projects_files', $id, 'UPDATE', json_encode($current), json_encode([
+            'description' => $description !== '' ? $description : null,
+            'file_type_id' => $file_type_id ?: null,
+            'status_id' => $status_id ?: null,
+            'sort_order' => $sort_order
+        ]));
+    } else {
+        header('HTTP/1.1 403 Forbidden');
+        exit;
+    }
+}
+
+header('Location: ../index.php?action=details&id=' . $project_id);
+exit;

--- a/module/project/include/details_view.php
+++ b/module/project/include/details_view.php
@@ -242,7 +242,7 @@ if (!empty($current_project)) {
                       <div class="row g-3">
                         <?php foreach ($imageFiles as $f): ?>
                           <div class="col-6 col-md-4 col-lg-3 position-relative">
-                            <a href="#" data-bs-toggle="modal" data-bs-target="#fileModal" data-file-src="<?php echo getURLDir(); ?><?= h($f['file_path']) ?>" data-file-type="<?= h($f['file_type']) ?>">
+                            <a href="#" data-bs-toggle="modal" data-bs-target="#fileModal" data-file-src="<?php echo getURLDir(); ?><?= h($f['file_path']) ?>" data-file-type="<?= h($f['file_type']) ?>" data-file-code="<?= h($f['type_code'] ?? '') ?>">
                               <img class="img-fluid rounded" src="<?php echo getURLDir(); ?><?= h($f['file_path']) ?>" alt="<?= h($f['file_name']) ?>">
                             </a>
                             <?php if ($is_admin || ($f['user_id'] ?? 0) == $this_user_id): ?>
@@ -266,7 +266,7 @@ if (!empty($current_project)) {
                           <div class="d-flex flex-between-center">
                             <div class="d-flex mb-1"><span class="fa-solid fa-file me-2 text-body-tertiary fs-9"></span>
                               <p class="text-body-highlight mb-0 lh-1">
-                                <a class="text-body-highlight" href="#" data-bs-toggle="modal" data-bs-target="#fileModal" data-file-src="<?php echo getURLDir(); ?><?= h($f['file_path']) ?>" data-file-type="<?= h($f['file_type']) ?>"><?= h($f['file_name']) ?></a>
+                                <a class="text-body-highlight" href="#" data-bs-toggle="modal" data-bs-target="#fileModal" data-file-src="<?php echo getURLDir(); ?><?= h($f['file_path']) ?>" data-file-type="<?= h($f['file_type']) ?>" data-file-code="<?= h($f['type_code'] ?? '') ?>"><?= h($f['file_name']) ?></a>
                               </p>
                             </div>
                             <?php if ($is_admin || ($f['user_id'] ?? 0) == $this_user_id): ?>
@@ -447,9 +447,9 @@ if (!empty($current_project)) {
                                 <div class="d-flex mb-1"><span class="fa-solid <?= strpos($f['file_type'], 'image/') === 0 ? 'fa-image' : 'fa-file' ?> me-2 text-body-tertiary fs-9"></span>
                                   <p class="text-body-highlight mb-0 lh-1">
                                     <?php if (strpos($f['file_type'], 'image/') === 0): ?>
-                                      <a class="text-body-highlight" href="#" data-bs-toggle="modal" data-bs-target="#fileModal" data-file-src="<?php echo getURLDir(); ?><?= h($f['file_path']) ?>" data-file-type="<?= h($f['file_type']) ?>"><?= h($f['file_name']) ?></a>
+                                      <a class="text-body-highlight" href="#" data-bs-toggle="modal" data-bs-target="#fileModal" data-file-src="<?php echo getURLDir(); ?><?= h($f['file_path']) ?>" data-file-type="<?= h($f['file_type']) ?>" data-file-code="<?= h($f['type_code'] ?? '') ?>"><?= h($f['file_name']) ?></a>
                                     <?php else: ?>
-                                      <a class="text-body-highlight" href="#" data-bs-toggle="modal" data-bs-target="#fileModal" data-file-src="<?php echo getURLDir(); ?><?= h($f['file_path']) ?>" data-file-type="<?= h($f['file_type']) ?>"><?= h($f['file_name']) ?></a>
+                                      <a class="text-body-highlight" href="#" data-bs-toggle="modal" data-bs-target="#fileModal" data-file-src="<?php echo getURLDir(); ?><?= h($f['file_path']) ?>" data-file-type="<?= h($f['file_type']) ?>" data-file-code="<?= h($f['type_code'] ?? '') ?>"><?= h($f['file_name']) ?></a>
                                     <?php endif; ?>
                                   </p>
                                 </div>
@@ -561,6 +561,7 @@ document.addEventListener('DOMContentLoaded', function () {
       var trigger = event.relatedTarget;
       var src = trigger ? trigger.getAttribute('data-file-src') : '';
       var type = trigger ? trigger.getAttribute('data-file-type') : '';
+      var code = trigger ? trigger.getAttribute('data-file-code') : '';
       var content = document.getElementById('modalContent');
       if (!content) return;
       content.innerHTML = '';
@@ -573,11 +574,19 @@ document.addEventListener('DOMContentLoaded', function () {
       } else {
         content.innerHTML = '<a href="' + src + '" download>Download</a>';
       }
+      var dialog = fileModal.querySelector('.modal-dialog');
+      if (dialog) {
+        var w = modalWidths[code] ? modalWidths[code] : '';
+        dialog.style.maxWidth = w ? w + 'px' : '';
+      }
     });
     fileModal.addEventListener('hidden.bs.modal', function(){ var content=document.getElementById('modalContent'); if(content){ content.innerHTML=''; } });
   }
   var statusOptions = <?= json_encode($taskStatusItems ?? []) ?>;
   var priorityOptions = <?= json_encode($taskPriorityItems ?? []) ?>;
+  var fileTypeItems = <?= json_encode($fileTypeItems ?? []) ?>;
+  var fileStatusItems = <?= json_encode($fileStatusItems ?? []) ?>;
+  var modalWidths = <?= json_encode($modalWidths ?? []) ?>;
 
   var assigneeFilter = document.getElementById('assigneeFilter');
   var statusFilter = document.getElementById('statusFilter');
@@ -767,7 +776,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   function renderNote(n){
     var files='';
-    if(n.files){ n.files.forEach(function(f){ files += `<li class=\"mb-1\"><div class=\"d-flex mb-1\"><span class=\"fa-solid ${f.file_type.startsWith('image/')?'fa-image':'fa-file'} me-2 text-body-tertiary fs-9\"></span><p class=\"text-body-highlight mb-0 lh-1\"><a class=\"text-body-highlight\" href=\"#\" data-bs-toggle=\"modal\" data-bs-target=\"#fileModal\" data-file-src=\"<?php echo getURLDir(); ?>${f.file_path}\" data-file-type=\"${f.file_type}\">${f.file_name}</a></p></div></li>`; }); if(files){ files = `<ul class=\"list-unstyled mt-2\">${files}</ul>`; } }
+    if(n.files){ n.files.forEach(function(f){ files += `<li class=\"mb-1\"><div class=\"d-flex mb-1\"><span class=\"fa-solid ${f.file_type.startsWith('image/')?'fa-image':'fa-file'} me-2 text-body-tertiary fs-9\"></span><p class=\"text-body-highlight mb-0 lh-1\"><a class=\"text-body-highlight\" href=\"#\" data-bs-toggle=\"modal\" data-bs-target=\"#fileModal\" data-file-src=\"<?php echo getURLDir(); ?>${f.file_path}\" data-file-type=\"${f.file_type}\" data-file-code=\"${f.type_code||''}\">${f.file_name}</a></p></div></li>`; }); if(files){ files = `<ul class=\"list-unstyled mt-2\">${files}</ul>`; } }
     return `<div class=\"timeline-item position-relative\" data-type=\"note\"><div class=\"row g-md-3 mb-4\"><div class=\"col-12 col-md-auto d-flex\"><div class=\"timeline-item-date order-1 order-md-0 me-md-4\"><p class=\"fs-10 fw-semibold text-body-tertiary text-opacity-85 text-end\">${n.date_created}</p></div><div class=\"timeline-item-bar position-md-relative me-3 me-md-0\"><div class=\"icon-item icon-item-sm rounded-7 shadow-none bg-primary-subtle\"><span class=\"fa-solid fa-note-sticky text-primary-dark fs-10\"></span></div><span class=\"timeline-bar border-end border-dashed\"></span></div></div><div class=\"col\"><div class=\"timeline-item-content ps-6 ps-md-3\"><div class=\"border rounded-2 p-3\"><div class=\"d-flex\"><p class=\"fs-9 lh-sm mb-1 flex-grow-1 note-text\" data-note-id=\"${n.id}\">${n.note_text.replace(/\n/g,'<br>')}</p></div>${files}<p class=\"fs-9 mb-0 d-flex align-items-center\"><img src=\"${n.file_path ? '<?php echo getURLDir(); ?>'+n.file_path : '<?php echo getURLDir(); ?>assets/img/team/avatar.webp'}\" class=\"rounded-circle avatar avatar-m me-2\" alt=\"\" />by <a class=\"fw-semibold ms-1\" href=\"#!\">${n.user_name??''}</a></p></div></div></div></div></div>`;
   }
 


### PR DESCRIPTION
## Summary
- extend `module_projects_files` table with description, type/status links and sorting
- allow uploads to set optional file metadata with defaults
- add endpoint and UI hooks for editing file metadata and dynamic preview widths

## Testing
- `php -l module/project/functions/upload_file.php`
- `php -l module/project/functions/edit_file.php`
- `php -l module/project/index.php`
- `php -l module/project/include/details_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68a769a927dc8333b67c2b98529f586c