### PR TITLE
Add agency filtering and assignment counts

### DIFF
--- a/module/agency/include/board_view.php
+++ b/module/agency/include/board_view.php
@@ -18,6 +18,8 @@ foreach ($agencies as $agency) {
             <div class="card mb-2">
               <div class="card-body p-2">
                 <?= htmlspecialchars($agency['name']); ?>
+                <span class="badge bg-primary-subtle text-primary ms-1"><?= (int)$agency['user_count']; ?></span>
+                <span class="badge bg-secondary-subtle text-secondary ms-1"><?= (int)$agency['person_count']; ?></span>
               </div>
             </div>
           <?php endforeach; ?>

--- a/module/agency/include/card_view.php
+++ b/module/agency/include/card_view.php
@@ -7,7 +7,11 @@
       <div class="col-12 col-md-6 col-lg-4">
         <div class="card h-100">
           <div class="card-body">
-            <h5 class="card-title mb-1"><?php echo htmlspecialchars($agency['name']); ?></h5>
+            <h5 class="card-title mb-1">
+              <?php echo htmlspecialchars($agency['name']); ?>
+              <span class="badge bg-primary-subtle text-primary ms-1"><?= (int)$agency['user_count']; ?></span>
+              <span class="badge bg-secondary-subtle text-secondary ms-1"><?= (int)$agency['person_count']; ?></span>
+            </h5>
             <p class="mb-0">
               <?= render_status_badge($statusList, $agency['status']) ?>
             </p>

--- a/module/agency/include/list_view.php
+++ b/module/agency/include/list_view.php
@@ -1,6 +1,36 @@
 <?php
 // List view of agencies
 ?>
+<div class="card mb-3">
+  <div class="card-body">
+    <form method="get" class="row g-2">
+      <input type="hidden" name="action" value="list">
+      <div class="col-sm-4">
+        <input class="form-control" type="text" name="name" placeholder="Search name" value="<?= h($filters['name']); ?>">
+      </div>
+      <div class="col-sm-3">
+        <select class="form-select" name="status">
+          <option value="">All Statuses</option>
+          <?php foreach ($statusList as $id => $status): ?>
+            <option value="<?= $id ?>" <?= $filters['status']==$id ? 'selected' : '' ?>><?= h($status['label']); ?></option>
+          <?php endforeach; ?>
+        </select>
+      </div>
+      <div class="col-sm-3">
+        <select class="form-select" name="lead">
+          <option value="">All Leads</option>
+          <?php foreach ($leadUsers as $user): ?>
+            <option value="<?= $user['id']; ?>" <?= $filters['lead']==$user['id'] ? 'selected' : '' ?>><?= h($user['name']); ?></option>
+          <?php endforeach; ?>
+        </select>
+      </div>
+      <div class="col-sm-2">
+        <button class="btn btn-primary w-100" type="submit">Filter</button>
+      </div>
+    </form>
+  </div>
+</div>
+
 <div class="card">
   <div class="card-body p-0">
     <div class="table-responsive scrollbar">
@@ -14,7 +44,11 @@
         <tbody class="list">
           <?php foreach ($agencies as $agency): ?>
             <tr>
-              <td class="align-middle name"><?php echo htmlspecialchars($agency['name']); ?></td>
+              <td class="align-middle name">
+                <?php echo htmlspecialchars($agency['name']); ?>
+                <span class="badge bg-primary-subtle text-primary ms-1"><?= (int)$agency['user_count']; ?></span>
+                <span class="badge bg-secondary-subtle text-secondary ms-1"><?= (int)$agency['person_count']; ?></span>
+              </td>
               <td class="align-middle status">
                 <?= render_status_badge($statusList, $agency['status']) ?>
               </td>

--- a/module/agency/index.php
+++ b/module/agency/index.php
@@ -4,10 +4,47 @@ require_permission('agency','read');
 
 $action = $_GET['action'] ?? 'card';
 
+$filters = [
+  'name'   => trim($_GET['name'] ?? ''),
+  'status' => $_GET['status'] ?? '',
+  'lead'   => $_GET['lead'] ?? ''
+];
+
 // Fetch agencies and status lookup
 $statusList = array_column(get_lookup_items($pdo, 'AGENCY_STATUS'), null, 'id');
 $statusList[0] = ['label' => 'Unassigned', 'color_class' => 'secondary'];
-$stmt = $pdo->query('SELECT id, name, status FROM module_agency ORDER BY name');
+
+// Lead users for filter select
+$leadUsers = $pdo->query("SELECT u.id, COALESCE(CONCAT(p.first_name,' ',p.last_name), u.email) AS name
+                           FROM users u
+                           LEFT JOIN person p ON u.id = p.user_id
+                           ORDER BY name")->fetchAll(PDO::FETCH_ASSOC);
+
+$sql = "SELECT a.id, a.name, a.status,
+               COUNT(DISTINCT aa.assigned_user_id) AS user_count,
+               (SELECT COUNT(*) FROM person p WHERE p.agency_id = a.id) AS person_count
+        FROM module_agency a
+        LEFT JOIN module_agency_assignments aa ON a.id = aa.agency_id";
+$conditions = [];
+$params = [];
+if ($filters['name'] !== '') {
+  $conditions[] = "a.name LIKE :name";
+  $params[':name'] = '%' . $filters['name'] . '%';
+}
+if ($filters['status'] !== '') {
+  $conditions[] = "a.status = :status";
+  $params[':status'] = $filters['status'];
+}
+if ($filters['lead'] !== '') {
+  $conditions[] = "aa.assigned_user_id = :lead";
+  $params[':lead'] = $filters['lead'];
+}
+if ($conditions) {
+  $sql .= ' WHERE ' . implode(' AND ', $conditions);
+}
+$sql .= ' GROUP BY a.id ORDER BY a.name';
+$stmt = $pdo->prepare($sql);
+$stmt->execute($params);
 $agencies = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
 require '../../includes/html_header.php';


### PR DESCRIPTION
## Summary
- Add name, status and lead filters to agency index
- Compute user and person assignment counts per agency
- Show counts as badges in card, list and board views

## Testing
- `php -l module/agency/index.php module/agency/include/list_view.php module/agency/include/card_view.php module/agency/include/board_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68a8ede11ee8833380ab57eb269deaa5