### PR TITLE
Implement person assignment tables and admin UI

### DIFF
--- a/_SQL/atlis.sql
+++ b/_SQL/atlis.sql
@@ -1209,7 +1209,10 @@ INSERT INTO `lookup_lists` (`id`, `user_id`, `user_updated`, `date_created`, `da
 (28, 1, 1, '2025-08-20 21:07:53', '2025-08-20 21:12:32', '', 'PERSON_ADDRESS_STATUS', ''),
 (29, 1, 1, '2025-08-20 21:07:59', '2025-08-20 21:10:50', '', 'PERSON_PHONE_STATUS', ''),
 (30, 1, 1, '2025-08-21 00:00:00', '2025-08-21 00:00:00', NULL, 'US_STATES', 'United States states and DC'),
-(31, 1, 1, '2025-08-22 08:16:54', '2025-08-22 08:18:20', '', 'PROJECT_TYPE', 'Normal Project, SoW, etc.');
+(31, 1, 1, '2025-08-22 08:16:54', '2025-08-22 08:18:20', '', 'PROJECT_TYPE', 'Normal Project, SoW, etc.'),
+(32, 1, 1, '2025-08-22 00:00:00', '2025-08-22 00:00:00', NULL, 'ORGANIZATION_PERSON_ROLES', 'Roles for persons assigned to organizations'),
+(33, 1, 1, '2025-08-22 00:00:00', '2025-08-22 00:00:00', NULL, 'AGENCY_PERSON_ROLES', 'Roles for persons assigned to agencies'),
+(34, 1, 1, '2025-08-22 00:00:00', '2025-08-22 00:00:00', NULL, 'DIVISION_PERSON_ROLES', 'Roles for persons assigned to divisions');
 
 -- --------------------------------------------------------
 
@@ -1389,7 +1392,10 @@ INSERT INTO `lookup_list_items` (`id`, `user_id`, `user_updated`, `date_created`
 (180, 1, 1, '2025-08-21 15:32:54', '2025-08-21 15:32:54', NULL, 24, 'Email Reply', 'EMAILREPLY', 0, '2025-08-21', NULL),
 (181, 1, 1, '2025-08-21 15:33:04', '2025-08-21 15:33:04', NULL, 24, 'Send Proposal', 'SENDPROPOSAL', 0, '2025-08-21', NULL),
 (182, 1, 1, '2025-08-22 08:17:19', '2025-08-22 08:17:19', NULL, 31, 'Project', 'PROJECT', 0, '2025-08-22', NULL),
-(183, 1, 1, '2025-08-22 08:17:32', '2025-08-22 08:17:32', NULL, 31, 'Statement of Work', 'STATEMENTOFWORK', 0, '2025-08-22', NULL);
+(183, 1, 1, '2025-08-22 08:17:32', '2025-08-22 08:17:32', NULL, 31, 'Statement of Work', 'STATEMENTOFWORK', 0, '2025-08-22', NULL),
+(184, 1, 1, '2025-08-22 00:00:00', '2025-08-22 00:00:00', NULL, 32, 'Member', 'MEMBER', 1, '2025-08-22', NULL),
+(185, 1, 1, '2025-08-22 00:00:00', '2025-08-22 00:00:00', NULL, 33, 'Member', 'MEMBER', 1, '2025-08-22', NULL),
+(186, 1, 1, '2025-08-22 00:00:00', '2025-08-22 00:00:00', NULL, 34, 'Member', 'MEMBER', 1, '2025-08-22', NULL);
 
 -- --------------------------------------------------------
 
@@ -1820,6 +1826,63 @@ INSERT INTO `module_division` (`id`, `user_id`, `user_updated`, `date_created`, 
 -- --------------------------------------------------------
 
 --
+-- Table structure for table `module_organization_persons`
+--
+
+CREATE TABLE `module_organization_persons` (
+  `id` int(11) NOT NULL,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT current_timestamp(),
+  `date_updated` datetime DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  `memo` text DEFAULT NULL,
+  `organization_id` int(11) NOT NULL,
+  `person_id` int(11) NOT NULL,
+  `role_id` int(11) DEFAULT NULL,
+  `is_lead` tinyint(1) DEFAULT 0
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `module_agency_persons`
+--
+
+CREATE TABLE `module_agency_persons` (
+  `id` int(11) NOT NULL,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT current_timestamp(),
+  `date_updated` datetime DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  `memo` text DEFAULT NULL,
+  `agency_id` int(11) NOT NULL,
+  `person_id` int(11) NOT NULL,
+  `role_id` int(11) DEFAULT NULL,
+  `is_lead` tinyint(1) DEFAULT 0
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `module_division_persons`
+--
+
+CREATE TABLE `module_division_persons` (
+  `id` int(11) NOT NULL,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT current_timestamp(),
+  `date_updated` datetime DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  `memo` text DEFAULT NULL,
+  `division_id` int(11) NOT NULL,
+  `person_id` int(11) NOT NULL,
+  `role_id` int(11) DEFAULT NULL,
+  `is_lead` tinyint(1) DEFAULT 0
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+
+--
 -- Table structure for table `module_kanban_boards`
 --
 
@@ -2220,9 +2283,6 @@ CREATE TABLE `person` (
   `last_name` varchar(100) DEFAULT NULL,
   `email` varchar(255) DEFAULT NULL,
   `gender_id` int(11) DEFAULT NULL,
-  `organization_id` int(11) DEFAULT NULL,
-  `agency_id` int(11) DEFAULT NULL,
-  `division_id` int(11) DEFAULT NULL,
   `dob` date DEFAULT NULL,
   `user_updated` int(11) DEFAULT NULL,
   `date_created` datetime DEFAULT current_timestamp(),
@@ -2234,18 +2294,18 @@ CREATE TABLE `person` (
 -- Dumping data for table `person`
 --
 
-INSERT INTO `person` (`id`, `user_id`, `first_name`, `last_name`, `email`, `gender_id`, `organization_id`, `agency_id`, `division_id`, `dob`, `user_updated`, `date_created`, `date_updated`, `memo`) VALUES
-(1, 1, 'Dave', 'Wilkins', NULL, 59, NULL, NULL, NULL, '1992-02-20', 1, '2025-08-08 21:52:52', '2025-08-19 23:03:53', NULL),
-(2, 2, 'Sean', 'Cadina', NULL, 59, NULL, NULL, NULL, NULL, 1, '2025-08-15 00:11:11', '2025-08-19 23:23:09', NULL),
-(5, 4, 'Tyler', 'Jessop', NULL, 59, NULL, NULL, NULL, NULL, 1, '2025-08-17 22:17:49', '2025-08-19 23:23:32', NULL),
-(12, 5, 'RJ', 'Calara', NULL, 59, NULL, NULL, NULL, NULL, 1, '2025-08-19 23:21:53', '2025-08-19 23:21:53', NULL),
-(13, 6, 'Kasper', 'Krynski', NULL, 59, NULL, NULL, NULL, NULL, 1, '2025-08-19 23:22:44', '2025-08-19 23:22:44', NULL),
-(14, 7, 'Mileny', 'Valdez', NULL, 60, NULL, NULL, NULL, NULL, 1, '2025-08-19 23:27:09', '2025-08-19 23:27:09', NULL),
-(23, 8, 'Kenny', 'Reynolds', NULL, 59, NULL, NULL, NULL, NULL, 1, '2025-08-20 14:44:46', '2025-08-20 14:44:46', NULL),
-(24, 9, 'Richard', 'Sprague', NULL, 59, NULL, NULL, NULL, NULL, 1, '2025-08-20 15:14:36', '2025-08-20 15:14:36', NULL),
-(27, 10, 'Emma', 'Baylor', NULL, 60, NULL, NULL, NULL, NULL, 1, '2025-08-20 20:47:24', '2025-08-20 20:47:24', NULL),
-(30, NULL, 'Keith', 'Grant', 'KGrant@lakecountyil.gov', 59, 2, 3, NULL, NULL, 1, '2025-08-20 21:03:51', '2025-08-21 02:17:10', NULL),
-(31, NULL, 'Lonnie', 'Renda', 'LRenda@LakeCountyIL.gov', 59, 2, 4, NULL, NULL, 1, '2025-08-21 02:15:50', '2025-08-21 02:17:20', NULL);
+INSERT INTO `person` (`id`, `user_id`, `first_name`, `last_name`, `email`, `gender_id`, `dob`, `user_updated`, `date_created`, `date_updated`, `memo`) VALUES
+(1, 1, 'Dave', 'Wilkins', NULL, 59, '1992-02-20', 1, '2025-08-08 21:52:52', '2025-08-19 23:03:53', NULL),
+(2, 2, 'Sean', 'Cadina', NULL, 59, NULL, 1, '2025-08-15 00:11:11', '2025-08-19 23:23:09', NULL),
+(5, 4, 'Tyler', 'Jessop', NULL, 59, NULL, 1, '2025-08-17 22:17:49', '2025-08-19 23:23:32', NULL),
+(12, 5, 'RJ', 'Calara', NULL, 59, NULL, 1, '2025-08-19 23:21:53', '2025-08-19 23:21:53', NULL),
+(13, 6, 'Kasper', 'Krynski', NULL, 59, NULL, 1, '2025-08-19 23:22:44', '2025-08-19 23:22:44', NULL),
+(14, 7, 'Mileny', 'Valdez', NULL, 60, NULL, 1, '2025-08-19 23:27:09', '2025-08-19 23:27:09', NULL),
+(23, 8, 'Kenny', 'Reynolds', NULL, 59, NULL, 1, '2025-08-20 14:44:46', '2025-08-20 14:44:46', NULL),
+(24, 9, 'Richard', 'Sprague', NULL, 59, NULL, 1, '2025-08-20 15:14:36', '2025-08-20 15:14:36', NULL),
+(27, 10, 'Emma', 'Baylor', NULL, 60, NULL, 1, '2025-08-20 20:47:24', '2025-08-20 20:47:24', NULL),
+(30, NULL, 'Keith', 'Grant', 'KGrant@lakecountyil.gov', 59, NULL, 1, '2025-08-20 21:03:51', '2025-08-21 02:17:10', NULL),
+(31, NULL, 'Lonnie', 'Renda', 'LRenda@LakeCountyIL.gov', 59, NULL, 1, '2025-08-21 02:15:50', '2025-08-21 02:17:20', NULL);
 
 -- --------------------------------------------------------
 
@@ -2693,6 +2753,39 @@ ALTER TABLE `module_division`
   ADD KEY `fk_module_division_status` (`status`);
 
 --
+-- Indexes for table `module_organization_persons`
+--
+ALTER TABLE `module_organization_persons`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `fk_module_organization_persons_user_id` (`user_id`),
+  ADD KEY `fk_module_organization_persons_user_updated` (`user_updated`),
+  ADD KEY `fk_module_organization_persons_organization_id` (`organization_id`),
+  ADD KEY `fk_module_organization_persons_person_id` (`person_id`),
+  ADD KEY `fk_module_organization_persons_role_id` (`role_id`);
+
+--
+-- Indexes for table `module_agency_persons`
+--
+ALTER TABLE `module_agency_persons`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `fk_module_agency_persons_user_id` (`user_id`),
+  ADD KEY `fk_module_agency_persons_user_updated` (`user_updated`),
+  ADD KEY `fk_module_agency_persons_agency_id` (`agency_id`),
+  ADD KEY `fk_module_agency_persons_person_id` (`person_id`),
+  ADD KEY `fk_module_agency_persons_role_id` (`role_id`);
+
+--
+-- Indexes for table `module_division_persons`
+--
+ALTER TABLE `module_division_persons`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `fk_module_division_persons_user_id` (`user_id`),
+  ADD KEY `fk_module_division_persons_user_updated` (`user_updated`),
+  ADD KEY `fk_module_division_persons_division_id` (`division_id`),
+  ADD KEY `fk_module_division_persons_person_id` (`person_id`),
+  ADD KEY `fk_module_division_persons_role_id` (`role_id`);
+
+--
 -- Indexes for table `module_kanban_boards`
 --
 ALTER TABLE `module_kanban_boards`
@@ -2823,9 +2916,7 @@ ALTER TABLE `person`
   ADD UNIQUE KEY `fk_person_user_id` (`user_id`),
   ADD KEY `fk_person_user_updated` (`user_updated`),
   ADD KEY `fk_person_gender_id` (`gender_id`),
-  ADD KEY `fk_person_organization_id` (`organization_id`),
-  ADD KEY `fk_person_agency_id` (`agency_id`),
-  ADD KEY `fk_person_division_id` (`division_id`);
+  ADD KEY `fk_person_gender_id` (`gender_id`);
 
 --
 -- Indexes for table `person_addresses`
@@ -2967,13 +3058,13 @@ ALTER TABLE `audit_log`
 -- AUTO_INCREMENT for table `lookup_lists`
 --
 ALTER TABLE `lookup_lists`
-  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=32;
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=35;
 
 --
 -- AUTO_INCREMENT for table `lookup_list_items`
 --
 ALTER TABLE `lookup_list_items`
-  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=184;
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=187;
 
 --
 -- AUTO_INCREMENT for table `lookup_list_item_attributes`
@@ -3040,6 +3131,24 @@ ALTER TABLE `module_contractors_status_history`
 --
 ALTER TABLE `module_division`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=6;
+
+--
+-- AUTO_INCREMENT for table `module_organization_persons`
+--
+ALTER TABLE `module_organization_persons`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT for table `module_agency_persons`
+--
+ALTER TABLE `module_agency_persons`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT for table `module_division_persons`
+--
+ALTER TABLE `module_division_persons`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `module_kanban_boards`
@@ -3330,6 +3439,36 @@ ALTER TABLE `module_division`
   ADD CONSTRAINT `fk_module_division_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`) ON DELETE SET NULL;
 
 --
+-- Constraints for table `module_organization_persons`
+--
+ALTER TABLE `module_organization_persons`
+  ADD CONSTRAINT `fk_module_organization_persons_organization_id` FOREIGN KEY (`organization_id`) REFERENCES `module_organization` (`id`) ON DELETE CASCADE,
+  ADD CONSTRAINT `fk_module_organization_persons_person_id` FOREIGN KEY (`person_id`) REFERENCES `person` (`id`) ON DELETE CASCADE,
+  ADD CONSTRAINT `fk_module_organization_persons_role_id` FOREIGN KEY (`role_id`) REFERENCES `lookup_list_items` (`id`),
+  ADD CONSTRAINT `fk_module_organization_persons_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  ADD CONSTRAINT `fk_module_organization_persons_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`) ON DELETE SET NULL;
+
+--
+-- Constraints for table `module_agency_persons`
+--
+ALTER TABLE `module_agency_persons`
+  ADD CONSTRAINT `fk_module_agency_persons_agency_id` FOREIGN KEY (`agency_id`) REFERENCES `module_agency` (`id`) ON DELETE CASCADE,
+  ADD CONSTRAINT `fk_module_agency_persons_person_id` FOREIGN KEY (`person_id`) REFERENCES `person` (`id`) ON DELETE CASCADE,
+  ADD CONSTRAINT `fk_module_agency_persons_role_id` FOREIGN KEY (`role_id`) REFERENCES `lookup_list_items` (`id`),
+  ADD CONSTRAINT `fk_module_agency_persons_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  ADD CONSTRAINT `fk_module_agency_persons_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`) ON DELETE SET NULL;
+
+--
+-- Constraints for table `module_division_persons`
+--
+ALTER TABLE `module_division_persons`
+  ADD CONSTRAINT `fk_module_division_persons_division_id` FOREIGN KEY (`division_id`) REFERENCES `module_division` (`id`) ON DELETE CASCADE,
+  ADD CONSTRAINT `fk_module_division_persons_person_id` FOREIGN KEY (`person_id`) REFERENCES `person` (`id`) ON DELETE CASCADE,
+  ADD CONSTRAINT `fk_module_division_persons_role_id` FOREIGN KEY (`role_id`) REFERENCES `lookup_list_items` (`id`),
+  ADD CONSTRAINT `fk_module_division_persons_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  ADD CONSTRAINT `fk_module_division_persons_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`) ON DELETE SET NULL;
+
+--
 -- Constraints for table `module_kanban_board_projects`
 --
 ALTER TABLE `module_kanban_board_projects`
@@ -3414,10 +3553,7 @@ ALTER TABLE `module_task_assignments`
 -- Constraints for table `person`
 --
 ALTER TABLE `person`
-  ADD CONSTRAINT `fk_person_agency_id` FOREIGN KEY (`agency_id`) REFERENCES `module_agency` (`id`) ON DELETE SET NULL,
-  ADD CONSTRAINT `fk_person_division_id` FOREIGN KEY (`division_id`) REFERENCES `module_division` (`id`) ON DELETE SET NULL,
   ADD CONSTRAINT `fk_person_gender_id` FOREIGN KEY (`gender_id`) REFERENCES `lookup_list_items` (`id`),
-  ADD CONSTRAINT `fk_person_organization_id` FOREIGN KEY (`organization_id`) REFERENCES `module_organization` (`id`) ON DELETE SET NULL,
   ADD CONSTRAINT `fk_person_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
   ADD CONSTRAINT `fk_person_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`) ON DELETE SET NULL;
 

--- a/admin/orgs/agency_edit.php
+++ b/admin/orgs/agency_edit.php
@@ -106,6 +106,18 @@ $personOptions = $personStmt->fetchAll(PDO::FETCH_KEY_PAIR);
 
 $statusItems   = get_lookup_items($pdo, 'AGENCY_STATUS');
 $statusOptions = array_column($statusItems, 'label', 'id');
+$roleItems     = get_lookup_items($pdo, 'AGENCY_PERSON_ROLES');
+$roleOptions   = array_column($roleItems, 'label', 'id');
+$assignedPersons = [];
+if ($id) {
+  $apStmt = $pdo->prepare('SELECT ap.id, ap.person_id, ap.role_id, ap.is_lead, CONCAT(p.first_name," ",p.last_name) AS name, li.label AS role_label
+                            FROM module_agency_persons ap
+                            JOIN person p ON ap.person_id = p.id
+                            LEFT JOIN lookup_list_items li ON ap.role_id = li.id
+                            WHERE ap.agency_id = :id');
+  $apStmt->execute([':id'=>$id]);
+  $assignedPersons = $apStmt->fetchAll(PDO::FETCH_ASSOC);
+}
 
 require '../admin_header.php';
 ?>
@@ -157,4 +169,57 @@ require '../admin_header.php';
   <button class="btn <?= $btnClass; ?>" type="submit">Save</button>
   <a href="index.php" class="btn btn-secondary">Cancel</a>
 </form>
+<?php if ($id): ?>
+  <hr class="my-4">
+  <h4>Assigned Persons</h4>
+  <table class="table table-sm">
+    <thead>
+      <tr><th>Name</th><th>Role</th><th>Lead</th><th></th></tr>
+    </thead>
+    <tbody>
+      <?php foreach($assignedPersons as $ap): ?>
+        <tr>
+          <td><?= htmlspecialchars($ap['name']); ?></td>
+          <td><?= htmlspecialchars($ap['role_label'] ?? ''); ?></td>
+          <td><?= $ap['is_lead'] ? 'Yes' : 'No'; ?></td>
+          <td>
+            <form method="post" action="functions/agency_remove_person.php" class="d-inline">
+              <input type="hidden" name="assignment_id" value="<?= $ap['id']; ?>">
+              <input type="hidden" name="agency_id" value="<?= $id; ?>">
+              <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+              <button class="btn btn-sm btn-danger" onclick="return confirm('Remove this person?');">Remove</button>
+            </form>
+          </td>
+        </tr>
+      <?php endforeach; ?>
+    </tbody>
+  </table>
+  <form method="post" action="functions/agency_assign_person.php" class="row g-2">
+    <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+    <input type="hidden" name="agency_id" value="<?= $id; ?>">
+    <div class="col-md-4">
+      <select name="person_id" class="form-select" required>
+        <option value="">-- Person --</option>
+        <?php foreach($personOptions as $pid=>$pname): ?>
+          <option value="<?= $pid; ?>"><?= htmlspecialchars($pname); ?></option>
+        <?php endforeach; ?>
+      </select>
+    </div>
+    <div class="col-md-4">
+      <select name="role_id" class="form-select">
+        <option value="">-- Role --</option>
+        <?php foreach($roleOptions as $rid=>$rlabel): ?>
+          <option value="<?= $rid; ?>"><?= htmlspecialchars($rlabel); ?></option>
+        <?php endforeach; ?>
+      </select>
+    </div>
+    <div class="col-md-2 form-check d-flex align-items-center">
+      <input class="form-check-input" type="checkbox" value="1" name="is_lead" id="agencyLeadChk">
+      <label class="form-check-label ms-2" for="agencyLeadChk">Lead</label>
+    </div>
+    <div class="col-md-2">
+      <button class="btn btn-primary" type="submit">Assign</button>
+    </div>
+  </form>
+<?php endif; ?>
 <?php require '../admin_footer.php'; ?>

--- a/admin/orgs/division_edit.php
+++ b/admin/orgs/division_edit.php
@@ -59,6 +59,18 @@ $personOptions = $personStmt->fetchAll(PDO::FETCH_KEY_PAIR);
 
 $statusItems   = get_lookup_items($pdo, 'DIVISION_STATUS');
 $statusOptions = array_column($statusItems, 'label', 'id');
+$roleItems     = get_lookup_items($pdo, 'DIVISION_PERSON_ROLES');
+$roleOptions   = array_column($roleItems, 'label', 'id');
+$assignedPersons = [];
+if ($id) {
+  $apStmt = $pdo->prepare('SELECT dp.id, dp.person_id, dp.role_id, dp.is_lead, CONCAT(p.first_name," ",p.last_name) AS name, li.label AS role_label
+                            FROM module_division_persons dp
+                            JOIN person p ON dp.person_id = p.id
+                            LEFT JOIN lookup_list_items li ON dp.role_id = li.id
+                            WHERE dp.division_id = :id');
+  $apStmt->execute([':id'=>$id]);
+  $assignedPersons = $apStmt->fetchAll(PDO::FETCH_ASSOC);
+}
 
 require '../admin_header.php';
 ?>
@@ -98,4 +110,57 @@ require '../admin_header.php';
   <button class="btn <?= $btnClass; ?>" type="submit">Save</button>
   <a href="index.php" class="btn btn-secondary">Cancel</a>
 </form>
+<?php if ($id): ?>
+  <hr class="my-4">
+  <h4>Assigned Persons</h4>
+  <table class="table table-sm">
+    <thead>
+      <tr><th>Name</th><th>Role</th><th>Lead</th><th></th></tr>
+    </thead>
+    <tbody>
+      <?php foreach($assignedPersons as $ap): ?>
+        <tr>
+          <td><?= htmlspecialchars($ap['name']); ?></td>
+          <td><?= htmlspecialchars($ap['role_label'] ?? ''); ?></td>
+          <td><?= $ap['is_lead'] ? 'Yes' : 'No'; ?></td>
+          <td>
+            <form method="post" action="functions/division_remove_person.php" class="d-inline">
+              <input type="hidden" name="assignment_id" value="<?= $ap['id']; ?>">
+              <input type="hidden" name="division_id" value="<?= $id; ?>">
+              <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+              <button class="btn btn-sm btn-danger" onclick="return confirm('Remove this person?');">Remove</button>
+            </form>
+          </td>
+        </tr>
+      <?php endforeach; ?>
+    </tbody>
+  </table>
+  <form method="post" action="functions/division_assign_person.php" class="row g-2">
+    <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+    <input type="hidden" name="division_id" value="<?= $id; ?>">
+    <div class="col-md-4">
+      <select name="person_id" class="form-select" required>
+        <option value="">-- Person --</option>
+        <?php foreach($personOptions as $pid=>$pname): ?>
+          <option value="<?= $pid; ?>"><?= htmlspecialchars($pname); ?></option>
+        <?php endforeach; ?>
+      </select>
+    </div>
+    <div class="col-md-4">
+      <select name="role_id" class="form-select">
+        <option value="">-- Role --</option>
+        <?php foreach($roleOptions as $rid=>$rlabel): ?>
+          <option value="<?= $rid; ?>"><?= htmlspecialchars($rlabel); ?></option>
+        <?php endforeach; ?>
+      </select>
+    </div>
+    <div class="col-md-2 form-check d-flex align-items-center">
+      <input class="form-check-input" type="checkbox" value="1" name="is_lead" id="divisionLeadChk">
+      <label class="form-check-label ms-2" for="divisionLeadChk">Lead</label>
+    </div>
+    <div class="col-md-2">
+      <button class="btn btn-primary" type="submit">Assign</button>
+    </div>
+  </form>
+<?php endif; ?>
 <?php require '../admin_footer.php'; ?>

--- a/admin/orgs/functions/agency_assign_person.php
+++ b/admin/orgs/functions/agency_assign_person.php
@@ -1,0 +1,23 @@
+<?php
+require '../../../includes/php_header.php';
+$agency_id = (int)($_POST['agency_id'] ?? 0);
+$person_id = (int)($_POST['person_id'] ?? 0);
+$role_id = $_POST['role_id'] !== '' ? (int)$_POST['role_id'] : null;
+$is_lead = isset($_POST['is_lead']) ? 1 : 0;
+$token = $_POST['csrf_token'] ?? '';
+require_permission('agency','update');
+if($token !== ($_SESSION['csrf_token'] ?? '')){
+  header('Location: ../agency_edit.php?id='.$agency_id);
+  exit;
+}
+if($agency_id && $person_id){
+  if($is_lead){
+    $pdo->prepare('UPDATE module_agency_persons SET is_lead=0 WHERE agency_id=:id')->execute([':id'=>$agency_id]);
+  }
+  $stmt = $pdo->prepare('INSERT INTO module_agency_persons (user_id,user_updated,agency_id,person_id,role_id,is_lead) VALUES (:uid,:uid,:aid,:pid,:role,:lead)');
+  $stmt->execute([':uid'=>$this_user_id,':aid'=>$agency_id,':pid'=>$person_id,':role'=>$role_id,':lead'=>$is_lead]);
+  $assignId = $pdo->lastInsertId();
+  admin_audit_log($pdo,$this_user_id,'module_agency_persons',$assignId,'CREATE',null,json_encode(['agency_id'=>$agency_id,'person_id'=>$person_id,'role_id'=>$role_id,'is_lead'=>$is_lead]),'Assigned person');
+}
+header('Location: ../agency_edit.php?id='.$agency_id.'#persons');
+exit;

--- a/admin/orgs/functions/agency_remove_person.php
+++ b/admin/orgs/functions/agency_remove_person.php
@@ -1,0 +1,17 @@
+<?php
+require '../../../includes/php_header.php';
+$assignment_id = (int)($_POST['assignment_id'] ?? 0);
+$agency_id = (int)($_POST['agency_id'] ?? 0);
+$token = $_POST['csrf_token'] ?? '';
+require_permission('agency','update');
+if($token !== ($_SESSION['csrf_token'] ?? '')){
+  header('Location: ../agency_edit.php?id='.$agency_id);
+  exit;
+}
+if($assignment_id){
+  $stmt = $pdo->prepare('DELETE FROM module_agency_persons WHERE id=:id');
+  $stmt->execute([':id'=>$assignment_id]);
+  admin_audit_log($pdo,$this_user_id,'module_agency_persons',$assignment_id,'DELETE',null,null,'Removed person');
+}
+header('Location: ../agency_edit.php?id='.$agency_id.'#persons');
+exit;

--- a/admin/orgs/functions/division_assign_person.php
+++ b/admin/orgs/functions/division_assign_person.php
@@ -1,0 +1,23 @@
+<?php
+require '../../../includes/php_header.php';
+$division_id = (int)($_POST['division_id'] ?? 0);
+$person_id = (int)($_POST['person_id'] ?? 0);
+$role_id = $_POST['role_id'] !== '' ? (int)$_POST['role_id'] : null;
+$is_lead = isset($_POST['is_lead']) ? 1 : 0;
+$token = $_POST['csrf_token'] ?? '';
+require_permission('division','update');
+if($token !== ($_SESSION['csrf_token'] ?? '')){
+  header('Location: ../division_edit.php?id='.$division_id);
+  exit;
+}
+if($division_id && $person_id){
+  if($is_lead){
+    $pdo->prepare('UPDATE module_division_persons SET is_lead=0 WHERE division_id=:id')->execute([':id'=>$division_id]);
+  }
+  $stmt = $pdo->prepare('INSERT INTO module_division_persons (user_id,user_updated,division_id,person_id,role_id,is_lead) VALUES (:uid,:uid,:did,:pid,:role,:lead)');
+  $stmt->execute([':uid'=>$this_user_id,':did'=>$division_id,':pid'=>$person_id,':role'=>$role_id,':lead'=>$is_lead]);
+  $assignId = $pdo->lastInsertId();
+  admin_audit_log($pdo,$this_user_id,'module_division_persons',$assignId,'CREATE',null,json_encode(['division_id'=>$division_id,'person_id'=>$person_id,'role_id'=>$role_id,'is_lead'=>$is_lead]),'Assigned person');
+}
+header('Location: ../division_edit.php?id='.$division_id.'#persons');
+exit;

--- a/admin/orgs/functions/division_remove_person.php
+++ b/admin/orgs/functions/division_remove_person.php
@@ -1,0 +1,17 @@
+<?php
+require '../../../includes/php_header.php';
+$assignment_id = (int)($_POST['assignment_id'] ?? 0);
+$division_id = (int)($_POST['division_id'] ?? 0);
+$token = $_POST['csrf_token'] ?? '';
+require_permission('division','update');
+if($token !== ($_SESSION['csrf_token'] ?? '')){
+  header('Location: ../division_edit.php?id='.$division_id);
+  exit;
+}
+if($assignment_id){
+  $stmt = $pdo->prepare('DELETE FROM module_division_persons WHERE id=:id');
+  $stmt->execute([':id'=>$assignment_id]);
+  admin_audit_log($pdo,$this_user_id,'module_division_persons',$assignment_id,'DELETE',null,null,'Removed person');
+}
+header('Location: ../division_edit.php?id='.$division_id.'#persons');
+exit;

--- a/admin/orgs/functions/organization_assign_person.php
+++ b/admin/orgs/functions/organization_assign_person.php
@@ -1,0 +1,24 @@
+<?php
+require '../../../includes/php_header.php';
+$organization_id = (int)($_POST['organization_id'] ?? 0);
+$person_id = (int)($_POST['person_id'] ?? 0);
+$role_id = $_POST['role_id'] !== '' ? (int)$_POST['role_id'] : null;
+$is_lead = isset($_POST['is_lead']) ? 1 : 0;
+$token = $_POST['csrf_token'] ?? '';
+require_permission('organization','update');
+if($token !== ($_SESSION['csrf_token'] ?? '')){
+  header('Location: ../organization_edit.php?id='.$organization_id);
+  exit;
+}
+if($organization_id && $person_id){
+  if($is_lead){
+    $stmt = $pdo->prepare('UPDATE module_organization_persons SET is_lead=0 WHERE organization_id=:id');
+    $stmt->execute([':id'=>$organization_id]);
+  }
+  $stmt = $pdo->prepare('INSERT INTO module_organization_persons (user_id,user_updated,organization_id,person_id,role_id,is_lead) VALUES (:uid,:uid,:org,:pid,:role,:lead)');
+  $stmt->execute([':uid'=>$this_user_id,':org'=>$organization_id,':pid'=>$person_id,':role'=>$role_id,':lead'=>$is_lead]);
+  $assignId = $pdo->lastInsertId();
+  admin_audit_log($pdo,$this_user_id,'module_organization_persons',$assignId,'CREATE',null,json_encode(['organization_id'=>$organization_id,'person_id'=>$person_id,'role_id'=>$role_id,'is_lead'=>$is_lead]),'Assigned person');
+}
+header('Location: ../organization_edit.php?id='.$organization_id.'#persons');
+exit;

--- a/admin/orgs/functions/organization_remove_person.php
+++ b/admin/orgs/functions/organization_remove_person.php
@@ -1,0 +1,17 @@
+<?php
+require '../../../includes/php_header.php';
+$assignment_id = (int)($_POST['assignment_id'] ?? 0);
+$organization_id = (int)($_POST['organization_id'] ?? 0);
+$token = $_POST['csrf_token'] ?? '';
+require_permission('organization','update');
+if($token !== ($_SESSION['csrf_token'] ?? '')){
+  header('Location: ../organization_edit.php?id='.$organization_id);
+  exit;
+}
+if($assignment_id){
+  $stmt = $pdo->prepare('DELETE FROM module_organization_persons WHERE id=:id');
+  $stmt->execute([':id'=>$assignment_id]);
+  admin_audit_log($pdo,$this_user_id,'module_organization_persons',$assignment_id,'DELETE',null,null,'Removed person');
+}
+header('Location: ../organization_edit.php?id='.$organization_id.'#persons');
+exit;

--- a/admin/orgs/organization_edit.php
+++ b/admin/orgs/organization_edit.php
@@ -33,6 +33,18 @@ $personOptions = $personStmt->fetchAll(PDO::FETCH_KEY_PAIR);
 
 $statusItems   = get_lookup_items($pdo, 'ORGANIZATION_STATUS');
 $statusOptions = array_column($statusItems, 'label', 'id');
+$roleItems     = get_lookup_items($pdo, 'ORGANIZATION_PERSON_ROLES');
+$roleOptions   = array_column($roleItems, 'label', 'id');
+$assignedPersons = [];
+if ($id) {
+  $apStmt = $pdo->prepare('SELECT op.id, op.person_id, op.role_id, op.is_lead, CONCAT(p.first_name," ",p.last_name) AS name, li.label AS role_label
+                            FROM module_organization_persons op
+                            JOIN person p ON op.person_id = p.id
+                            LEFT JOIN lookup_list_items li ON op.role_id = li.id
+                            WHERE op.organization_id = :id');
+  $apStmt->execute([':id'=>$id]);
+  $assignedPersons = $apStmt->fetchAll(PDO::FETCH_ASSOC);
+}
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   if (!hash_equals($token, $_POST['csrf_token'] ?? '')) {
@@ -84,4 +96,57 @@ require '../admin_header.php';
   <button class="btn <?= $btnClass; ?>" type="submit">Save</button>
   <a href="index.php" class="btn btn-secondary">Cancel</a>
 </form>
+<?php if ($id): ?>
+  <hr class="my-4">
+  <h4>Assigned Persons</h4>
+  <table class="table table-sm">
+    <thead>
+      <tr><th>Name</th><th>Role</th><th>Lead</th><th></th></tr>
+    </thead>
+    <tbody>
+      <?php foreach($assignedPersons as $ap): ?>
+        <tr>
+          <td><?= htmlspecialchars($ap['name']); ?></td>
+          <td><?= htmlspecialchars($ap['role_label'] ?? ''); ?></td>
+          <td><?= $ap['is_lead'] ? 'Yes' : 'No'; ?></td>
+          <td>
+            <form method="post" action="functions/organization_remove_person.php" class="d-inline">
+              <input type="hidden" name="assignment_id" value="<?= $ap['id']; ?>">
+              <input type="hidden" name="organization_id" value="<?= $id; ?>">
+              <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+              <button class="btn btn-sm btn-danger" onclick="return confirm('Remove this person?');">Remove</button>
+            </form>
+          </td>
+        </tr>
+      <?php endforeach; ?>
+    </tbody>
+  </table>
+  <form method="post" action="functions/organization_assign_person.php" class="row g-2">
+    <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+    <input type="hidden" name="organization_id" value="<?= $id; ?>">
+    <div class="col-md-4">
+      <select name="person_id" class="form-select" required>
+        <option value="">-- Person --</option>
+        <?php foreach($personOptions as $pid=>$pname): ?>
+          <option value="<?= $pid; ?>"><?= htmlspecialchars($pname); ?></option>
+        <?php endforeach; ?>
+      </select>
+    </div>
+    <div class="col-md-4">
+      <select name="role_id" class="form-select">
+        <option value="">-- Role --</option>
+        <?php foreach($roleOptions as $rid=>$rlabel): ?>
+          <option value="<?= $rid; ?>"><?= htmlspecialchars($rlabel); ?></option>
+        <?php endforeach; ?>
+      </select>
+    </div>
+    <div class="col-md-2 form-check d-flex align-items-center">
+      <input class="form-check-input" type="checkbox" value="1" name="is_lead" id="orgLeadChk">
+      <label class="form-check-label ms-2" for="orgLeadChk">Lead</label>
+    </div>
+    <div class="col-md-2">
+      <button class="btn btn-primary" type="submit">Assign</button>
+    </div>
+  </form>
+<?php endif; ?>
 <?php require '../admin_footer.php'; ?>


### PR DESCRIPTION
## Summary
- Support many-to-many person assignments for organizations, agencies, and divisions
- Add role-based assignment management to admin UI with lead designation
- Drop direct organization/agency/division fields from person records

## Testing
- `php -l admin/orgs/organization_edit.php`
- `php -l admin/orgs/agency_edit.php`
- `php -l admin/orgs/division_edit.php`
- `php -l admin/orgs/index.php`
- `php -l admin/person/edit.php`
- `for f in admin/orgs/functions/*.php; do php -l "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_68a8eddd9ebc8333ba9812b55c264f91