### PR TITLE
Ensure header redirects occur before admin header

### DIFF
--- a/admin/README.md
+++ b/admin/README.md
@@ -9,3 +9,7 @@ Admin pages check entries in the `admin_permissions` table. User management page
 - module `users` with actions `create`, `read`, `update`, and `delete`
 
 These permissions are automatically granted to the default **Admin** role.
+
+## Redirect Handling
+
+Pages that may trigger a `header()` redirect should execute that logic before including `admin_header.php`. This ordering avoids the "headers already sent" warning and keeps redirect behaviour consistent across modules.

--- a/admin/orgs/organization_edit.php
+++ b/admin/orgs/organization_edit.php
@@ -1,5 +1,7 @@
 <?php
-require '../admin_header.php';
+require_once __DIR__ . '/../../includes/admin_guard.php';
+require_once __DIR__ . '/../../includes/functions.php';
+require_once __DIR__ . '/../../includes/helpers.php';
 
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 $name = '';
@@ -51,6 +53,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   header('Location: index.php');
   exit;
 }
+
+require '../admin_header.php';
 ?>
 <h2 class="mb-4"><?= $id ? 'Edit' : 'Add'; ?> Organization</h2>
 <form method="post">

--- a/admin/person/edit.php
+++ b/admin/person/edit.php
@@ -1,5 +1,7 @@
 <?php
-require_once '../admin_header.php';
+require_once __DIR__ . '/../../includes/admin_guard.php';
+require_once __DIR__ . '/../../includes/functions.php';
+require_once __DIR__ . '/../../includes/helpers.php';
 
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 $first_name = $last_name = $email = $dob = '';
@@ -194,6 +196,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     exit;
   }
 }
+ 
+require '../admin_header.php';
 ?>
 <h2 class="mb-4"><?= $id ? 'Edit' : 'Add'; ?> Person</h2>
 <form method="post">

--- a/admin/roles/edit.php
+++ b/admin/roles/edit.php
@@ -1,5 +1,7 @@
 <?php
-require '../admin_header.php';
+require_once __DIR__ . '/../../includes/admin_guard.php';
+require_once __DIR__ . '/../../includes/functions.php';
+require_once __DIR__ . '/../../includes/helpers.php';
 
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 $name = '';
@@ -59,6 +61,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   header('Location: index.php');
   exit;
 }
+
+require '../admin_header.php';
 ?>
 <h2 class="mb-4"><?= $id ? 'Edit Role' : 'Add Role'; ?></h2>
 <form method="post">

--- a/admin/roles/permission_edit.php
+++ b/admin/roles/permission_edit.php
@@ -1,5 +1,7 @@
 <?php
-require '../admin_header.php';
+require_once __DIR__ . '/../../includes/admin_guard.php';
+require_once __DIR__ . '/../../includes/functions.php';
+require_once __DIR__ . '/../../includes/helpers.php';
 
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 $module = '';
@@ -41,6 +43,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   header('Location: permissions.php');
   exit;
 }
+
+require '../admin_header.php';
 ?>
 <h2 class="mb-4"><?= $id ? 'Edit Permission' : 'Add Permission'; ?></h2>
 <form method="post">


### PR DESCRIPTION
## Summary
- Reorder admin pages so `admin_header.php` is included only after any `header()` redirects
- Note redirect handling requirement in admin README for consistent module behaviour

## Testing
- `php -l admin/orgs/organization_edit.php`
- `php -l admin/roles/edit.php`
- `php -l admin/roles/permission_edit.php`
- `php -l admin/person/edit.php`


------
https://chatgpt.com/codex/tasks/task_e_68a7f015f7c483338443b4db07431cc0