### PR TITLE
Handle person edit redirects before rendering header

### DIFF
--- a/admin/person/edit.php
+++ b/admin/person/edit.php
@@ -1,5 +1,7 @@
 <?php
-require_once '../admin_header.php';
+require_once __DIR__ . '/../../includes/admin_guard.php';
+require_once __DIR__ . '/../../includes/functions.php';
+require_once __DIR__ . '/../../includes/helpers.php';
 
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 $first_name = $last_name = $email = $dob = '';
@@ -194,6 +196,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     exit;
   }
 }
+
+require_once '../admin_header.php';
 ?>
 <h2 class="mb-4"><?= $id ? 'Edit' : 'Add'; ?> Person</h2>
 <form method="post">


### PR DESCRIPTION
## Summary
- Load admin guard and helpers before handling person edits
- Defer admin header include until after all redirects

## Testing
- `php -l admin/person/edit.php`

------
https://chatgpt.com/codex/tasks/task_e_68a7f0147f288333894c4b28e455536f