### PR TITLE
Add AJAX endpoint for profile picture uploads

### DIFF
--- a/admin/users/edit.php
+++ b/admin/users/edit.php
@@ -264,11 +264,32 @@ document.querySelectorAll('.reactivate-form').forEach(form => {
 
 document.addEventListener('DOMContentLoaded', function () {
   var uploadInput = document.getElementById('upload-avatar');
-  if (uploadInput) {
+  var userIdInput = document.querySelector('input[name="id"]');
+  var csrfInput = document.querySelector('input[name="csrf_token"]');
+  var previewImg = document.querySelector('.avatar.avatar-5xl img');
+  var baseURL = '<?php echo getURLDir(); ?>';
+  if (uploadInput && userIdInput && csrfInput && previewImg) {
     uploadInput.addEventListener('change', function () {
-      if (this.files.length && document.querySelector('input[name="id"]')) {
-        this.closest('form').submit();   // bypass validation and post immediately
-      }
+      if (!this.files.length) { return; }
+      var fd = new FormData();
+      fd.append('profile_pic', this.files[0]);
+      fd.append('id', userIdInput.value);
+      fd.append('csrf_token', csrfInput.value);
+      fetch('functions/upload_pic.php', {
+        method: 'POST',
+        body: fd
+      }).then(function(r){ return r.json(); })
+        .then(function(data){
+          if(data.success && data.path){
+            previewImg.src = baseURL + data.path + '?t=' + Date.now();
+          } else {
+            alert(data.error || 'Upload failed');
+          }
+          uploadInput.value = '';
+        }).catch(function(){
+          alert('Upload failed');
+          uploadInput.value = '';
+        });
     });
   }
 });

--- a/admin/users/functions/upload_pic.php
+++ b/admin/users/functions/upload_pic.php
@@ -1,0 +1,116 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) {
+  session_start();
+}
+require_once '../../../includes/php_header.php';
+require_permission('users','update');
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+  http_response_code(405);
+  echo json_encode(['error' => 'Method not allowed']);
+  exit;
+}
+
+if (!hash_equals($_SESSION['csrf_token'] ?? '', $_POST['csrf_token'] ?? '')) {
+  http_response_code(400);
+  echo json_encode(['error' => 'Invalid CSRF token']);
+  exit;
+}
+
+$id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+if (!$id || empty($_FILES['profile_pic']['name'])) {
+  http_response_code(400);
+  echo json_encode(['error' => 'Missing data']);
+  exit;
+}
+
+function get_status_id(PDO $pdo, string $code): int {
+  $stmt = $pdo->prepare("SELECT li.id FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'USER_PROFILE_PIC_STATUS' AND li.code = :code LIMIT 1");
+  $stmt->execute([':code' => $code]);
+  return (int)$stmt->fetchColumn();
+}
+
+$activeStatusId = get_status_id($pdo, 'ACTIVE');
+$inactiveStatusId = get_status_id($pdo, 'INACTIVE');
+if (!$activeStatusId || !$inactiveStatusId) {
+  http_response_code(500);
+  echo json_encode(['error' => 'Profile picture status not configured']);
+  exit;
+}
+
+$file = $_FILES['profile_pic'];
+if ($file['error'] !== UPLOAD_ERR_OK) {
+  http_response_code(400);
+  echo json_encode(['error' => 'Upload error']);
+  exit;
+}
+if ($file['size'] > 10 * 1024 * 1024) {
+  http_response_code(400);
+  echo json_encode(['error' => 'File too large']);
+  exit;
+}
+
+$finfo = finfo_open(FILEINFO_MIME_TYPE);
+$mime = finfo_file($finfo, $file['tmp_name']);
+finfo_close($finfo);
+$typeItems = get_lookup_items($pdo, 'IMAGE_FILE_TYPES');
+$allowed = array_column($typeItems, 'code');
+$extMap = array_column($typeItems, 'label', 'code');
+if (!in_array($mime, $allowed, true)) {
+  http_response_code(400);
+  echo json_encode(['error' => 'Invalid file type']);
+  exit;
+}
+$ext = $extMap[$mime] ?? pathinfo($file['name'], PATHINFO_EXTENSION);
+$safe = preg_replace('/[^a-zA-Z0-9_-]/', '_', pathinfo($file['name'], PATHINFO_FILENAME));
+$filename = $safe . '_' . time() . '.' . $ext;
+$destDir = '../../../module/users/uploads/';
+if (!is_dir($destDir)) {
+  mkdir($destDir, 0755, true);
+}
+$dest = $destDir . $filename;
+if (!move_uploaded_file($file['tmp_name'], $dest)) {
+  http_response_code(500);
+  echo json_encode(['error' => 'Failed to save file']);
+  exit;
+}
+$profilePath = 'module/users/uploads/' . $filename;
+$fileSize = $file['size'];
+$hashFile = hash_file('sha256', $dest);
+$img = getimagesize($dest);
+$width = $img ? $img[0] : null;
+$height = $img ? $img[1] : null;
+
+try {
+  $pdo->beginTransaction();
+  $pdo->prepare('UPDATE users_profile_pics SET status_id = :inactive, user_updated = :uid WHERE user_id = :user AND status_id = :active')
+      ->execute([':inactive' => $inactiveStatusId, ':uid' => $this_user_id, ':user' => $id, ':active' => $activeStatusId]);
+  $pstmt = $pdo->prepare('INSERT INTO users_profile_pics (user_id, uploaded_by, file_name, file_path, file_size, file_type, width, height, file_hash, status_id, user_updated) VALUES (:user_id, :uploaded_by, :file_name, :file_path, :file_size, :file_type, :width, :height, :file_hash, :status_id, :uid)');
+  $pstmt->execute([
+    ':user_id' => $id,
+    ':uploaded_by' => $this_user_id,
+    ':file_name' => $filename,
+    ':file_path' => $profilePath,
+    ':file_size' => $fileSize,
+    ':file_type' => $mime,
+    ':width' => $width,
+    ':height' => $height,
+    ':file_hash' => $hashFile,
+    ':status_id' => $activeStatusId,
+    ':uid' => $this_user_id
+  ]);
+  $picId = (int)$pdo->lastInsertId();
+  $pdo->prepare('UPDATE users SET current_profile_pic_id = :pic, user_updated = :uid WHERE id = :user')
+      ->execute([':pic' => $picId, ':uid' => $this_user_id, ':user' => $id]);
+  $pdo->commit();
+  echo json_encode(['success' => true, 'path' => $profilePath]);
+} catch (Exception $e) {
+  if ($pdo->inTransaction()) {
+    $pdo->rollBack();
+  }
+  error_log($e->getMessage());
+  http_response_code(500);
+  echo json_encode(['error' => 'Server error']);
+}


### PR DESCRIPTION
## Summary
- Add dedicated `upload_pic.php` for user profile picture uploads with CSRF validation and DB updates.
- Replace form auto-submit with AJAX `FormData` upload that refreshes the preview without touching other fields.

## Testing
- `php -l admin/users/functions/upload_pic.php`
- `php -l admin/users/edit.php`


------
https://chatgpt.com/codex/tasks/task_e_68a7b9210fd88333b33120c979e836a8