### PR TITLE
Guard null values in user profile pic listing

### DIFF
--- a/admin/users/edit.php
+++ b/admin/users/edit.php
@@ -125,10 +125,10 @@ $_SESSION['csrf_token'] = $token;
                   <tbody>
                     <?php foreach ($profilePics as $pic): ?>
                       <tr>
-                        <td><img src="<?php echo getURLDir(); echo htmlspecialchars($pic['file_path']); ?>" class="img-thumbnail" style="width:60px;height:auto;"></td>
-                        <td><?php echo htmlspecialchars($pic['status_label']); ?></td>
-                        <td><?php echo htmlspecialchars($pic['date_created']); ?></td>
-                        <td><?php echo htmlspecialchars($pic['width']); ?>x<?php echo htmlspecialchars($pic['height']); ?></td>
+                        <td><img src="<?php echo getURLDir(); echo htmlspecialchars($pic['file_path'] ?? ''); ?>" class="img-thumbnail" style="width:60px;height:auto;"></td>
+                        <td><?php echo htmlspecialchars($pic['status_label'] ?? ''); ?></td>
+                        <td><?php echo htmlspecialchars($pic['date_created'] ?? ''); ?></td>
+                        <td><?php echo htmlspecialchars($pic['width'] ?? ''); ?>x<?php echo htmlspecialchars($pic['height'] ?? ''); ?></td>
                         <td>
                           <?php if ($pic['status_code'] !== 'ACTIVE'): ?>
                             <form method="post" action="functions/save.php" class="d-inline reactivate-form">
@@ -136,7 +136,7 @@ $_SESSION['csrf_token'] = $token;
                               <input type="hidden" name="id" value="<?php echo $id; ?>">
                               <input type="hidden" name="reactivate_pic_id" value="<?php echo $pic['id']; ?>">
                               <input type="hidden" name="gender_id" value="<?php echo htmlspecialchars($gender_id ?? ''); ?>">
-                              <input type="hidden" name="dob" value="<?php echo htmlspecialchars($dob); ?>">
+                              <input type="hidden" name="dob" value="<?php echo htmlspecialchars($dob ?? ''); ?>">
                               <button type="submit" class="btn btn-sm btn-primary">Reactivate</button>
                             </form>
                           <?php endif; ?>


### PR DESCRIPTION
## Summary
- Safely handle potentially null profile picture fields when editing users
- Guard date of birth field during profile pic reactivation

## Testing
- `php -l admin/users/edit.php`
- `php -d error_reporting=E_ALL -d log_errors=1 -d error_log=php_error.log -r '$pic=["file_path"=>NULL,"status_label"=>NULL,"date_created"=>NULL,"width"=>NULL,"height"=>NULL]; htmlspecialchars($pic["file_path"] ?? ""); htmlspecialchars($pic["status_label"] ?? ""); htmlspecialchars($pic["date_created"] ?? ""); htmlspecialchars($pic["width"] ?? ""); htmlspecialchars($pic["height"] ?? "");'`
- `ls -l php_error.log`

------
https://chatgpt.com/codex/tasks/task_e_68a7b595a0a4833393cd30e80322e882