### PR TITLE
Display user name in navigation bar dropdown

### DIFF
--- a/includes/navigation.php
+++ b/includes/navigation.php
@@ -105,12 +105,11 @@
         </div>
       </li>
 
-        <li class="nav-item dropdown"><a class="nav-link lh-1 pe-0" id="navbarDropdownUser" href="#!" role="button" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-haspopup="true" aria-expanded="false">
-            <div class="avatar avatar-l ">
-
+        <li class="nav-item dropdown"><a class="nav-link lh-1 pe-0 d-flex align-items-center" id="navbarDropdownUser" href="#!" role="button" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-haspopup="true" aria-expanded="false">
+            <div class="avatar avatar-l">
               <img class="rounded-circle" src="<?php echo getURLDir() . (!empty($this_user_profile_pic) ? $this_user_profile_pic : 'assets/img/team/avatar.webp'); ?>" alt="<?php echo $this_user_name; ?>" />
-
             </div>
+            <span class="ms-2 d-none d-sm-inline"><?php echo $this_user_name; ?></span>
           </a>
           <div class="dropdown-menu dropdown-menu-end navbar-dropdown-caret py-0 dropdown-profile shadow border" aria-labelledby="navbarDropdownUser">
             <div class="card position-relative border-0">


### PR DESCRIPTION
## Summary
- Show logged-in user's full name beside avatar in top navigation

## Testing
- `php -l includes/navigation.php`
- `php -l includes/php_header.php`


------
https://chatgpt.com/codex/tasks/task_e_68a87f8015408333bd70ca7c6b137d32