### PR TITLE
Defer admin header include in organization edit

### DIFF
--- a/admin/orgs/organization_edit.php
+++ b/admin/orgs/organization_edit.php
@@ -1,6 +1,4 @@
 <?php
-require '../admin_header.php';
-
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 $name = '';
 $main_person = null;
@@ -51,6 +49,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   header('Location: index.php');
   exit;
 }
+
+require '../admin_header.php';
 ?>
 <h2 class="mb-4"><?= $id ? 'Edit' : 'Add'; ?> Organization</h2>
 <form method="post">


### PR DESCRIPTION
## Summary
- Move `admin_header.php` include until after POST processing to prevent premature HTML output.

## Testing
- `php -l admin/orgs/organization_edit.php`


------
https://chatgpt.com/codex/tasks/task_e_68a7f013b2e883338f51979f8cd2e669