### PR TITLE
Add default status system properties

### DIFF
--- a/_SQL/atlis.sql
+++ b/_SQL/atlis.sql
@@ -2339,7 +2339,10 @@ CREATE TABLE `system_properties` (
 --
 
 INSERT INTO `system_properties` (`id`, `user_id`, `user_updated`, `date_created`, `date_updated`, `memo`, `category_id`, `name`, `value`, `type_id`, `description`) VALUES
-(1, 1, 1, '2025-08-13 16:28:53', '2025-08-13 16:28:53', NULL, 30, 'logo', '/assets/logo.png', 32, 'Default site logo');
+(1, 1, 1, '2025-08-13 16:28:53', '2025-08-13 16:28:53', NULL, 30, 'logo', '/assets/logo.png', 32, 'Default site logo'),
+(2, 1, 1, '2025-08-21 00:00:00', '2025-08-21 00:00:00', NULL, 30, 'DEFAULT_ORGANIZATION_STATUS', '1', 32, 'Default status for new organizations'),
+(3, 1, 1, '2025-08-21 00:00:00', '2025-08-21 00:00:00', NULL, 30, 'DEFAULT_AGENCY_STATUS', '3', 32, 'Default status for new agencies'),
+(4, 1, 1, '2025-08-21 00:00:00', '2025-08-21 00:00:00', NULL, 30, 'DEFAULT_DIVISION_STATUS', '5', 32, 'Default status for new divisions');
 
 -- --------------------------------------------------------
 

--- a/admin/orgs/agency_edit.php
+++ b/admin/orgs/agency_edit.php
@@ -32,6 +32,7 @@ if ($id) {
   }
 } else {
   require_permission('agency','create');
+  $status = (int)get_system_property($pdo, 'DEFAULT_AGENCY_STATUS');
 }
 
 $token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));

--- a/admin/orgs/division_edit.php
+++ b/admin/orgs/division_edit.php
@@ -24,6 +24,7 @@ if ($id) {
   }
 } else {
   require_permission('division','create');
+  $status = (int)get_system_property($pdo, 'DEFAULT_DIVISION_STATUS');
 }
 
 $token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));

--- a/admin/orgs/organization_edit.php
+++ b/admin/orgs/organization_edit.php
@@ -23,6 +23,7 @@ if ($id) {
   }
 } else {
   require_permission('organization','create');
+  $status = (int)get_system_property($pdo, 'DEFAULT_ORGANIZATION_STATUS');
 }
 
 $token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));

--- a/admin/system-properties/README.md
+++ b/admin/system-properties/README.md
@@ -1,0 +1,11 @@
+# System Properties
+
+The following system properties control default statuses when creating new records:
+
+| Property Name | Description | Default Value |
+|---------------|-------------|---------------|
+| `DEFAULT_ORGANIZATION_STATUS` | ID of the status preselected when adding a new organization. | `1` |
+| `DEFAULT_AGENCY_STATUS` | ID of the status preselected when adding a new agency. | `3` |
+| `DEFAULT_DIVISION_STATUS` | ID of the status preselected when adding a new division. | `5` |
+
+Administrators can manage these and other system settings through the System Properties interface.


### PR DESCRIPTION
## Summary
- Define system properties to hold default statuses for organizations, agencies, and divisions
- Auto-select default status on new organization, agency, and division forms
- Document new system properties for administrators

## Testing
- `php -l admin/orgs/organization_edit.php`
- `php -l admin/orgs/agency_edit.php`
- `php -l admin/orgs/division_edit.php`


------
https://chatgpt.com/codex/tasks/task_e_68a8ede0d4ec8333b49f8aa97e7fa20f