### PR TITLE
Handle NULL values in system property edit form

### DIFF
--- a/admin/system-properties/edit.php
+++ b/admin/system-properties/edit.php
@@ -53,11 +53,11 @@ if($id){
   </div>
   <div class="mb-3">
     <label class="form-label">Value</label>
-    <textarea class="form-control" name="value" required><?= htmlspecialchars($prop['value']); ?></textarea>
+    <textarea class="form-control" name="value" required><?= htmlspecialchars($prop['value'] ?? ''); ?></textarea>
   </div>
   <div class="mb-3">
     <label class="form-label">Memo</label>
-    <textarea class="form-control" name="memo"><?= htmlspecialchars($prop['memo']); ?></textarea>
+    <textarea class="form-control" name="memo"><?= htmlspecialchars($prop['memo'] ?? ''); ?></textarea>
   </div>
   <button type="submit" class="btn btn-primary">Save</button>
   <a href="index.php" class="btn btn-secondary">Cancel</a>


### PR DESCRIPTION
## Summary
- Avoid warnings by defaulting system property `value` and `memo` to empty strings when NULL

## Testing
- `php -l admin/system-properties/edit.php`


------
https://chatgpt.com/codex/tasks/task_e_68aa6985ac08833389817928095f4642