### PR TITLE
Enable organization and division file attachments

### DIFF
--- a/_SQL/atlis.sql
+++ b/_SQL/atlis.sql
@@ -1803,19 +1803,23 @@ CREATE TABLE `module_division` (
   `agency_id` int(11) NOT NULL,
   `name` varchar(255) NOT NULL,
   `main_person` int(11) DEFAULT NULL,
-  `status` int(11) DEFAULT NULL
+  `status` int(11) DEFAULT NULL,
+  `file_name` varchar(255) DEFAULT NULL,
+  `file_path` varchar(255) DEFAULT NULL,
+  `file_size` int(11) DEFAULT NULL,
+  `file_type` varchar(255) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --
 -- Dumping data for table `module_division`
 --
 
-INSERT INTO `module_division` (`id`, `user_id`, `user_updated`, `date_created`, `date_updated`, `memo`, `agency_id`, `name`, `main_person`, `status`) VALUES
-(1, 1, 1, '2025-08-06 16:27:41', '2025-08-08 21:58:10', NULL, 1, 'Atlis', 1, 5),
-(2, 1, 1, '2025-08-06 16:28:28', '2025-08-21 15:48:03', NULL, 2, 'Judicial Information Services & Technology', NULL, 5),
-(3, 1, 1, '2025-08-06 16:28:37', '2025-08-08 21:58:10', NULL, 2, 'Business Operations', NULL, 5),
-(4, 1, 1, '2025-08-06 16:28:48', '2025-08-08 21:58:10', NULL, 2, 'Court Clerks', NULL, 5),
-(5, 1, 1, '2025-08-21 02:22:59', '2025-08-21 15:48:10', NULL, 3, 'Public Defender', 30, 6);
+INSERT INTO `module_division` (`id`, `user_id`, `user_updated`, `date_created`, `date_updated`, `memo`, `agency_id`, `name`, `main_person`, `status`, `file_name`, `file_path`, `file_size`, `file_type`) VALUES
+(1, 1, 1, '2025-08-06 16:27:41', '2025-08-08 21:58:10', NULL, 1, 'Atlis', 1, 5, NULL, NULL, NULL, NULL),
+(2, 1, 1, '2025-08-06 16:28:28', '2025-08-21 15:48:03', NULL, 2, 'Judicial Information Services & Technology', NULL, 5, NULL, NULL, NULL, NULL),
+(3, 1, 1, '2025-08-06 16:28:37', '2025-08-08 21:58:10', NULL, 2, 'Business Operations', NULL, 5, NULL, NULL, NULL, NULL),
+(4, 1, 1, '2025-08-06 16:28:48', '2025-08-08 21:58:10', NULL, 2, 'Court Clerks', NULL, 5, NULL, NULL, NULL, NULL),
+(5, 1, 1, '2025-08-21 02:22:59', '2025-08-21 15:48:10', NULL, 3, 'Public Defender', 30, 6, NULL, NULL, NULL, NULL);
 
 -- --------------------------------------------------------
 
@@ -1912,16 +1916,20 @@ CREATE TABLE `module_organization` (
   `memo` text DEFAULT NULL,
   `name` varchar(255) NOT NULL,
   `main_person` int(11) DEFAULT NULL,
-  `status` int(11) DEFAULT NULL
+  `status` int(11) DEFAULT NULL,
+  `file_name` varchar(255) DEFAULT NULL,
+  `file_path` varchar(255) DEFAULT NULL,
+  `file_size` int(11) DEFAULT NULL,
+  `file_type` varchar(255) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --
 -- Dumping data for table `module_organization`
 --
 
-INSERT INTO `module_organization` (`id`, `user_id`, `user_updated`, `date_created`, `date_updated`, `memo`, `name`, `main_person`, `status`) VALUES
-(1, 1, 1, '2025-08-06 16:27:19', '2025-08-08 22:19:06', NULL, 'Atlis Technologies LLC', 1, 1),
-(2, 1, 1, '2025-08-06 16:27:55', '2025-08-08 22:19:06', NULL, 'Lake County, IL', NULL, 1);
+INSERT INTO `module_organization` (`id`, `user_id`, `user_updated`, `date_created`, `date_updated`, `memo`, `name`, `main_person`, `status`, `file_name`, `file_path`, `file_size`, `file_type`) VALUES
+(1, 1, 1, '2025-08-06 16:27:19', '2025-08-08 22:19:06', NULL, 'Atlis Technologies LLC', 1, 1, NULL, NULL, NULL, NULL),
+(2, 1, 1, '2025-08-06 16:27:55', '2025-08-08 22:19:06', NULL, 'Lake County, IL', NULL, 1, NULL, NULL, NULL, NULL);
 
 -- --------------------------------------------------------
 

--- a/admin/orgs/division_edit.php
+++ b/admin/orgs/division_edit.php
@@ -9,11 +9,15 @@ $name = '';
 $main_person = null;
 $status = null;
 $existing = null;
+$file_name = '';
+$file_path = '';
+$file_size = null;
+$file_type = '';
 $btnClass = $id ? 'btn-warning' : 'btn-success';
 
 if ($id) {
   require_permission('division','update');
-  $stmt = $pdo->prepare('SELECT agency_id, name, main_person, status FROM module_division WHERE id = :id');
+  $stmt = $pdo->prepare('SELECT agency_id, name, main_person, status, file_name, file_path, file_size, file_type FROM module_division WHERE id = :id');
   $stmt->execute([':id' => $id]);
   $existing = $stmt->fetch(PDO::FETCH_ASSOC);
   if ($existing) {
@@ -21,6 +25,10 @@ if ($id) {
     $name = $existing['name'];
     $main_person = $existing['main_person'];
     $status = $existing['status'];
+    $file_name = $existing['file_name'];
+    $file_path = $existing['file_path'];
+    $file_size = $existing['file_size'];
+    $file_type = $existing['file_type'];
   }
 } else {
   require_permission('division','create');
@@ -47,6 +55,44 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $id = $pdo->lastInsertId();
     admin_audit_log($pdo, $this_user_id, 'module_division', $id, 'CREATE', null, json_encode(['agency_id'=>$agency_id,'name'=>$name,'main_person'=>$main_person,'status'=>$status]), 'Created division');
   }
+  // handle file upload (max 5MB)
+  if (!empty($_FILES['upload_file']['name'])) {
+    $maxSize = 5 * 1024 * 1024; // 5MB
+    if ($_FILES['upload_file']['size'] <= $maxSize && is_uploaded_file($_FILES['upload_file']['tmp_name'])) {
+      $originalName = $_FILES['upload_file']['name'];
+      $fileSize = (int)$_FILES['upload_file']['size'];
+
+      $finfo = finfo_open(FILEINFO_MIME_TYPE);
+      $mime = finfo_file($finfo, $_FILES['upload_file']['tmp_name']);
+      finfo_close($finfo);
+
+      $allowedTypes = [
+        'image/jpeg' => 'jpg',
+        'image/png'  => 'png',
+        'image/gif'  => 'gif',
+        'image/webp' => 'webp',
+        'application/pdf' => 'pdf'
+      ];
+
+      if (isset($allowedTypes[$mime])) {
+        $ext = $allowedTypes[$mime];
+        $uploadDir = dirname(__DIR__, 3) . '/uploads/division/';
+        if (!is_dir($uploadDir)) {
+          mkdir($uploadDir, 0775, true);
+        }
+        if (!empty($file_path)) {
+          @unlink($uploadDir . $file_path);
+        }
+        $randomName = bin2hex(random_bytes(16)) . '.' . $ext;
+        $dest = $uploadDir . $randomName;
+        if (move_uploaded_file($_FILES['upload_file']['tmp_name'], $dest)) {
+          $fileStmt = $pdo->prepare('UPDATE module_division SET file_name=?, file_path=?, file_size=?, file_type=? WHERE id=?');
+          $fileStmt->execute([$originalName, $randomName, $fileSize, $mime, $id]);
+          admin_audit_log($pdo, $this_user_id, 'module_division', $id, 'UPLOAD', null, json_encode(['file_name'=>$originalName,'file_path'=>$randomName,'file_size'=>$fileSize,'file_type'=>$mime]), 'Uploaded division file');
+        }
+      }
+    }
+  }
   header('Location: index.php');
   exit;
 }
@@ -63,7 +109,7 @@ $statusOptions = array_column($statusItems, 'label', 'id');
 require '../admin_header.php';
 ?>
 <h2 class="mb-4"><?= $id ? 'Edit' : 'Add'; ?> Division</h2>
-<form method="post">
+<form method="post" enctype="multipart/form-data">
   <input type="hidden" name="csrf_token" value="<?= $token; ?>">
   <div class="mb-3">
     <label class="form-label">Agency</label>
@@ -94,6 +140,15 @@ require '../admin_header.php';
         <option value="<?= $sid; ?>" <?= (int)$sid === (int)$status ? 'selected' : ''; ?>><?= htmlspecialchars($slabel); ?></option>
       <?php endforeach; ?>
     </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Upload File</label>
+    <?php if ($file_path): ?>
+      <div class="mb-2">
+        <a href="/module/division/download.php?id=<?= $id; ?>" target="_blank"><?= htmlspecialchars($file_name); ?></a>
+      </div>
+    <?php endif; ?>
+    <input type="file" name="upload_file" class="form-control" accept="image/*,application/pdf">
   </div>
   <button class="btn <?= $btnClass; ?>" type="submit">Save</button>
   <a href="index.php" class="btn btn-secondary">Cancel</a>

--- a/admin/orgs/index.php
+++ b/admin/orgs/index.php
@@ -40,9 +40,11 @@ $divisionStatuses = array_column(get_lookup_items($pdo, 'DIVISION_STATUS'), null
 
 // Load organizations, agencies and divisions in a single query
 $sql = 'SELECT o.id AS org_id, o.name AS org_name, o.status AS org_status,
+               o.file_path AS org_file_path, o.file_name AS org_file_name, o.file_type AS org_file_type,
                a.id AS agency_id, a.name AS agency_name, a.status AS agency_status,
-               a.file_path, a.file_name, a.file_type,
-               d.id AS division_id, d.name AS division_name, d.status AS division_status
+               a.file_path AS agency_file_path, a.file_name AS agency_file_name, a.file_type AS agency_file_type,
+               d.id AS division_id, d.name AS division_name, d.status AS division_status,
+               d.file_path AS division_file_path, d.file_name AS division_file_name, d.file_type AS division_file_type
         FROM module_organization o
         LEFT JOIN module_agency a ON a.organization_id = o.id
         LEFT JOIN module_division d ON d.agency_id = a.id
@@ -57,10 +59,13 @@ foreach ($rows as $row) {
   $orgId = $row['org_id'];
   if (!isset($organizations[$orgId])) {
     $organizations[$orgId] = [
-      'id'       => $orgId,
-      'name'     => $row['org_name'],
-      'status'   => $row['org_status'],
-      'agencies' => []
+      'id'        => $orgId,
+      'name'      => $row['org_name'],
+      'status'    => $row['org_status'],
+      'file_path' => $row['org_file_path'],
+      'file_name' => $row['org_file_name'],
+      'file_type' => $row['org_file_type'],
+      'agencies'  => []
     ];
   }
 
@@ -71,18 +76,21 @@ foreach ($rows as $row) {
         'id'        => $agencyId,
         'name'      => $row['agency_name'],
         'status'    => $row['agency_status'],
-        'file_path' => $row['file_path'],
-        'file_name' => $row['file_name'],
-        'file_type' => $row['file_type'],
+        'file_path' => $row['agency_file_path'],
+        'file_name' => $row['agency_file_name'],
+        'file_type' => $row['agency_file_type'],
         'divisions' => []
       ];
     }
 
     if (!empty($row['division_id'])) {
       $organizations[$orgId]['agencies'][$agencyId]['divisions'][$row['division_id']] = [
-        'id'     => $row['division_id'],
-        'name'   => $row['division_name'],
-        'status' => $row['division_status']
+        'id'        => $row['division_id'],
+        'name'      => $row['division_name'],
+        'status'    => $row['division_status'],
+        'file_path' => $row['division_file_path'],
+        'file_name' => $row['division_file_name'],
+        'file_type' => $row['division_file_type']
       ];
     }
   }
@@ -118,7 +126,11 @@ $organizations = array_values($organizations);
     <tbody>
       <?php foreach ($organizations as $org): ?>
         <tr>
-          <td class="ps-2"><?= htmlspecialchars($org['name']); ?></td>
+          <td class="ps-2"><?= htmlspecialchars($org['name']); ?>
+            <?php if (!empty($org['file_path'])): ?>
+              <br><a href="/module/organization/download.php?id=<?= $org['id']; ?>" target="_blank">View File</a>
+            <?php endif; ?>
+          </td>
           <td>
             <?= render_status_badge($orgStatuses, $org['status']) ?>
           </td>
@@ -162,7 +174,11 @@ $organizations = array_values($organizations);
           </tr>
           <?php foreach ($agency['divisions'] as $division): ?>
             <tr class="bg-body-secondary">
-              <td class="ps-12"><b>Division:</b> <?= htmlspecialchars($division['name']); ?></td>
+              <td class="ps-12"><b>Division:</b> <?= htmlspecialchars($division['name']); ?>
+                <?php if (!empty($division['file_path'])): ?>
+                  <br><a href="/module/division/download.php?id=<?= $division['id']; ?>" target="_blank">View File</a>
+                <?php endif; ?>
+              </td>
               <td>
                 <?= render_status_badge($divisionStatuses, $division['status']) ?>
               </td>

--- a/admin/orgs/organization_edit.php
+++ b/admin/orgs/organization_edit.php
@@ -9,17 +9,25 @@ $name = '';
 $main_person = null;
 $status = null;
 $existing = null;
+$file_name = '';
+$file_path = '';
+$file_size = null;
+$file_type = '';
 $btnClass = $id ? 'btn-warning' : 'btn-success';
 
 if ($id) {
   require_permission('organization','update');
-  $stmt = $pdo->prepare('SELECT name, main_person, status FROM module_organization WHERE id = :id');
+  $stmt = $pdo->prepare('SELECT name, main_person, status, file_name, file_path, file_size, file_type FROM module_organization WHERE id = :id');
   $stmt->execute([':id' => $id]);
   $existing = $stmt->fetch(PDO::FETCH_ASSOC);
   if ($existing) {
     $name = $existing['name'];
     $main_person = $existing['main_person'];
     $status = $existing['status'];
+    $file_name = $existing['file_name'];
+    $file_path = $existing['file_path'];
+    $file_size = $existing['file_size'];
+    $file_type = $existing['file_type'];
   }
 } else {
   require_permission('organization','create');
@@ -51,6 +59,44 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $id = $pdo->lastInsertId();
     admin_audit_log($pdo, $this_user_id, 'module_organization', $id, 'CREATE', null, json_encode(['name'=>$name,'main_person'=>$main_person,'status'=>$status]), 'Created organization');
   }
+  // handle file upload (max 5MB)
+  if (!empty($_FILES['upload_file']['name'])) {
+    $maxSize = 5 * 1024 * 1024; // 5MB
+    if ($_FILES['upload_file']['size'] <= $maxSize && is_uploaded_file($_FILES['upload_file']['tmp_name'])) {
+      $originalName = $_FILES['upload_file']['name'];
+      $fileSize = (int)$_FILES['upload_file']['size'];
+
+      $finfo = finfo_open(FILEINFO_MIME_TYPE);
+      $mime = finfo_file($finfo, $_FILES['upload_file']['tmp_name']);
+      finfo_close($finfo);
+
+      $allowedTypes = [
+        'image/jpeg' => 'jpg',
+        'image/png'  => 'png',
+        'image/gif'  => 'gif',
+        'image/webp' => 'webp',
+        'application/pdf' => 'pdf'
+      ];
+
+      if (isset($allowedTypes[$mime])) {
+        $ext = $allowedTypes[$mime];
+        $uploadDir = dirname(__DIR__, 3) . '/uploads/organization/';
+        if (!is_dir($uploadDir)) {
+          mkdir($uploadDir, 0775, true);
+        }
+        if (!empty($file_path)) {
+          @unlink($uploadDir . $file_path);
+        }
+        $randomName = bin2hex(random_bytes(16)) . '.' . $ext;
+        $dest = $uploadDir . $randomName;
+        if (move_uploaded_file($_FILES['upload_file']['tmp_name'], $dest)) {
+          $fileStmt = $pdo->prepare('UPDATE module_organization SET file_name=?, file_path=?, file_size=?, file_type=? WHERE id=?');
+          $fileStmt->execute([$originalName, $randomName, $fileSize, $mime, $id]);
+          admin_audit_log($pdo, $this_user_id, 'module_organization', $id, 'UPLOAD', null, json_encode(['file_name'=>$originalName,'file_path'=>$randomName,'file_size'=>$fileSize,'file_type'=>$mime]), 'Uploaded organization file');
+        }
+      }
+    }
+  }
   header('Location: index.php');
   exit;
 }
@@ -58,7 +104,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 require '../admin_header.php';
 ?>
 <h2 class="mb-4"><?= $id ? 'Edit' : 'Add'; ?> Organization</h2>
-<form method="post">
+<form method="post" enctype="multipart/form-data">
   <input type="hidden" name="csrf_token" value="<?= $token; ?>">
   <div class="mb-3">
     <label class="form-label">Name</label>
@@ -80,6 +126,15 @@ require '../admin_header.php';
         <option value="<?= $sid; ?>" <?= (int)$sid === (int)$status ? 'selected' : ''; ?>><?= htmlspecialchars($slabel); ?></option>
       <?php endforeach; ?>
     </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Upload File</label>
+    <?php if ($file_path): ?>
+      <div class="mb-2">
+        <a href="/module/organization/download.php?id=<?= $id; ?>" target="_blank"><?= htmlspecialchars($file_name); ?></a>
+      </div>
+    <?php endif; ?>
+    <input type="file" name="upload_file" class="form-control" accept="image/*,application/pdf">
   </div>
   <button class="btn <?= $btnClass; ?>" type="submit">Save</button>
   <a href="index.php" class="btn btn-secondary">Cancel</a>

--- a/module/division/download.php
+++ b/module/division/download.php
@@ -1,0 +1,34 @@
+<?php
+require '../../includes/php_header.php';
+require_permission('division','read');
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+if (!$id) {
+  header('HTTP/1.1 400 Bad Request');
+  exit('Bad Request');
+}
+
+$stmt = $pdo->prepare('SELECT file_name, file_path, file_size, file_type FROM module_division WHERE id = ?');
+$stmt->execute([$id]);
+$file = $stmt->fetch(PDO::FETCH_ASSOC);
+
+if (!$file || empty($file['file_path'])) {
+  header('HTTP/1.1 404 Not Found');
+  exit('File not found');
+}
+
+$uploadDir = dirname(__DIR__, 3) . '/uploads/division/';
+$path = $uploadDir . $file['file_path'];
+
+if (!is_file($path) || !is_readable($path)) {
+  header('HTTP/1.1 404 Not Found');
+  exit('File not found');
+}
+
+header('Content-Type: ' . $file['file_type']);
+header('Content-Length: ' . $file['file_size']);
+header('Content-Disposition: attachment; filename="' . basename($file['file_name']) . '"');
+readfile($path);
+exit;
+?>
+

--- a/module/organization/download.php
+++ b/module/organization/download.php
@@ -1,0 +1,34 @@
+<?php
+require '../../includes/php_header.php';
+require_permission('organization','read');
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+if (!$id) {
+  header('HTTP/1.1 400 Bad Request');
+  exit('Bad Request');
+}
+
+$stmt = $pdo->prepare('SELECT file_name, file_path, file_size, file_type FROM module_organization WHERE id = ?');
+$stmt->execute([$id]);
+$file = $stmt->fetch(PDO::FETCH_ASSOC);
+
+if (!$file || empty($file['file_path'])) {
+  header('HTTP/1.1 404 Not Found');
+  exit('File not found');
+}
+
+$uploadDir = dirname(__DIR__, 3) . '/uploads/organization/';
+$path = $uploadDir . $file['file_path'];
+
+if (!is_file($path) || !is_readable($path)) {
+  header('HTTP/1.1 404 Not Found');
+  exit('File not found');
+}
+
+header('Content-Type: ' . $file['file_type']);
+header('Content-Length: ' . $file['file_size']);
+header('Content-Disposition: attachment; filename="' . basename($file['file_name']) . '"');
+readfile($path);
+exit;
+?>
+


### PR DESCRIPTION
## Summary
- allow organizations and divisions to store optional uploaded files
- handle upload and retrieval in organization/division editors
- display download links for organization, agency, and division attachments on the index page

## Testing
- `php -l admin/orgs/organization_edit.php`
- `php -l admin/orgs/division_edit.php`
- `php -l admin/orgs/index.php`
- `php -l module/organization/download.php`
- `php -l module/division/download.php`


------
https://chatgpt.com/codex/tasks/task_e_68a8ede11a408333a62cfbfe5a13697e