### PR TITLE
Add user-specific default settings for projects and tasks

### DIFF
--- a/_SQL/atlis.sql
+++ b/_SQL/atlis.sql
@@ -2613,8 +2613,38 @@ INSERT INTO `users_profile_pics` (`id`, `user_id`, `user_updated`, `date_created
 (5, 1, 1, '2025-08-22 08:26:01', '2025-08-22 08:26:16', NULL, '535471462_1222365166585268_6061415345364469578_n_1755872761.JPEG', 'module/users/uploads/535471462_1222365166585268_6061415345364469578_n_1755872761.JPEG', 72399, 'image/jpeg', 'db5dc9b5e63e2d99f123f9e42ab5f902239c4f8f9ba2674c54e2084159fc5a51', 600, 596, 1, 83);
 
 --
+-- Table structure for table `module_users_defaults`
+--
+
+CREATE TABLE `module_users_defaults` (
+  `id` int(11) NOT NULL,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT current_timestamp(),
+  `date_updated` datetime DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  `memo` text DEFAULT NULL,
+  `list_name` varchar(255) NOT NULL,
+  `item_id` int(11) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+--
+-- Dumping data for table `module_users_defaults`
+--
+
+
+--
 -- Indexes for dumped tables
 --
+
+--
+-- Indexes for table `module_users_defaults`
+--
+ALTER TABLE `module_users_defaults`
+  ADD PRIMARY KEY (`id`),
+  ADD UNIQUE KEY `uk_module_users_defaults_user_list` (`user_id`,`list_name`),
+  ADD KEY `fk_module_users_defaults_user_id` (`user_id`),
+  ADD KEY `fk_module_users_defaults_user_updated` (`user_updated`),
+  ADD KEY `fk_module_users_defaults_item_id` (`item_id`);
 
 --
 -- Indexes for table `admin_audit_log`
@@ -4013,6 +4043,14 @@ ALTER TABLE `person_phones`
   ADD CONSTRAINT `fk_person_phones_type_id` FOREIGN KEY (`type_id`) REFERENCES `lookup_list_items` (`id`),
   ADD CONSTRAINT `fk_person_phones_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
   ADD CONSTRAINT `fk_person_phones_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`) ON DELETE SET NULL;
+
+--
+-- Constraints for table `module_users_defaults`
+--
+ALTER TABLE `module_users_defaults`
+  ADD CONSTRAINT `fk_module_users_defaults_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE,
+  ADD CONSTRAINT `fk_module_users_defaults_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  ADD CONSTRAINT `fk_module_users_defaults_item_id` FOREIGN KEY (`item_id`) REFERENCES `lookup_list_items` (`id`);
 
 --
 -- Constraints for table `users`

--- a/includes/lookup_helpers.php
+++ b/includes/lookup_helpers.php
@@ -62,4 +62,42 @@ function render_status_badge(array $lookupList, int|string|null $id, ?string $cl
     return '<span class="' . $classString . '"' . $attrString . '><span class="badge-label">' . htmlspecialchars($label) . '</span></span>';
 }
 
+/**
+ * Get a user's default lookup item for a specific list name.
+ *
+ * @param PDO    $pdo      PDO connection.
+ * @param int    $userId   User ID.
+ * @param string $listName Lookup list name.
+ * @return int|null        Lookup item ID or null if none set.
+ */
+function get_user_default_lookup_item(PDO $pdo, int $userId, string $listName): ?int {
+    $sql = 'SELECT item_id FROM module_users_defaults WHERE user_id = :uid AND list_name = :list';
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute([':uid' => $userId, ':list' => $listName]);
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
+    return $row['item_id'] ?? null;
+}
+
+/**
+ * Save or update a user's default lookup item for a list.
+ *
+ * @param PDO    $pdo         PDO connection.
+ * @param int    $userId      User ID the default is for.
+ * @param string $listName    Lookup list name.
+ * @param int    $itemId      Lookup item ID.
+ * @param int    $userUpdated User ID performing the update.
+ */
+function set_user_default_lookup_item(PDO $pdo, int $userId, string $listName, int $itemId, int $userUpdated): void {
+    $sql = 'INSERT INTO module_users_defaults (user_id, user_updated, list_name, item_id)
+            VALUES (:user_id, :user_updated, :list_name, :item_id)
+            ON DUPLICATE KEY UPDATE item_id = VALUES(item_id), user_updated = VALUES(user_updated)';
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute([
+        ':user_id' => $userId,
+        ':user_updated' => $userUpdated,
+        ':list_name' => $listName,
+        ':item_id' => $itemId,
+    ]);
+}
+
 ?>

--- a/includes/navigation.php
+++ b/includes/navigation.php
@@ -153,7 +153,7 @@
               <div class="overflow-auto scrollbar" style="height: 10rem;">
                 <ul class="nav d-flex flex-column mb-2 pb-1">
                   <li class="nav-item"><a class="nav-link px-3 d-block" href="#!"><span class="me-2 text-body align-bottom" data-feather="user"></span><span>Profile</span></a></li>
-                  <li class="nav-item"><a class="nav-link px-3 d-block" href="#!"><span class="me-2 text-body align-bottom" data-feather="settings"></span>Settings</a></li>
+                  <li class="nav-item"><a class="nav-link px-3 d-block" href="<?php echo getURLDir(); ?>module/users/index.php?action=settings"><span class="me-2 text-body align-bottom" data-feather="settings"></span>Settings</a></li>
                 </ul>
               </div>
             </div>

--- a/module/project/include/create_edit.php
+++ b/module/project/include/create_edit.php
@@ -6,6 +6,10 @@ require_permission('project','create');
 $statusMap   = $statusMap   ?? get_lookup_items($pdo, 'PROJECT_STATUS');
 $priorityMap = $priorityMap ?? get_lookup_items($pdo, 'PROJECT_PRIORITY');
 $typeMap     = $typeMap     ?? get_lookup_items($pdo, 'PROJECT_TYPE');
+
+$defaultStatusId   = get_user_default_lookup_item($pdo, $this_user_id, 'PROJECT_STATUS');
+$defaultPriorityId = get_user_default_lookup_item($pdo, $this_user_id, 'PROJECT_PRIORITY');
+$defaultTypeId     = get_user_default_lookup_item($pdo, $this_user_id, 'PROJECT_TYPE');
 ?>
 <nav class="mb-3" aria-label="breadcrumb">
   <ol class="breadcrumb mb-0">
@@ -26,18 +30,19 @@ $typeMap     = $typeMap     ?? get_lookup_items($pdo, 'PROJECT_TYPE');
       <div class="col-sm-6 col-md-4">
         <div class="form-floating">
           <?php
-            $hasStatusDefault = false;
-            foreach ($statusMap as $s) {
-              if (!empty($s['is_default'])) {
-                $hasStatusDefault = true;
-                break;
+            if ($defaultStatusId === null) {
+              foreach ($statusMap as $s) {
+                if (!empty($s['is_default'])) {
+                  $defaultStatusId = $s['id'];
+                  break;
+                }
               }
             }
           ?>
           <select class="form-select" id="projectStatus" name="status" required>
-            <option value="" <?= $hasStatusDefault ? '' : 'selected'; ?>>Select status</option>
+            <option value="" <?= $defaultStatusId ? '' : 'selected'; ?>>Select status</option>
             <?php foreach ($statusMap as $s): ?>
-              <option value="<?= h($s['id']); ?>" <?= !empty($s['is_default']) ? 'selected' : ''; ?>><?= h($s['label']); ?></option>
+              <option value="<?= h($s['id']); ?>" <?= ($defaultStatusId == $s['id']) ? 'selected' : ''; ?>><?= h($s['label']); ?></option>
             <?php endforeach; ?>
           </select>
           <label for="projectStatus">Status</label>
@@ -46,18 +51,19 @@ $typeMap     = $typeMap     ?? get_lookup_items($pdo, 'PROJECT_TYPE');
       <div class="col-sm-6 col-md-4">
         <div class="form-floating">
           <?php
-            $hasPriorityDefault = false;
-            foreach ($priorityMap as $p) {
-              if (!empty($p['is_default'])) {
-                $hasPriorityDefault = true;
-                break;
+            if ($defaultPriorityId === null) {
+              foreach ($priorityMap as $p) {
+                if (!empty($p['is_default'])) {
+                  $defaultPriorityId = $p['id'];
+                  break;
+                }
               }
             }
           ?>
           <select class="form-select" id="projectPriority" name="priority" required>
-            <option value="" <?= $hasPriorityDefault ? '' : 'selected'; ?>>Select priority</option>
+            <option value="" <?= $defaultPriorityId ? '' : 'selected'; ?>>Select priority</option>
             <?php foreach ($priorityMap as $p): ?>
-              <option value="<?= h($p['id']); ?>" <?= !empty($p['is_default']) ? 'selected' : ''; ?>><?= h($p['label']); ?></option>
+              <option value="<?= h($p['id']); ?>" <?= ($defaultPriorityId == $p['id']) ? 'selected' : ''; ?>><?= h($p['label']); ?></option>
             <?php endforeach; ?>
           </select>
           <label for="projectPriority">Priority</label>
@@ -66,18 +72,19 @@ $typeMap     = $typeMap     ?? get_lookup_items($pdo, 'PROJECT_TYPE');
       <div class="col-sm-6 col-md-4">
         <div class="form-floating">
           <?php
-            $hasTypeDefault = false;
-            foreach ($typeMap as $t) {
-              if (!empty($t['is_default'])) {
-                $hasTypeDefault = true;
-                break;
+            if ($defaultTypeId === null) {
+              foreach ($typeMap as $t) {
+                if (!empty($t['is_default'])) {
+                  $defaultTypeId = $t['id'];
+                  break;
+                }
               }
             }
           ?>
           <select class="form-select" id="projectType" name="type" required>
-            <option value="" <?= $hasTypeDefault ? '' : 'selected'; ?>>Select type</option>
+            <option value="" <?= $defaultTypeId ? '' : 'selected'; ?>>Select type</option>
             <?php foreach ($typeMap as $t): ?>
-              <option value="<?= h($t['id']); ?>" <?= !empty($t['is_default']) ? 'selected' : ''; ?>><?= h($t['label']); ?></option>
+              <option value="<?= h($t['id']); ?>" <?= ($defaultTypeId == $t['id']) ? 'selected' : ''; ?>><?= h($t['label']); ?></option>
             <?php endforeach; ?>
           </select>
           <label for="projectType">Type</label>

--- a/module/task/include/form.php
+++ b/module/task/include/form.php
@@ -39,7 +39,7 @@
         <div class="form-floating">
           <select class="form-select" id="taskStatus" name="status" required>
             <?php foreach ($statusMap as $s): ?>
-              <?php $sel = (($task['status'] ?? null) == $s['id']) || (empty($task['status']) && !empty($s['is_default'])); ?>
+              <?php $sel = (($task['status'] ?? null) == $s['id']) || (empty($task['status']) && $defaultTaskStatusId == $s['id']); ?>
               <option value="<?php echo $s['id']; ?>" data-color="<?php echo h($s['color_class']); ?>" <?php echo $sel ? 'selected' : ''; ?>><?php echo h($s['label']); ?></option>
             <?php endforeach; ?>
           </select>
@@ -50,7 +50,7 @@
         <div class="form-floating">
           <select class="form-select" id="taskPriority" name="priority" required>
             <?php foreach ($priorityMap as $p): ?>
-              <?php $sel = (($task['priority'] ?? null) == $p['id']) || (empty($task['priority']) && !empty($p['is_default'])); ?>
+              <?php $sel = (($task['priority'] ?? null) == $p['id']) || (empty($task['priority']) && $defaultTaskPriorityId == $p['id']); ?>
               <option value="<?php echo $p['id']; ?>" data-color="<?php echo h($p['color_class']); ?>" <?php echo $sel ? 'selected' : ''; ?>><?php echo h($p['label']); ?></option>
             <?php endforeach; ?>
           </select>
@@ -195,7 +195,7 @@
         <div class="form-floating">
           <select class="form-select" id="taskStatus" name="status" required>
             <?php foreach ($statusMap as $s): ?>
-              <?php $sel = (($task['status'] ?? null) == $s['id']) || (empty($task['status']) && !empty($s['is_default'])); ?>
+              <?php $sel = (($task['status'] ?? null) == $s['id']) || (empty($task['status']) && $defaultTaskStatusId == $s['id']); ?>
               <option value="<?php echo $s['id']; ?>" data-color="<?php echo h($s['color_class']); ?>" <?php echo $sel ? 'selected' : ''; ?>><?php echo h($s['label']); ?></option>
             <?php endforeach; ?>
           </select>
@@ -206,7 +206,7 @@
         <div class="form-floating">
           <select class="form-select" id="taskPriority" name="priority" required>
             <?php foreach ($priorityMap as $p): ?>
-              <?php $sel = (($task['priority'] ?? null) == $p['id']) || (empty($task['priority']) && !empty($p['is_default'])); ?>
+              <?php $sel = (($task['priority'] ?? null) == $p['id']) || (empty($task['priority']) && $defaultTaskPriorityId == $p['id']); ?>
               <option value="<?php echo $p['id']; ?>" data-color="<?php echo h($p['color_class']); ?>" <?php echo $sel ? 'selected' : ''; ?>><?php echo h($p['label']); ?></option>
             <?php endforeach; ?>
           </select>

--- a/module/task/index.php
+++ b/module/task/index.php
@@ -90,6 +90,18 @@ if ($action === 'create' || $action === 'edit') {
   }
   $statusMap = get_lookup_items($pdo, 'TASK_STATUS');
   $priorityMap = get_lookup_items($pdo, 'TASK_PRIORITY');
+  $defaultTaskStatusId = get_user_default_lookup_item($pdo, $this_user_id, 'TASK_STATUS');
+  if ($defaultTaskStatusId === null) {
+    foreach ($statusMap as $s) {
+      if (!empty($s['is_default'])) { $defaultTaskStatusId = $s['id']; break; }
+    }
+  }
+  $defaultTaskPriorityId = get_user_default_lookup_item($pdo, $this_user_id, 'TASK_PRIORITY');
+  if ($defaultTaskPriorityId === null) {
+    foreach ($priorityMap as $p) {
+      if (!empty($p['is_default'])) { $defaultTaskPriorityId = $p['id']; break; }
+    }
+  }
   if (user_has_role('Admin')) {
     $projects = $pdo->query('SELECT id,name FROM module_projects ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
   } else {
@@ -148,6 +160,18 @@ if ($action === 'create-edit' && isset($_GET['modal'])) {
   }
   $statusMap   = get_lookup_items($pdo, 'TASK_STATUS');
   $priorityMap = get_lookup_items($pdo, 'TASK_PRIORITY');
+  $defaultTaskStatusId = get_user_default_lookup_item($pdo, $this_user_id, 'TASK_STATUS');
+  if ($defaultTaskStatusId === null) {
+    foreach ($statusMap as $s) {
+      if (!empty($s['is_default'])) { $defaultTaskStatusId = $s['id']; break; }
+    }
+  }
+  $defaultTaskPriorityId = get_user_default_lookup_item($pdo, $this_user_id, 'TASK_PRIORITY');
+  if ($defaultTaskPriorityId === null) {
+    foreach ($priorityMap as $p) {
+      if (!empty($p['is_default'])) { $defaultTaskPriorityId = $p['id']; break; }
+    }
+  }
   if (user_has_role('Admin')) {
     $projects = $pdo->query('SELECT id,name FROM module_projects ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
   } else {

--- a/module/users/functions/save_settings.php
+++ b/module/users/functions/save_settings.php
@@ -1,0 +1,31 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) {
+  session_start();
+}
+require_once '../../../includes/php_header.php';
+
+if (!isset($this_user_id)) {
+  exit;
+}
+
+$fields = [
+  'project_status' => 'PROJECT_STATUS',
+  'project_priority' => 'PROJECT_PRIORITY',
+  'project_type' => 'PROJECT_TYPE',
+  'task_status' => 'TASK_STATUS',
+  'task_priority' => 'TASK_PRIORITY',
+];
+
+foreach ($fields as $postField => $listName) {
+  $value = $_POST[$postField] ?? '';
+  if ($value === '') {
+    $stmt = $pdo->prepare('DELETE FROM module_users_defaults WHERE user_id = :uid AND list_name = :list');
+    $stmt->execute([':uid' => $this_user_id, ':list' => $listName]);
+  } else {
+    set_user_default_lookup_item($pdo, $this_user_id, $listName, (int)$value, $this_user_id);
+  }
+}
+
+header('Location: ../index.php?action=settings&saved=1');
+exit;
+?>

--- a/module/users/include/settings.php
+++ b/module/users/include/settings.php
@@ -1,0 +1,88 @@
+<?php
+// User settings page
+?>
+<nav class="mb-3" aria-label="breadcrumb">
+  <ol class="breadcrumb mb-0">
+    <li class="breadcrumb-item"><a href="index.php">Users</a></li>
+    <li class="breadcrumb-item active" aria-current="page">Settings</li>
+  </ol>
+</nav>
+<h2 class="mb-4">User Settings</h2>
+<?php if (!empty($_GET['saved'])): ?>
+<div class="alert alert-success" role="alert">Settings saved.</div>
+<?php endif; ?>
+<div class="row">
+  <div class="col-xl-8">
+    <form class="row g-3 mb-6" method="post" action="index.php?action=save-settings">
+      <h5 class="mb-3">Defaults</h5>
+      <div class="col-12">
+        <h6 class="mb-2">Projects</h6>
+      </div>
+      <div class="col-sm-6 col-md-4">
+        <div class="form-floating">
+          <select class="form-select" id="defaultProjectStatus" name="project_status">
+            <option value="">No default</option>
+            <?php foreach ($projectStatusItems as $item): ?>
+              <option value="<?php echo $item['id']; ?>" <?php if (($userDefaults['PROJECT_STATUS'] ?? '') == $item['id']) echo 'selected'; ?>><?php echo h($item['label']); ?></option>
+            <?php endforeach; ?>
+          </select>
+          <label for="defaultProjectStatus">Status</label>
+        </div>
+      </div>
+      <div class="col-sm-6 col-md-4">
+        <div class="form-floating">
+          <select class="form-select" id="defaultProjectPriority" name="project_priority">
+            <option value="">No default</option>
+            <?php foreach ($projectPriorityItems as $item): ?>
+              <option value="<?php echo $item['id']; ?>" <?php if (($userDefaults['PROJECT_PRIORITY'] ?? '') == $item['id']) echo 'selected'; ?>><?php echo h($item['label']); ?></option>
+            <?php endforeach; ?>
+          </select>
+          <label for="defaultProjectPriority">Priority</label>
+        </div>
+      </div>
+      <div class="col-sm-6 col-md-4">
+        <div class="form-floating">
+          <select class="form-select" id="defaultProjectType" name="project_type">
+            <option value="">No default</option>
+            <?php foreach ($projectTypeItems as $item): ?>
+              <option value="<?php echo $item['id']; ?>" <?php if (($userDefaults['PROJECT_TYPE'] ?? '') == $item['id']) echo 'selected'; ?>><?php echo h($item['label']); ?></option>
+            <?php endforeach; ?>
+          </select>
+          <label for="defaultProjectType">Type</label>
+        </div>
+      </div>
+      <div class="col-12 mt-3">
+        <h6 class="mb-2">Tasks</h6>
+      </div>
+      <div class="col-sm-6 col-md-4">
+        <div class="form-floating">
+          <select class="form-select" id="defaultTaskStatus" name="task_status">
+            <option value="">No default</option>
+            <?php foreach ($taskStatusItems as $item): ?>
+              <option value="<?php echo $item['id']; ?>" <?php if (($userDefaults['TASK_STATUS'] ?? '') == $item['id']) echo 'selected'; ?>><?php echo h($item['label']); ?></option>
+            <?php endforeach; ?>
+          </select>
+          <label for="defaultTaskStatus">Status</label>
+        </div>
+      </div>
+      <div class="col-sm-6 col-md-4">
+        <div class="form-floating">
+          <select class="form-select" id="defaultTaskPriority" name="task_priority">
+            <option value="">No default</option>
+            <?php foreach ($taskPriorityItems as $item): ?>
+              <option value="<?php echo $item['id']; ?>" <?php if (($userDefaults['TASK_PRIORITY'] ?? '') == $item['id']) echo 'selected'; ?>><?php echo h($item['label']); ?></option>
+            <?php endforeach; ?>
+          </select>
+          <label for="defaultTaskPriority">Priority</label>
+        </div>
+      </div>
+      <div class="col-12 gy-6">
+        <div class="row g-3 justify-content-end mt-3">
+          <div class="col-auto">
+            <button class="btn btn-success px-5" type="submit">Save Settings</button>
+          </div>
+        </div>
+      </div>
+    </form>
+  </div>
+</div>

--- a/module/users/index.php
+++ b/module/users/index.php
@@ -35,6 +35,41 @@ if ($action === '2fa') {
   exit;
 }
 
+if ($action === 'save-settings' && $_SERVER['REQUEST_METHOD'] === 'POST') {
+  require 'functions/save_settings.php';
+  exit;
+}
+
+if ($action === 'settings') {
+  $projectStatusItems   = get_lookup_items($pdo, 'PROJECT_STATUS');
+  $projectPriorityItems = get_lookup_items($pdo, 'PROJECT_PRIORITY');
+  $projectTypeItems     = get_lookup_items($pdo, 'PROJECT_TYPE');
+  $taskStatusItems      = get_lookup_items($pdo, 'TASK_STATUS');
+  $taskPriorityItems    = get_lookup_items($pdo, 'TASK_PRIORITY');
+
+  $userDefaults = [
+    'PROJECT_STATUS'   => get_user_default_lookup_item($pdo, $this_user_id, 'PROJECT_STATUS'),
+    'PROJECT_PRIORITY' => get_user_default_lookup_item($pdo, $this_user_id, 'PROJECT_PRIORITY'),
+    'PROJECT_TYPE'     => get_user_default_lookup_item($pdo, $this_user_id, 'PROJECT_TYPE'),
+    'TASK_STATUS'      => get_user_default_lookup_item($pdo, $this_user_id, 'TASK_STATUS'),
+    'TASK_PRIORITY'    => get_user_default_lookup_item($pdo, $this_user_id, 'TASK_PRIORITY'),
+  ];
+
+  require '../../includes/html_header.php';
+  ?>
+  <main class="main" id="top">
+    <?php require "../../includes/left_navigation.php"; ?>
+    <?php require "../../includes/navigation.php"; ?>
+    <div id="main_content" class="content">
+      <?php require 'include/settings.php'; ?>
+      <?php require '../../includes/html_footer.php'; ?>
+    </div>
+  </main>
+  <?php require '../../includes/js_footer.php'; ?>
+  <?php
+  exit;
+}
+
 require '../../includes/html_header.php';
 ?>
 <main class="main" id="top">


### PR DESCRIPTION
## Summary
- add user settings page for selecting default project and task dropdown values
- store user defaults in new `module_users_defaults` table and helper functions
- use per-user defaults in project and task creation forms and navigation link

## Testing
- `php -l includes/navigation.php includes/lookup_helpers.php module/users/include/settings.php module/users/functions/save_settings.php module/users/index.php module/project/include/create_edit.php module/task/index.php module/task/include/form.php`

------
https://chatgpt.com/codex/tasks/task_e_68aa55139d908333bd40393a58835802