### PR TITLE
Load user gender for avatar selection

### DIFF
--- a/includes/navigation.php
+++ b/includes/navigation.php
@@ -136,7 +136,7 @@
 
         <li class="nav-item dropdown"><a class="nav-link lh-1 pe-0 d-flex align-items-center" id="navbarDropdownUser" href="#!" role="button" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-haspopup="true" aria-expanded="false">
             <div class="avatar avatar-l">
-              <img class="rounded-circle" src="<?php echo getURLDir() . (!empty($this_user_profile_pic) ? $this_user_profile_pic : 'assets/img/team/avatar.webp'); ?>" alt="<?php echo $this_user_name; ?>" />
+              <img class="rounded-circle" src="<?php echo getURLDir() . (!empty($this_user_profile_pic) ? $this_user_profile_pic : ('assets/img/team/' . ($this_user_gender_code === 'FEMALE' ? 'avatar-female.webp' : 'avatar.webp'))); ?>" alt="<?php echo $this_user_name; ?>" />
             </div>
             <span class="ms-2 d-none d-sm-inline"><?php echo $this_user_name; ?></span>
           </a>
@@ -145,7 +145,7 @@
               <div class="card-body p-0">
                 <div class="text-center pt-4 pb-3">
                   <div class="avatar avatar-xl ">
-                    <img class="rounded-circle" src="<?php echo getURLDir() . (!empty($this_user_profile_pic) ? $this_user_profile_pic : 'assets/img/team/avatar.webp'); ?>" alt="<?php echo $this_user_name; ?>" />
+                    <img class="rounded-circle" src="<?php echo getURLDir() . (!empty($this_user_profile_pic) ? $this_user_profile_pic : ('assets/img/team/' . ($this_user_gender_code === 'FEMALE' ? 'avatar-female.webp' : 'avatar.webp'))); ?>" alt="<?php echo $this_user_name; ?>" />
                   </div>
                   <h6 class="mt-2 text-body-emphasis"><?php echo $this_user_name; ?></h6>
                 </div>

--- a/includes/php_header.php
+++ b/includes/php_header.php
@@ -31,9 +31,11 @@ if ($is_logged_in) {
   // STRINGS AREN'T FUN IN MySQL QUERIES
   $email = $_SESSION['this_user_email'];
 
-  $sql = "SELECT u.*, upp.file_path
+  $sql = "SELECT u.*, upp.file_path, p.first_name, p.last_name, p.gender_id, lli.code AS gender_code
           FROM users u
           LEFT JOIN users_profile_pics upp ON u.current_profile_pic_id = upp.id
+          LEFT JOIN person p ON u.id = p.user_id
+          LEFT JOIN lookup_list_items lli ON p.gender_id = lli.id
           WHERE u.email = :email";
   $stmt = $pdo->prepare($sql);
   $stmt->bindParam(':email', $email, PDO::PARAM_STR);
@@ -47,16 +49,10 @@ if ($is_logged_in) {
     $this_user_status = $row['status']; // 1 or 0
     $this_user_date_created = $row['date_created'];
     $this_user_last_login = $row['last_login'];
-
-
-    $sql = "SELECT first_name, last_name FROM person p WHERE p.user_id = :user_id";
-    $stmt = $pdo->prepare($sql);
-    $stmt->bindParam(':user_id', $this_user_id, PDO::PARAM_INT);
-    $stmt->execute();
-    if ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-      $this_user_first_name = $row['first_name'];
-      $this_user_last_name = $row['last_name'];
-    }
+    $this_user_first_name = $row['first_name'];
+    $this_user_last_name = $row['last_name'];
+    $this_user_gender_id = $row['gender_id'];
+    $this_user_gender_code = $row['gender_code'];
 
     $this_user_name = $this_user_first_name . " " . $this_user_last_name;
   } // END THIS_USER


### PR DESCRIPTION
## Summary
- Join `person` and `lookup_list_items` when loading session user to expose gender code.
- Use gender-specific default avatars in navigation when profile picture is missing.

## Testing
- `php -l includes/php_header.php`
- `php -l includes/navigation.php`


------
https://chatgpt.com/codex/tasks/task_e_68aa6a2f7100833394dc32e34c2456d3