### PR TITLE
Add role assignment management for users

### DIFF
--- a/admin/users/edit.php
+++ b/admin/users/edit.php
@@ -9,6 +9,9 @@ $dob = '';
 $addresses = [];
 $phones = [];
 
+$roles = [];
+$userRoleIds = [];
+
 $memo = [];
 $profile_pic = '';
 $profilePics = [];
@@ -52,6 +55,13 @@ if ($id) {
 } else {
   require_permission('users','create');
   $defaultPassword = get_system_property($pdo, 'USER_DEFAULT_PASSWORD') ?? '';
+}
+
+$roles = $pdo->query('SELECT id, name FROM admin_roles ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
+if ($id) {
+  $stmt = $pdo->prepare('SELECT role_id FROM admin_user_roles WHERE user_account_id = :uid');
+  $stmt->execute([':uid' => $id]);
+  $userRoleIds = $stmt->fetchAll(PDO::FETCH_COLUMN);
 }
 
 $imageTypes = get_lookup_items($pdo, 'IMAGE_FILE_TYPES');
@@ -185,6 +195,16 @@ $_SESSION['csrf_token'] = $token;
             <label for="confirmPassword">Confirm Password</label>
             <div class="invalid-feedback">Please confirm password.</div>
           </div>
+        </div>
+        <div class="col-12">
+          <h5>Roles</h5>
+          <?php foreach ($roles as $r): ?>
+            <div class="form-check">
+              <input class="form-check-input" type="checkbox" name="roles[]" value="<?= $r['id']; ?>"
+                     id="role_<?= $r['id']; ?>" <?= in_array($r['id'], $userRoleIds) ? 'checked' : ''; ?>>
+              <label for="role_<?= $r['id']; ?>"><?= h($r['name']); ?></label>
+            </div>
+          <?php endforeach; ?>
         </div>
         <div class="col-sm-6 col-md-4">
           <div class="form-floating">

--- a/admin/users/index.php
+++ b/admin/users/index.php
@@ -3,7 +3,7 @@ require '../admin_header.php';
 
 require_permission('users','view');
 
-$users = $pdo->query("SELECT u.id, u.email, CONCAT(p.first_name, ' ', p.last_name) AS name, upp.file_path FROM users u LEFT JOIN person p ON p.user_id = u.id LEFT JOIN users_profile_pics upp ON u.current_profile_pic_id = upp.id ORDER BY u.email")->fetchAll(PDO::FETCH_ASSOC);
+$users = $pdo->query("SELECT u.id, u.email, CONCAT(p.first_name, ' ', p.last_name) AS name, upp.file_path, GROUP_CONCAT(r.name ORDER BY r.name SEPARATOR ', ') AS roles FROM users u LEFT JOIN person p ON p.user_id = u.id LEFT JOIN users_profile_pics upp ON u.current_profile_pic_id = upp.id LEFT JOIN admin_user_roles ur ON u.id = ur.user_account_id LEFT JOIN admin_roles r ON ur.role_id = r.id GROUP BY u.id, u.email, p.first_name, p.last_name, upp.file_path ORDER BY u.email")->fetchAll(PDO::FETCH_ASSOC);
 $message = $_SESSION['message'] ?? '';
 $error_message = $_SESSION['error_message'] ?? '';
 unset($_SESSION['message'], $_SESSION['error_message']);
@@ -25,6 +25,9 @@ if($error_message){ echo '<div class="alert alert-danger">'.htmlspecialchars($er
           </a>
         </h4>
         <?php echo htmlspecialchars($u['email']); ?>
+        <?php if (!empty($u['roles'])): ?>
+          <div class="text-body-secondary small"><?php echo h($u['roles']); ?></div>
+        <?php endif; ?>
       </td>
     </tr>
     <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- Fetch roles and assigned roles to display checkboxes on user edit form
- Sync admin_user_roles assignments on save with audit logging
- Show aggregated user roles in admin user list

## Testing
- `php -l admin/users/edit.php`
- `php -l admin/users/functions/save.php`
- `php -l admin/users/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68aa785d78448333a911e228cb887d60