### PR TITLE
Enable output buffering and flush footer

### DIFF
--- a/includes/html_footer.php
+++ b/includes/html_footer.php
@@ -17,6 +17,7 @@
           <label class="mb-0 theme-control-toggle-label theme-control-toggle-light" for="themeControlToggle" data-bs-toggle="tooltip" data-bs-placement="left" data-bs-title="Switch theme" style="height:32px;width:32px;"><span class="icon" data-feather="moon"></span></label>
           <label class="mb-0 theme-control-toggle-label theme-control-toggle-dark" for="themeControlToggle" data-bs-toggle="tooltip" data-bs-placement="left" data-bs-title="Switch theme" style="height:32px;width:32px;"><span class="icon" data-feather="sun"></span></label>
         </div>
-    </div>
   </div>
+</div>
 </footer>
+<?php ob_end_flush(); ?>

--- a/includes/php_header.php
+++ b/includes/php_header.php
@@ -1,4 +1,6 @@
-<?php if (session_status() !== PHP_SESSION_ACTIVE) {
+<?php
+ob_start();
+if (session_status() !== PHP_SESSION_ACTIVE) {
   session_start();
 }
 date_default_timezone_set('America/Denver');


### PR DESCRIPTION
## Summary
- Start PHP output buffering before session initialization in `php_header.php`
- Flush and end the output buffer in the shared HTML footer
- Searched for stray whitespace outside PHP tags to avoid unintended early output

## Testing
- `php -l includes/php_header.php`
- `php -l includes/html_footer.php`
- `rg '^\s+<\?php' -n`


------
https://chatgpt.com/codex/tasks/task_e_68a7f015c3888333a9d47f616ec4e9d5