### PR TITLE
Add project type selection for projects

### DIFF
--- a/_SQL/atlis.sql
+++ b/_SQL/atlis.sql
@@ -1944,6 +1944,7 @@ CREATE TABLE `module_projects` (
   `specifications` text DEFAULT NULL,
   `status` int(11) DEFAULT NULL,
   `priority` int(11) DEFAULT NULL,
+  `type` int(11) DEFAULT NULL,
   `start_date` date DEFAULT NULL,
   `complete_date` date DEFAULT NULL,
   `completed` tinyint(1) DEFAULT 0
@@ -1953,14 +1954,14 @@ CREATE TABLE `module_projects` (
 -- Dumping data for table `module_projects`
 --
 
-INSERT INTO `module_projects` (`id`, `user_id`, `user_updated`, `date_created`, `date_updated`, `memo`, `agency_id`, `division_id`, `name`, `description`, `requirements`, `specifications`, `status`, `priority`, `start_date`, `complete_date`, `completed`) VALUES
-(1, 1, 1, '2025-08-19 23:01:08', '2025-08-19 23:04:25', NULL, 2, 2, 'Emailing Sealed Documents (E.S.D)', '', '', '', 29, 56, '2025-08-01', NULL, 0),
-(2, 1, 1, '2025-08-19 23:02:03', '2025-08-19 23:24:13', NULL, 2, 3, 'Bench View', '', '', '', 29, 58, '2025-08-01', NULL, 0),
-(3, 1, 1, '2025-08-20 00:15:31', '2025-08-20 00:42:24', NULL, 2, 2, 'Fee Waiver Icon in Case Header', '', '', '', 31, 57, '2025-04-26', NULL, 0),
-(4, 1, 1, '2025-08-21 15:38:14', '2025-08-21 15:38:14', NULL, 1, 1, 'ATLIS TECHNOLOGIES - CORE PROJECT', '', '', '', 29, NULL, '2025-08-21', NULL, 0),
-(5, 1, 1, '2025-08-21 18:08:35', '2025-08-21 18:08:35', NULL, 2, 3, 'Judge Mass Reassignment', 'Hi Gia & Davey,\r\n\r\nDo you have any specific requirements or specifications for the Judge Mass Reassignment project? I don’t want to make this any more complex than necessary—at a high level, it should be straightforward. For the sake of example, Judge A is the retiring judge and Judge B is the newly assigned judge.\r\n\r\n\r\nThanks,\r\nDave\r\n', '1) What gets reassigned\r\n-	Reassign all future events currently assigned to Judge A over to Judge B.\r\no	“All” assumes no filters (Case Type, Event Type, etc.).\r\no	“Future” assumes we are not modifying past events.\r\n-	Should any case-level or caseAssignment fields also be updated (for Judge A and/or Judge B)?\r\n\r\n\r\n2) Audit, validation, and proof checking\r\n-	Do you need audit artifacts (e.g., before/after counts, per-case change logs with timestamp/user, downloadable CSV)?\r\n-	Should we add guardrails (e.g., exclude sealed/closed cases, skip in-progress or same-day events)?\r\n\r\n\r\n3) Execution & UX\r\n-	Once Judge A → Judge B is selected, should the process run automatically in the background, or would you prefer a preview/confirm step with progress tracking?\r\n-	Would a summary be useful (e.g., via Search, Report, or Email notification)?', '', 29, NULL, '2025-08-21', NULL, 0),
-(6, 1, 1, '2025-08-21 22:22:02', '2025-08-21 22:22:02', NULL, 1, 1, 'McLean County, IL', '', '', '', 29, 56, '2025-08-21', NULL, 0),
-(7, 1, 1, '2025-08-21 22:25:38', '2025-08-21 22:25:38', NULL, 1, 1, 'JIT 2025 User Conference', '', '', '', 30, 87, '2025-11-13', NULL, 0);
+INSERT INTO `module_projects` (`id`, `user_id`, `user_updated`, `date_created`, `date_updated`, `memo`, `agency_id`, `division_id`, `name`, `description`, `requirements`, `specifications`, `status`, `priority`, `type`, `start_date`, `complete_date`, `completed`) VALUES
+(1, 1, 1, '2025-08-19 23:01:08', '2025-08-19 23:04:25', NULL, 2, 2, 'Emailing Sealed Documents (E.S.D)', '', '', '', 29, 56, NULL, '2025-08-01', NULL, 0),
+(2, 1, 1, '2025-08-19 23:02:03', '2025-08-19 23:24:13', NULL, 2, 3, 'Bench View', '', '', '', 29, 58, NULL, '2025-08-01', NULL, 0),
+(3, 1, 1, '2025-08-20 00:15:31', '2025-08-20 00:42:24', NULL, 2, 2, 'Fee Waiver Icon in Case Header', '', '', '', 31, 57, NULL, '2025-04-26', NULL, 0),
+(4, 1, 1, '2025-08-21 15:38:14', '2025-08-21 15:38:14', NULL, 1, 1, 'ATLIS TECHNOLOGIES - CORE PROJECT', '', '', '', 29, NULL, NULL, '2025-08-21', NULL, 0),
+(5, 1, 1, '2025-08-21 18:08:35', '2025-08-21 18:08:35', NULL, 2, 3, 'Judge Mass Reassignment', 'Hi Gia & Davey,\r\n\r\nDo you have any specific requirements or specifications for the Judge Mass Reassignment project? I don’t want to make this any more complex than necessary—at a high level, it should be straightforward. For the sake of example, Judge A is the retiring judge and Judge B is the newly assigned judge.\r\n\r\n\r\nThanks,\r\nDave\r\n', '1) What gets reassigned\r\n-	Reassign all future events currently assigned to Judge A over to Judge B.\r\no	“All” assumes no filters (Case Type, Event Type, etc.).\r\no	“Future” assumes we are not modifying past events.\r\n-	Should any case-level or caseAssignment fields also be updated (for Judge A and/or Judge B)?\r\n\r\n\r\n2) Audit, validation, and proof checking\r\n-	Do you need audit artifacts (e.g., before/after counts, per-case change logs with timestamp/user, downloadable CSV)?\r\n-	Should we add guardrails (e.g., exclude sealed/closed cases, skip in-progress or same-day events)?\r\n\r\n\r\n3) Execution & UX\r\n-	Once Judge A → Judge B is selected, should the process run automatically in the background, or would you prefer a preview/confirm step with progress tracking?\r\n-	Would a summary be useful (e.g., via Search, Report, or Email notification)?', ', '', 29, NULL, NULL, '2025-08-21', NULL, 0),
+(6, 1, 1, '2025-08-21 22:22:02', '2025-08-21 22:22:02', NULL, 1, 1, 'McLean County, IL', '', '', '', 29, 56, NULL, '2025-08-21', NULL, 0),
+(7, 1, 1, '2025-08-21 22:25:38', '2025-08-21 22:25:38', NULL, 1, 1, 'JIT 2025 User Conference', '', '', '', 30, 87, NULL, '2025-11-13', NULL, 0);
 
 -- --------------------------------------------------------
 
@@ -2740,7 +2741,8 @@ ALTER TABLE `module_projects`
   ADD KEY `fk_module_projects_agency_id` (`agency_id`),
   ADD KEY `fk_module_projects_division_id` (`division_id`),
   ADD KEY `fk_module_projects_status` (`status`),
-  ADD KEY `fk_module_projects_priority` (`priority`);
+  ADD KEY `fk_module_projects_priority` (`priority`),
+  ADD KEY `fk_module_projects_type` (`type`);
 
 --
 -- Indexes for table `module_projects_assignments`
@@ -3358,7 +3360,8 @@ ALTER TABLE `module_projects`
   ADD CONSTRAINT `fk_module_projects_agency_id` FOREIGN KEY (`agency_id`) REFERENCES `module_agency` (`id`),
   ADD CONSTRAINT `fk_module_projects_division_id` FOREIGN KEY (`division_id`) REFERENCES `module_division` (`id`),
   ADD CONSTRAINT `fk_module_projects_priority_id` FOREIGN KEY (`priority`) REFERENCES `lookup_list_items` (`id`),
-  ADD CONSTRAINT `fk_module_projects_status_id` FOREIGN KEY (`status`) REFERENCES `lookup_list_items` (`id`);
+  ADD CONSTRAINT `fk_module_projects_status_id` FOREIGN KEY (`status`) REFERENCES `lookup_list_items` (`id`),
+  ADD CONSTRAINT `fk_module_projects_type_id` FOREIGN KEY (`type`) REFERENCES `lookup_list_items` (`id`);
 
 --
 -- Constraints for table `module_projects_assignments`

--- a/module/project/functions/create.php
+++ b/module/project/functions/create.php
@@ -8,6 +8,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   $name = $_POST['name'] ?? '';
   $status   = $_POST['status'] ?? null;
   $priority = $_POST['priority'] ?? null;
+  $type     = $_POST['type'] ?? null;
   $description = $_POST['description'] ?? null;
   $requirements = $_POST['requirements'] ?? null;
   $specifications = $_POST['specifications'] ?? null;
@@ -15,7 +16,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   $agency_id = $_POST['agency_id'] ?? null;
   $division_id = $_POST['division_id'] ?? null;
 
-  $stmt = $pdo->prepare('INSERT INTO module_projects (user_id, user_updated, agency_id, division_id, name, description, requirements, specifications, status, priority, start_date) VALUES (:uid, :uid, :agency_id, :division_id, :name, :description, :requirements, :specifications, :status, :priority, :start_date)');
+  $stmt = $pdo->prepare('INSERT INTO module_projects (user_id, user_updated, agency_id, division_id, name, description, requirements, specifications, status, priority, type, start_date) VALUES (:uid, :uid, :agency_id, :division_id, :name, :description, :requirements, :specifications, :status, :priority, :type, :start_date)');
   $stmt->execute([
     ':uid' => $this_user_id,
     ':agency_id' => $agency_id,
@@ -26,6 +27,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     ':specifications' => $specifications,
     ':status' => $status,
     ':priority' => $priority,
+    ':type' => $type,
     ':start_date' => $start_date
   ]);
   $id = $pdo->lastInsertId();
@@ -46,6 +48,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
       'specifications' => $specifications,
       'status' => $status,
       'priority' => $priority,
+      'type' => $type,
       'start_date' => $start_date
     ]),
     'Created project'

--- a/module/project/functions/update.php
+++ b/module/project/functions/update.php
@@ -6,14 +6,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   $id = (int)($_POST['id'] ?? 0);
   $name = $_POST['name'] ?? '';
   $status = $_POST['status'] ?? null;
+  $type   = $_POST['type'] ?? null;
   $description = $_POST['description'] ?? null;
 
   if ($id) {
-    $stmt = $pdo->prepare('UPDATE module_projects SET name = :name, status = :status, description = :description, user_updated = :uid WHERE id = :id');
+    $stmt = $pdo->prepare('UPDATE module_projects SET name = :name, status = :status, type = :type, description = :description, user_updated = :uid WHERE id = :id');
     $stmt->execute([
       ':uid' => $this_user_id,
       ':name' => $name,
       ':status' => $status,
+      ':type' => $type,
       ':description' => $description,
       ':id' => $id
     ]);

--- a/module/project/include/create_edit.php
+++ b/module/project/include/create_edit.php
@@ -5,6 +5,7 @@ require_permission('project','create');
 // Ensure lookup lists are available
 $statusMap   = $statusMap   ?? get_lookup_items($pdo, 'PROJECT_STATUS');
 $priorityMap = $priorityMap ?? get_lookup_items($pdo, 'PROJECT_PRIORITY');
+$typeMap     = $typeMap     ?? get_lookup_items($pdo, 'PROJECT_TYPE');
 ?>
 <nav class="mb-3" aria-label="breadcrumb">
   <ol class="breadcrumb mb-0">
@@ -60,6 +61,26 @@ $priorityMap = $priorityMap ?? get_lookup_items($pdo, 'PROJECT_PRIORITY');
             <?php endforeach; ?>
           </select>
           <label for="projectPriority">Priority</label>
+        </div>
+      </div>
+      <div class="col-sm-6 col-md-4">
+        <div class="form-floating">
+          <?php
+            $hasTypeDefault = false;
+            foreach ($typeMap as $t) {
+              if (!empty($t['is_default'])) {
+                $hasTypeDefault = true;
+                break;
+              }
+            }
+          ?>
+          <select class="form-select" id="projectType" name="type" required>
+            <option value="" <?= $hasTypeDefault ? '' : 'selected'; ?>>Select type</option>
+            <?php foreach ($typeMap as $t): ?>
+              <option value="<?= h($t['id']); ?>" <?= !empty($t['is_default']) ? 'selected' : ''; ?>><?= h($t['label']); ?></option>
+            <?php endforeach; ?>
+          </select>
+          <label for="projectType">Type</label>
         </div>
       </div>
       <div class="col-sm-6 col-md-4">

--- a/module/project/include/create_edit_view.php
+++ b/module/project/include/create_edit_view.php
@@ -3,6 +3,13 @@
 require_once __DIR__ . '/../../../includes/functions.php';
 $editing = !empty($current_project);
 $actionUrl = $editing ? 'functions/update.php' : 'functions/create.php';
+$defaultTypeId = '';
+foreach ($typeMap as $id => $t) {
+  if (!empty($t['is_default'])) {
+    $defaultTypeId = $id;
+    break;
+  }
+}
 ?>
 <form class="row g-3 mb-6" method="post" action="<?php echo $actionUrl; ?>">
   <?php if ($editing): ?>
@@ -22,6 +29,19 @@ $actionUrl = $editing ? 'functions/update.php' : 'functions/create.php';
         <?php endforeach; ?>
       </select>
       <label for="projectStatus">Status</label>
+    </div>
+  </div>
+  <div class="col-12">
+    <div class="form-floating">
+      <select class="form-select" id="projectType" name="type">
+        <option value="" <?php echo $defaultTypeId ? '' : 'selected'; ?>>Select type</option>
+        <?php foreach ($typeMap as $id => $type): ?>
+          <option value="<?php echo h($id); ?>" <?php
+            echo ($editing ? (($current_project['type'] ?? '') == $id) : ($defaultTypeId == $id)) ? 'selected' : '';
+          ?>><?php echo h($type['label']); ?></option>
+        <?php endforeach; ?>
+      </select>
+      <label for="projectType">Type</label>
     </div>
   </div>
   <div class="col-12 gy-3">

--- a/module/project/index.php
+++ b/module/project/index.php
@@ -11,6 +11,7 @@ if ($action === 'create' && $_SERVER['REQUEST_METHOD'] === 'POST') {
 if ($action === 'create') {
   require_permission('project', 'create');
   $statusMap = get_lookup_items($pdo, 'PROJECT_STATUS');
+  $typeMap   = get_lookup_items($pdo, 'PROJECT_TYPE');
   $agencies = $pdo->query('SELECT id, name FROM module_agency ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
   $divisions = $pdo->query('SELECT id, name FROM module_division ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
   require '../../includes/html_header.php';
@@ -84,6 +85,7 @@ $priorityItems = get_lookup_items($pdo, 'PROJECT_PRIORITY');
 
     $statusMap   = array_column(get_lookup_items($pdo,'PROJECT_STATUS'), null, 'id');
     $priorityMap = array_column(get_lookup_items($pdo,'PROJECT_PRIORITY'), null, 'id');
+    $typeMap     = array_column(get_lookup_items($pdo,'PROJECT_TYPE'), null, 'id');
     $fileTypes   = get_lookup_items($pdo, 'PROJECT_FILE_TYPE');
     $fileStatuses = get_lookup_items($pdo, 'PROJECT_FILE_STATUS');
     $modalWidths = [
@@ -176,14 +178,17 @@ $priorityItems = get_lookup_items($pdo, 'PROJECT_PRIORITY');
         $availableStmt = $pdo->query("SELECT u.id AS user_id, CONCAT(p.first_name, ' ', p.last_name) AS name FROM users u LEFT JOIN person p ON u.id = p.user_id ORDER BY name");
       }
       $availableUsers = $availableStmt->fetchAll(PDO::FETCH_ASSOC);
-    }
   }
+}
 
 if ($action === 'create-edit') {
   if (!empty($current_project)) {
     require_permission('project', 'update');
   } else {
     require_permission('project', 'create');
+    $statusMap   = array_column(get_lookup_items($pdo,'PROJECT_STATUS'), null, 'id');
+    $priorityMap = array_column(get_lookup_items($pdo,'PROJECT_PRIORITY'), null, 'id');
+    $typeMap     = array_column(get_lookup_items($pdo,'PROJECT_TYPE'), null, 'id');
   }
 }
 


### PR DESCRIPTION
## Summary
- add `type` column to `module_projects` and sample data
- support project type in create/update handlers and index controller
- expose Type selection in create/edit forms honoring default lookup items

## Testing
- `php -l module/project/functions/create.php`
- `php -l module/project/functions/update.php`
- `php -l module/project/index.php`
- `php -l module/project/include/create_edit.php`
- `php -l module/project/include/create_edit_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68a87f76a2f08333911a4ccdd5fd08c7