### PR TITLE
Refactor profile picture reactivation forms

### DIFF
--- a/admin/users/edit.php
+++ b/admin/users/edit.php
@@ -131,14 +131,7 @@ $_SESSION['csrf_token'] = $token;
                         <td><?php echo htmlspecialchars($pic['width']); ?>x<?php echo htmlspecialchars($pic['height']); ?></td>
                         <td>
                           <?php if ($pic['status_code'] !== 'ACTIVE'): ?>
-                            <form method="post" action="functions/save.php" class="d-inline reactivate-form">
-                              <input type="hidden" name="csrf_token" value="<?php echo $token; ?>">
-                              <input type="hidden" name="id" value="<?php echo $id; ?>">
-                              <input type="hidden" name="reactivate_pic_id" value="<?php echo $pic['id']; ?>">
-                              <input type="hidden" name="gender_id" value="<?php echo htmlspecialchars($gender_id ?? ''); ?>">
-                              <input type="hidden" name="dob" value="<?php echo htmlspecialchars($dob); ?>">
-                              <button type="submit" class="btn btn-sm btn-primary">Reactivate</button>
-                            </form>
+                            <button type="submit" class="btn btn-sm btn-primary" form="reactivate-form-<?php echo $pic['id']; ?>">Reactivate</button>
                           <?php endif; ?>
                         </td>
                       </tr>
@@ -228,6 +221,17 @@ $_SESSION['csrf_token'] = $token;
   </div>
   </div>
 </form>
+<?php if ($id && $profilePics): ?>
+  <?php foreach ($profilePics as $pic): ?>
+    <form id="reactivate-form-<?php echo $pic['id']; ?>" method="post" action="functions/save.php" class="reactivate-form d-none">
+      <input type="hidden" name="csrf_token" value="<?php echo $token; ?>">
+      <input type="hidden" name="id" value="<?php echo $id; ?>">
+      <input type="hidden" name="reactivate_pic_id" value="<?php echo $pic['id']; ?>">
+      <input type="hidden" name="gender_id" value="<?php echo htmlspecialchars($gender_id ?? ''); ?>">
+      <input type="hidden" name="dob" value="<?php echo htmlspecialchars($dob); ?>">
+    </form>
+  <?php endforeach; ?>
+<?php endif; ?>
 <template id="phone-template">
 <?php $index='__INDEX__'; $phRow=[]; include __DIR__.'/../person/_phone_row.php'; ?>
 </template>

--- a/admin/users/functions/save.php
+++ b/admin/users/functions/save.php
@@ -37,20 +37,22 @@ if ($reactivatePicId && $id) {
   try {
     $pdo->beginTransaction();
 
-    $personParams = [
-      ':uid_fk' => $id,
-      ':gender_id' => $gender_id,
-      ':dob' => $dob ?: null,
-      ':uid_update' => $this_user_id
-    ];
-    $pdo->prepare(
-      'INSERT INTO person (user_id, gender_id, dob, user_updated)
-       VALUES (:uid_fk, :gender_id, :dob, :uid_update)
-       ON DUPLICATE KEY UPDATE
-         gender_id = VALUES(gender_id),
-         dob = VALUES(dob),
-         user_updated = VALUES(user_updated)'
-    )->execute($personParams);
+    if ($gender_id !== null || $dob !== '') {
+      $personParams = [
+        ':uid_fk' => $id,
+        ':gender_id' => $gender_id,
+        ':dob' => $dob ?: null,
+        ':uid_update' => $this_user_id
+      ];
+      $pdo->prepare(
+        'INSERT INTO person (user_id, gender_id, dob, user_updated)
+         VALUES (:uid_fk, :gender_id, :dob, :uid_update)
+         ON DUPLICATE KEY UPDATE
+           gender_id = VALUES(gender_id),
+           dob = VALUES(dob),
+           user_updated = VALUES(user_updated)'
+      )->execute($personParams);
+    }
 
     $pdo->prepare('UPDATE users_profile_pics SET status_id = :inactive, user_updated = :uid WHERE user_id = :user AND status_id = :active')
         ->execute([':inactive' => $inactiveStatusId, ':uid' => $this_user_id, ':user' => $id, ':active' => $activeStatusId]);


### PR DESCRIPTION
## Summary
- Move profile picture reactivation buttons to use external forms referenced via the `form` attribute, keeping the main user edit form free of reactivation inputs
- Add hidden standalone reactivation forms to submit profile picture reactivation requests
- Guard person updates in reactivation logic so existing data is preserved when optional fields are omitted

## Testing
- `php -l admin/users/edit.php`
- `php -l admin/users/functions/save.php`


------
https://chatgpt.com/codex/tasks/task_e_68a7b59520c08333833c90ca902cd68c