### PR TITLE
Handle null status and priority lookups

### DIFF
--- a/includes/lookup_helpers.php
+++ b/includes/lookup_helpers.php
@@ -37,16 +37,20 @@ function get_lookup_items(PDO $pdo, int|string $list): array {
 /**
  * Render a Phoenix badge for a lookup item.
  *
- * @param array       $lookupList Associative array of lookup items keyed by ID.
- * @param int|string  $id         Lookup item ID.
- * @param string|null $classes    Optional additional classes (size etc.).
- * @param array       $attributes Optional attribute key/value pairs.
- * @return string                  HTML span markup for the badge.
+ * @param array             $lookupList Associative array of lookup items keyed by ID.
+ * @param int|string|null   $id         Lookup item ID or null.
+ * @param string|null       $classes    Optional additional classes (size etc.).
+ * @param array             $attributes Optional attribute key/value pairs.
+ * @return string                        HTML span markup for the badge.
  */
-function render_status_badge(array $lookupList, int|string $id, ?string $classes = 'fs-10', array $attributes = []): string {
-    $item  = $lookupList[$id] ?? [];
+function render_status_badge(array $lookupList, int|string|null $id, ?string $classes = 'fs-10', array $attributes = []): string {
+    if ($id === null) {
+        return '';
+    }
+
+    $item  = $lookupList[$id] ?? ['color_class' => 'secondary', 'label' => 'Unknown'];
     $color = $item['color_class'] ?? 'secondary';
-    $label = $item['label'] ?? '';
+    $label = $item['label'] ?? 'Unknown';
 
     $attrString = '';
     foreach ($attributes as $attr => $value) {

--- a/module/project/functions/create.php
+++ b/module/project/functions/create.php
@@ -6,7 +6,8 @@ require_permission('project', 'create');
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   $name = $_POST['name'] ?? '';
-  $status = $_POST['status'] ?? null;
+  $status   = $_POST['status'] ?? null;
+  $priority = $_POST['priority'] ?? null;
   $description = $_POST['description'] ?? null;
   $requirements = $_POST['requirements'] ?? null;
   $specifications = $_POST['specifications'] ?? null;
@@ -14,7 +15,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   $agency_id = $_POST['agency_id'] ?? null;
   $division_id = $_POST['division_id'] ?? null;
 
-  $stmt = $pdo->prepare('INSERT INTO module_projects (user_id, user_updated, agency_id, division_id, name, description, requirements, specifications, status, start_date) VALUES (:uid, :uid, :agency_id, :division_id, :name, :description, :requirements, :specifications, :status, :start_date)');
+  $stmt = $pdo->prepare('INSERT INTO module_projects (user_id, user_updated, agency_id, division_id, name, description, requirements, specifications, status, priority, start_date) VALUES (:uid, :uid, :agency_id, :division_id, :name, :description, :requirements, :specifications, :status, :priority, :start_date)');
   $stmt->execute([
     ':uid' => $this_user_id,
     ':agency_id' => $agency_id,
@@ -24,6 +25,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     ':requirements' => $requirements,
     ':specifications' => $specifications,
     ':status' => $status,
+    ':priority' => $priority,
     ':start_date' => $start_date
   ]);
   $id = $pdo->lastInsertId();
@@ -43,6 +45,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
       'requirements' => $requirements,
       'specifications' => $specifications,
       'status' => $status,
+      'priority' => $priority,
       'start_date' => $start_date
     ]),
     'Created project'

--- a/module/project/include/create_edit.php
+++ b/module/project/include/create_edit.php
@@ -1,6 +1,10 @@
 <?php
 require_once __DIR__ . '/../../../includes/functions.php';
 require_permission('project','create');
+
+// Ensure lookup lists are available
+$statusMap   = $statusMap   ?? get_lookup_items($pdo, 'PROJECT_STATUS');
+$priorityMap = $priorityMap ?? get_lookup_items($pdo, 'PROJECT_PRIORITY');
 ?>
 <nav class="mb-3" aria-label="breadcrumb">
   <ol class="breadcrumb mb-0">
@@ -36,6 +40,26 @@ require_permission('project','create');
             <?php endforeach; ?>
           </select>
           <label for="projectStatus">Status</label>
+        </div>
+      </div>
+      <div class="col-sm-6 col-md-4">
+        <div class="form-floating">
+          <?php
+            $hasPriorityDefault = false;
+            foreach ($priorityMap as $p) {
+              if (!empty($p['is_default'])) {
+                $hasPriorityDefault = true;
+                break;
+              }
+            }
+          ?>
+          <select class="form-select" id="projectPriority" name="priority" required>
+            <option value="" <?= $hasPriorityDefault ? '' : 'selected'; ?>>Select priority</option>
+            <?php foreach ($priorityMap as $p): ?>
+              <option value="<?= h($p['id']); ?>" <?= !empty($p['is_default']) ? 'selected' : ''; ?>><?= h($p['label']); ?></option>
+            <?php endforeach; ?>
+          </select>
+          <label for="projectPriority">Priority</label>
         </div>
       </div>
       <div class="col-sm-6 col-md-4">

--- a/module/project/include/details_view.php
+++ b/module/project/include/details_view.php
@@ -3,6 +3,8 @@
 require_once __DIR__ . '/../../../includes/functions.php';
 
 if (!empty($current_project)) {
+    $statusId  = $current_project['status'] ?? null;
+    $priorityId = $current_project['priority'] ?? null;
     $totalTasks = count($tasks ?? []);
     $completedTasks = 0;
     $chartData = [];
@@ -60,12 +62,16 @@ if (!empty($current_project)) {
           <h2 class="text-body-emphasis fw-bolder mb-2"><?= h($current_project['name'] ?? '') ?></h2>
         </div>
         <div class="dropdown d-inline me-2">
-          <?= render_status_badge(
-                $statusMap,
-                $current_project['status'],
-                'dropdown-toggle',
-                ['id' => 'statusBadge', 'data-bs-toggle' => 'dropdown', 'role' => 'button', 'aria-expanded' => 'false']
-            ) ?>
+          <?php if ($statusId !== null): ?>
+            <?= render_status_badge(
+                  $statusMap,
+                  $statusId,
+                  'dropdown-toggle',
+                  ['id' => 'statusBadge', 'data-bs-toggle' => 'dropdown', 'role' => 'button', 'aria-expanded' => 'false']
+              ) ?>
+          <?php else: ?>
+            <span class="text-muted">No status</span>
+          <?php endif; ?>
           <ul class="dropdown-menu" aria-labelledby="statusBadge">
             <?php foreach ($statusMap as $sid => $s): ?>
               <li><a class="dropdown-item project-field-option" href="#" data-field="status" data-value="<?= (int)$sid ?>" data-color="<?= h($s['color_class'] ?? 'secondary') ?>"><?= h($s['label'] ?? '') ?></a></li>
@@ -73,12 +79,16 @@ if (!empty($current_project)) {
           </ul>
         </div>
         <div class="dropdown d-inline">
-          <?= render_status_badge(
-                $priorityMap,
-                $current_project['priority'],
-                'dropdown-toggle',
-                ['id' => 'priorityBadge', 'data-bs-toggle' => 'dropdown', 'role' => 'button', 'aria-expanded' => 'false']
-            ) ?>
+          <?php if ($priorityId !== null): ?>
+            <?= render_status_badge(
+                  $priorityMap,
+                  $priorityId,
+                  'dropdown-toggle',
+                  ['id' => 'priorityBadge', 'data-bs-toggle' => 'dropdown', 'role' => 'button', 'aria-expanded' => 'false']
+              ) ?>
+          <?php else: ?>
+            <span class="text-muted">No priority</span>
+          <?php endif; ?>
           <ul class="dropdown-menu" aria-labelledby="priorityBadge">
             <?php foreach ($priorityMap as $pid => $p): ?>
               <li><a class="dropdown-item project-field-option" href="#" data-field="priority" data-value="<?= (int)$pid ?>" data-color="<?= h($p['color_class'] ?? 'secondary') ?>"><?= h($p['label'] ?? '') ?></a></li>


### PR DESCRIPTION
## Summary
- allow `render_status_badge` to accept null IDs and fall back to an "Unknown" badge
- guard project detail view from null status/priority and show placeholders when missing
- preselect default lookup values for new projects and persist priority on create

## Testing
- `php -l includes/lookup_helpers.php module/project/include/details_view.php module/project/include/create_edit.php module/project/functions/create.php`


------
https://chatgpt.com/codex/tasks/task_e_68a7edefdee48333b753dd37ea999557