### PR TITLE
Add lookup badge helper and refactor badge rendering

### DIFF
--- a/admin/orgs/index.php
+++ b/admin/orgs/index.php
@@ -61,8 +61,7 @@ $organizations = $orgStmt->fetchAll(PDO::FETCH_ASSOC);
         <tr>
           <td><?= htmlspecialchars($org['name']); ?></td>
           <td>
-            <?php $status = $orgStatuses[$org['status']] ?? null; $class = $status['color_class'] ?? 'secondary'; ?>
-            <span class="badge badge-phoenix fs-10 badge-phoenix-<?= htmlspecialchars($class); ?>"><span class="badge-label"><?= htmlspecialchars($status['label'] ?? ''); ?></span></span>
+            <?= render_status_badge($orgStatuses, $org['status']) ?>
           </td>
           <td>
             <a class="btn btn-sm btn-warning" href="organization_edit.php?id=<?= $org['id']; ?>">Edit</a>
@@ -90,8 +89,7 @@ $organizations = $orgStmt->fetchAll(PDO::FETCH_ASSOC);
               <?php endif; ?>
             </td>
             <td>
-              <?php $aStatus = $agencyStatuses[$agency['status']] ?? null; $aClass = $aStatus['color_class'] ?? 'secondary'; ?>
-              <span class="badge badge-phoenix fs-10 badge-phoenix-<?= htmlspecialchars($aClass); ?>"><span class="badge-label"><?= htmlspecialchars($aStatus['label'] ?? ''); ?></span></span>
+              <?= render_status_badge($agencyStatuses, $agency['status']) ?>
             </td>
             <td>
               <a class="btn btn-sm btn-warning" href="agency_edit.php?id=<?= $agency['id']; ?>">Edit</a>
@@ -115,8 +113,7 @@ $organizations = $orgStmt->fetchAll(PDO::FETCH_ASSOC);
             <tr class="bg-body-secondary">
               <td class="ps-5">Division: <?= htmlspecialchars($division['name']); ?></td>
               <td>
-                <?php $dStatus = $divisionStatuses[$division['status']] ?? null; $dClass = $dStatus['color_class'] ?? 'secondary'; ?>
-                <span class="badge badge-phoenix fs-10 badge-phoenix-<?= htmlspecialchars($dClass); ?>"><span class="badge-label"><?= htmlspecialchars($dStatus['label'] ?? ''); ?></span></span>
+                <?= render_status_badge($divisionStatuses, $division['status']) ?>
               </td>
               <td>
                 <a class="btn btn-sm btn-warning" href="division_edit.php?id=<?= $division['id']; ?>">Edit</a>

--- a/admin/person/_address_row.php
+++ b/admin/person/_address_row.php
@@ -4,10 +4,8 @@ $index = $index ?? 0;
 $selType = $addrRow['type_id'] ?? $defaultAddressTypeId;
 $selStatus = $addrRow['status_id'] ?? $defaultAddressStatusId;
 $selState  = $addrRow['state_id'] ?? null;
-$typeColor = 'secondary';
-foreach ($addressTypeItems as $it) { if ($it['id']==$selType) { $typeColor=$it['color_class']; break; } }
-$statusColor = 'secondary';
-foreach ($addressStatusItems as $it) { if ($it['id']==$selStatus) { $statusColor=$it['color_class']; break; } }
+$addressTypeMap = array_column($addressTypeItems, null, 'id');
+$addressStatusMap = array_column($addressStatusItems, null, 'id');
 ?>
 <div class="address-item border p-2 mb-2">
   <input type="hidden" name="addresses[<?= $index; ?>][id]" value="<?= h($addrRow['id'] ?? ''); ?>">
@@ -19,7 +17,7 @@ foreach ($addressStatusItems as $it) { if ($it['id']==$selStatus) { $statusColor
           <option value="<?= h($pt['id']); ?>" data-color="<?= h($pt['color_class']); ?>" <?= $selected; ?>><?= h($pt['label']); ?></option>
         <?php endforeach; ?>
       </select>
-      <span class="badge badge-phoenix fs-10 ms-1 lookup-badge badge-phoenix-<?= h($typeColor); ?>"></span>
+      <?= render_status_badge($addressTypeMap, $selType, 'fs-10 ms-1 lookup-badge') ?>
     </div>
     <div class="col-md-2">
       <label class="form-label mb-0">Status</label>
@@ -28,7 +26,7 @@ foreach ($addressStatusItems as $it) { if ($it['id']==$selStatus) { $statusColor
           <option value="<?= h($ps['id']); ?>" data-color="<?= h($ps['color_class']); ?>" <?= $selected; ?>><?= h($ps['label']); ?></option>
         <?php endforeach; ?>
       </select>
-      <span class="badge badge-phoenix fs-10 ms-1 lookup-badge badge-phoenix-<?= h($statusColor); ?>"></span>
+      <?= render_status_badge($addressStatusMap, $selStatus, 'fs-10 ms-1 lookup-badge') ?>
     </div>
     <div class="col-md-4">
       <label class="form-label mb-0">Line 1</label>

--- a/admin/person/_phone_row.php
+++ b/admin/person/_phone_row.php
@@ -3,10 +3,8 @@ $phRow = $phRow ?? [];
 $index = $index ?? 0;
 $selType = $phRow['type_id'] ?? $defaultPhoneTypeId;
 $selStatus = $phRow['status_id'] ?? $defaultPhoneStatusId;
-$typeColor = 'secondary';
-foreach ($phoneTypeItems as $it) { if ($it['id']==$selType) { $typeColor=$it['color_class']; break; } }
-$statusColor = 'secondary';
-foreach ($phoneStatusItems as $it) { if ($it['id']==$selStatus) { $statusColor=$it['color_class']; break; } }
+$phoneTypeMap = array_column($phoneTypeItems, null, 'id');
+$phoneStatusMap = array_column($phoneStatusItems, null, 'id');
 ?>
 <div class="phone-item border p-2 mb-2">
   <input type="hidden" name="phones[<?= $index; ?>][id]" value="<?= h($phRow['id'] ?? ''); ?>">
@@ -18,7 +16,7 @@ foreach ($phoneStatusItems as $it) { if ($it['id']==$selStatus) { $statusColor=$
           <option value="<?= h($pt['id']); ?>" data-color="<?= h($pt['color_class']); ?>" <?= $selected; ?>><?= h($pt['label']); ?></option>
         <?php endforeach; ?>
       </select>
-      <span class="badge badge-phoenix fs-10 ms-1 lookup-badge badge-phoenix-<?= h($typeColor); ?>"></span>
+      <?= render_status_badge($phoneTypeMap, $selType, 'fs-10 ms-1 lookup-badge') ?>
     </div>
     <div class="col-md-2">
       <label class="form-label mb-0">Status</label>
@@ -27,7 +25,7 @@ foreach ($phoneStatusItems as $it) { if ($it['id']==$selStatus) { $statusColor=$
           <option value="<?= h($ps['id']); ?>" data-color="<?= h($ps['color_class']); ?>" <?= $selected; ?>><?= h($ps['label']); ?></option>
         <?php endforeach; ?>
       </select>
-      <span class="badge badge-phoenix fs-10 ms-1 lookup-badge badge-phoenix-<?= h($statusColor); ?>"></span>
+      <?= render_status_badge($phoneStatusMap, $selStatus, 'fs-10 ms-1 lookup-badge') ?>
     </div>
     <div class="col-md-3">
       <label class="form-label mb-0">Number</label>

--- a/includes/lookup_helpers.php
+++ b/includes/lookup_helpers.php
@@ -34,4 +34,28 @@ function get_lookup_items(PDO $pdo, int|string $list): array {
     return $stmt->fetchAll(PDO::FETCH_ASSOC);
 }
 
+/**
+ * Render a Phoenix badge for a lookup item.
+ *
+ * @param array       $lookupList Associative array of lookup items keyed by ID.
+ * @param int|string  $id         Lookup item ID.
+ * @param string|null $classes    Optional additional classes (size etc.).
+ * @param array       $attributes Optional attribute key/value pairs.
+ * @return string                  HTML span markup for the badge.
+ */
+function render_status_badge(array $lookupList, int|string $id, ?string $classes = 'fs-10', array $attributes = []): string {
+    $item  = $lookupList[$id] ?? [];
+    $color = $item['color_class'] ?? 'secondary';
+    $label = $item['label'] ?? '';
+
+    $attrString = '';
+    foreach ($attributes as $attr => $value) {
+        $attrString .= ' ' . htmlspecialchars($attr) . '="' . htmlspecialchars($value) . '"';
+    }
+
+    $classString = trim('badge badge-phoenix badge-phoenix-' . htmlspecialchars($color) . ' ' . ($classes ?? ''));
+
+    return '<span class="' . $classString . '"' . $attrString . '><span class="badge-label">' . htmlspecialchars($label) . '</span></span>';
+}
+
 ?>

--- a/module/agency/include/board_view.php
+++ b/module/agency/include/board_view.php
@@ -2,24 +2,22 @@
 // Board view of agencies grouped by status
 $columns = [];
 foreach ($agencies as $agency) {
-  $status = $agency['status_label'] ?? 'Unassigned';
-  $color  = $agency['status_color'] ?? 'secondary';
-  $columns[$status]['color'] = $color;
-  $columns[$status]['items'][] = $agency;
+  $sid = $agency['status'] ?? 0;
+  $columns[$sid]['items'][] = $agency;
 }
 ?>
 <div class="row g-3">
-  <?php foreach ($columns as $status => $data): ?>
+  <?php foreach ($columns as $sid => $data): ?>
     <div class="col-12 col-md-6 col-lg-4">
       <div class="card">
         <div class="card-header bg-body-tertiary">
-          <h6 class="mb-0"><span class="badge badge-phoenix badge-phoenix-<?= htmlspecialchars($data['color']); ?>"><?php echo htmlspecialchars($status); ?></span></h6>
+          <h6 class="mb-0"><?= render_status_badge($statusList, $sid) ?></h6>
         </div>
         <div class="card-body">
           <?php foreach (($data['items'] ?? []) as $agency): ?>
             <div class="card mb-2">
               <div class="card-body p-2">
-                <?php echo htmlspecialchars($agency['name']); ?>
+                <?= htmlspecialchars($agency['name']); ?>
               </div>
             </div>
           <?php endforeach; ?>

--- a/module/agency/include/card_view.php
+++ b/module/agency/include/card_view.php
@@ -9,9 +9,7 @@
           <div class="card-body">
             <h5 class="card-title mb-1"><?php echo htmlspecialchars($agency['name']); ?></h5>
             <p class="mb-0">
-              <span class="badge badge-phoenix fs-10 badge-phoenix-<?= htmlspecialchars($agency['status_color'] ?? 'secondary'); ?>">
-                <span class="badge-label"><?php echo htmlspecialchars($agency['status_label'] ?? ''); ?></span>
-              </span>
+              <?= render_status_badge($statusList, $agency['status']) ?>
             </p>
           </div>
         </div>

--- a/module/agency/include/list_view.php
+++ b/module/agency/include/list_view.php
@@ -16,9 +16,7 @@
             <tr>
               <td class="align-middle name"><?php echo htmlspecialchars($agency['name']); ?></td>
               <td class="align-middle status">
-                <span class="badge badge-phoenix fs-10 badge-phoenix-<?= htmlspecialchars($agency['status_color'] ?? 'secondary'); ?>">
-                  <span class="badge-label"><?php echo htmlspecialchars($agency['status_label'] ?? ''); ?></span>
-                </span>
+                <?= render_status_badge($statusList, $agency['status']) ?>
               </td>
             </tr>
           <?php endforeach; ?>

--- a/module/agency/index.php
+++ b/module/agency/index.php
@@ -4,16 +4,11 @@ require_permission('agency','read');
 
 $action = $_GET['action'] ?? 'card';
 
-// Fetch agencies and attach status info
-$statusMap = array_column(get_lookup_items($pdo, 'AGENCY_STATUS'), null, 'id');
+// Fetch agencies and status lookup
+$statusList = array_column(get_lookup_items($pdo, 'AGENCY_STATUS'), null, 'id');
+$statusList[0] = ['label' => 'Unassigned', 'color_class' => 'secondary'];
 $stmt = $pdo->query('SELECT id, name, status FROM module_agency ORDER BY name');
 $agencies = $stmt->fetchAll(PDO::FETCH_ASSOC);
-foreach ($agencies as &$agency) {
-  $status = $statusMap[$agency['status']] ?? null;
-  $agency['status_label'] = $status['label'] ?? null;
-  $agency['status_color'] = $status['color_class'] ?? 'secondary';
-}
-unset($agency);
 
 require '../../includes/html_header.php';
 ?>

--- a/module/project/include/details_view.php
+++ b/module/project/include/details_view.php
@@ -60,9 +60,12 @@ if (!empty($current_project)) {
           <h2 class="text-body-emphasis fw-bolder mb-2"><?= h($current_project['name'] ?? '') ?></h2>
         </div>
         <div class="dropdown d-inline me-2">
-          <span class="badge badge-phoenix badge-phoenix-<?= h($statusMap[$current_project['status']]['color_class'] ?? 'secondary') ?> dropdown-toggle" id="statusBadge" data-bs-toggle="dropdown" role="button" aria-expanded="false">
-            <?= h($statusMap[$current_project['status']]['label'] ?? '') ?>
-          </span>
+          <?= render_status_badge(
+                $statusMap,
+                $current_project['status'],
+                'dropdown-toggle',
+                ['id' => 'statusBadge', 'data-bs-toggle' => 'dropdown', 'role' => 'button', 'aria-expanded' => 'false']
+            ) ?>
           <ul class="dropdown-menu" aria-labelledby="statusBadge">
             <?php foreach ($statusMap as $sid => $s): ?>
               <li><a class="dropdown-item project-field-option" href="#" data-field="status" data-value="<?= (int)$sid ?>" data-color="<?= h($s['color_class'] ?? 'secondary') ?>"><?= h($s['label'] ?? '') ?></a></li>
@@ -70,9 +73,12 @@ if (!empty($current_project)) {
           </ul>
         </div>
         <div class="dropdown d-inline">
-          <span class="badge badge-phoenix badge-phoenix-<?= h($priorityMap[$current_project['priority']]['color_class'] ?? 'secondary') ?> dropdown-toggle" id="priorityBadge" data-bs-toggle="dropdown" role="button" aria-expanded="false">
-            <?= h($priorityMap[$current_project['priority']]['label'] ?? '') ?>
-          </span>
+          <?= render_status_badge(
+                $priorityMap,
+                $current_project['priority'],
+                'dropdown-toggle',
+                ['id' => 'priorityBadge', 'data-bs-toggle' => 'dropdown', 'role' => 'button', 'aria-expanded' => 'false']
+            ) ?>
           <ul class="dropdown-menu" aria-labelledby="priorityBadge">
             <?php foreach ($priorityMap as $pid => $p): ?>
               <li><a class="dropdown-item project-field-option" href="#" data-field="priority" data-value="<?= (int)$pid ?>" data-color="<?= h($p['color_class'] ?? 'secondary') ?>"><?= h($p['label'] ?? '') ?></a></li>

--- a/module/task/include/details_view.php
+++ b/module/task/include/details_view.php
@@ -24,23 +24,19 @@ require_once __DIR__ . '/../../../includes/functions.php';
       <p class="text-body-secondary mb-0"><?php echo implode(' / ', array_map('h', $hierarchyParts)); ?></p>
     <?php endif; ?>
     <p class="mb-3 mt-3">
-      <span id="statusBadge" class="badge badge-phoenix fs-8 badge-phoenix-<?php echo h($statusMap[$current_task['status']]['color_class'] ?? 'secondary'); ?>">
-        <span class="badge-label"><?php echo h($statusMap[$current_task['status']]['label'] ?? ''); ?></span>
-      </span>
-      <span id="priorityBadge" class="badge badge-phoenix fs-8 badge-phoenix-<?php echo h($priorityMap[$current_task['priority']]['color_class'] ?? 'secondary'); ?>">
-        <span class="badge-label"><?php echo h($priorityMap[$current_task['priority']]['label'] ?? ''); ?></span>
-      </span>
+      <?= render_status_badge($statusMap, $current_task['status'], 'fs-8', ['id' => 'statusBadge']) ?>
+      <?= render_status_badge($priorityMap, $current_task['priority'], 'fs-8', ['id' => 'priorityBadge']) ?>
       <?php if (user_has_permission('task','update')): ?>
       <form id="taskUpdateForm" class="d-inline ms-2">
         <input type="hidden" name="id" value="<?php echo (int)$current_task['id']; ?>">
         <select class="form-select form-select-sm d-inline w-auto" name="status">
           <?php foreach ($statusMap as $s): ?>
-            <option value="<?php echo (int)$s['id']; ?>" <?php echo ((int)$current_task['status'] === (int)$s['id']) ? 'selected' : ''; ?>><?php echo h($s['label']); ?></option>
+            <option value="<?php echo (int)$s['id']; ?>" data-color="<?php echo h($s['color_class']); ?>" <?php echo ((int)$current_task['status'] === (int)$s['id']) ? 'selected' : ''; ?>><?php echo h($s['label']); ?></option>
           <?php endforeach; ?>
         </select>
         <select class="form-select form-select-sm d-inline w-auto ms-1" name="priority">
           <?php foreach ($priorityMap as $p): ?>
-            <option value="<?php echo (int)$p['id']; ?>" <?php echo ((int)$current_task['priority'] === (int)$p['id']) ? 'selected' : ''; ?>><?php echo h($p['label']); ?></option>
+            <option value="<?php echo (int)$p['id']; ?>" data-color="<?php echo h($p['color_class']); ?>" <?php echo ((int)$current_task['priority'] === (int)$p['id']) ? 'selected' : ''; ?>><?php echo h($p['label']); ?></option>
           <?php endforeach; ?>
         </select>
         <button class="btn btn-atlis btn-sm ms-1" type="submit">Update</button>


### PR DESCRIPTION
## Summary
- add `render_status_badge` helper for consistent badge markup
- refactor organization, agency, project, task, and person forms to use the helper
- include badge color data attributes for dynamic styling

## Testing
- `php -l includes/lookup_helpers.php`
- `php -l admin/orgs/index.php`
- `php -l module/agency/index.php`
- `php -l module/agency/include/card_view.php`
- `php -l module/agency/include/list_view.php`
- `php -l module/agency/include/board_view.php`
- `php -l module/project/include/details_view.php`
- `php -l module/task/include/details_view.php`
- `php -l admin/person/_phone_row.php`
- `php -l admin/person/_address_row.php`


------
https://chatgpt.com/codex/tasks/task_e_68a7b84522448333808c7ce68b4db7e2