### PR TITLE
Refactor active profile picture handling

### DIFF
--- a/_SQL/atlis.sql
+++ b/_SQL/atlis.sql
@@ -2388,9 +2388,7 @@ CREATE TABLE `users_profile_pics` (
   `width` int(11) DEFAULT NULL,
   `height` int(11) DEFAULT NULL,
   `uploaded_by` int(11) DEFAULT NULL,
-  `status_id` int(11) NOT NULL,
-  `is_active` tinyint(1) GENERATED ALWAYS AS (`status_id` = 82) STORED,
-  `active_user_id` int(11) GENERATED ALWAYS AS (if(`status_id` = 82,`user_id`,NULL)) STORED
+  `status_id` int(11) NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --
@@ -2830,12 +2828,22 @@ ALTER TABLE `users_2fa`
 --
 -- Indexes for table `users_profile_pics`
 --
+-- Determine the ACTIVE status id for user profile pictures
+SET @active_user_profile_pic_status_id = (
+  SELECT li.id
+  FROM lookup_list_items li
+  INNER JOIN lookup_lists ll ON li.list_id = ll.id
+  WHERE ll.name = 'USER_PROFILE_PIC_STATUS'
+    AND li.code = 'ACTIVE'
+);
+
 ALTER TABLE `users_profile_pics`
   ADD PRIMARY KEY (`id`),
   ADD KEY `fk_users_profile_pics_user_id` (`user_id`),
   ADD KEY `fk_users_profile_pics_user_updated` (`user_updated`),
   ADD KEY `fk_users_profile_pics_uploaded_by` (`uploaded_by`),
-  ADD KEY `fk_users_profile_pics_status_id` (`status_id`);
+  ADD KEY `fk_users_profile_pics_status_id` (`status_id`),
+  ADD UNIQUE KEY `uq_users_profile_pics_active_user` ((CASE WHEN `status_id` = @active_user_profile_pic_status_id THEN `user_id` END));
 
 --
 -- AUTO_INCREMENT for dumped tables

--- a/admin/contractors/index.php
+++ b/admin/contractors/index.php
@@ -36,7 +36,7 @@ $sql = "SELECT mc.id,
         LEFT JOIN lookup_list_item_attributes sa ON s.id = sa.item_id AND sa.attr_code = 'COLOR-CLASS'
         LEFT JOIN lookup_list_items t ON mc.contractor_type_id = t.id
         LEFT JOIN users u ON p.user_id = u.id
-        LEFT JOIN users_profile_pics upp ON u.current_profile_pic_id = upp.id AND upp.is_active = 1
+        LEFT JOIN users_profile_pics upp ON u.current_profile_pic_id = upp.id
         ORDER BY p.last_name, p.first_name";
 $stmt = $pdo->prepare($sql);
 $stmt->execute();


### PR DESCRIPTION
## Summary
- remove generated `is_active`/`active_user_id` columns from `users_profile_pics`
- derive active status ID and enforce unique active picture per user
- drop reliance on `is_active` in contractors listing

## Testing
- `php -l admin/contractors/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68a7b91f38a883339ed17a276e1c5196