### PR TITLE
Add JTI employment fields to users

### DIFF
--- a/_SQL/atlis.sql
+++ b/_SQL/atlis.sql
@@ -2577,7 +2577,12 @@ CREATE TABLE `users` (
   `current_profile_pic_id` int(11) DEFAULT NULL,
   `type` enum('ADMIN','USER') DEFAULT 'USER',
   `status` tinyint(1) DEFAULT 1,
-  `last_login` datetime DEFAULT NULL
+  `last_login` datetime DEFAULT NULL,
+  `JTIformer` tinyint(1) DEFAULT 0,
+  `JTIcurrent` tinyint(1) DEFAULT 0,
+  `JTI_start_date` date DEFAULT NULL,
+  `JTI_end_date` date DEFAULT NULL,
+  `JTI_Team` varchar(255) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --

--- a/admin/users/edit.php
+++ b/admin/users/edit.php
@@ -12,6 +12,9 @@ $phones = [];
 $memo = [];
 $profile_pic = '';
 $profilePics = [];
+$JTIformer = $JTIcurrent = 0;
+$JTI_start_date = $JTI_end_date = '';
+$JTI_Team = '';
 
 $defaultPassword = '';
 
@@ -23,7 +26,7 @@ unset($_SESSION['form_errors'], $_SESSION['error_message']);
 
 if ($id) {
   require_permission('users','update');
-  $stmt = $pdo->prepare('SELECT u.email, u.current_profile_pic_id, u.memo, p.id AS person_id, p.first_name, p.last_name, p.gender_id, p.dob, up.file_path AS profile_path FROM users u LEFT JOIN person p ON u.id = p.user_id LEFT JOIN users_profile_pics up ON u.current_profile_pic_id = up.id WHERE u.id = :id');
+  $stmt = $pdo->prepare('SELECT u.email, u.current_profile_pic_id, u.memo, u.JTIformer, u.JTIcurrent, u.JTI_start_date, u.JTI_end_date, u.JTI_Team, p.id AS person_id, p.first_name, p.last_name, p.gender_id, p.dob, up.file_path AS profile_path FROM users u LEFT JOIN person p ON u.id = p.user_id LEFT JOIN users_profile_pics up ON u.current_profile_pic_id = up.id WHERE u.id = :id');
   $stmt->execute([':id' => $id]);
   if ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
     $email = $row['email'];
@@ -34,6 +37,11 @@ if ($id) {
     $gender_id = $row['gender_id'] ?? null;
     $dob = $row['dob'] ?? '';
     $person_id = $row['person_id'] ?? null;
+    $JTIformer = (int)($row['JTIformer'] ?? 0);
+    $JTIcurrent = (int)($row['JTIcurrent'] ?? 0);
+    $JTI_start_date = $row['JTI_start_date'] ?? '';
+    $JTI_end_date = $row['JTI_end_date'] ?? '';
+    $JTI_Team = $row['JTI_Team'] ?? '';
 
     if ($person_id) {
       $stmt = $pdo->prepare('SELECT * FROM person_addresses WHERE person_id = :pid');
@@ -203,6 +211,40 @@ $_SESSION['csrf_token'] = $token;
             <label for="dob">Date of Birth</label>
           </div>
         </div>
+        <div class="col-sm-6 col-md-4 d-flex align-items-center">
+          <div class="form-check">
+            <input class="form-check-input" type="checkbox" id="JTIformer" name="JTIformer" value="1" <?php echo $JTIformer ? 'checked' : ''; ?>>
+            <label class="form-check-label" for="JTIformer">Former JTI Employee</label>
+          </div>
+        </div>
+        <div class="col-sm-6 col-md-4 d-flex align-items-center">
+          <div class="form-check">
+            <input class="form-check-input" type="checkbox" id="JTIcurrent" name="JTIcurrent" value="1" <?php echo $JTIcurrent ? 'checked' : ''; ?>>
+            <label class="form-check-label" for="JTIcurrent">Current JTI Employee</label>
+          </div>
+        </div>
+        <div class="col-12">
+          <div id="jti-details" class="row g-3 d-none">
+            <div class="col-sm-6 col-md-4">
+              <div class="form-floating">
+                <input type="date" class="form-control" id="JTI_start_date" name="JTI_start_date" placeholder="JTI Start Date" value="<?php echo htmlspecialchars($JTI_start_date); ?>">
+                <label for="JTI_start_date">JTI Start Date</label>
+              </div>
+            </div>
+            <div class="col-sm-6 col-md-4">
+              <div class="form-floating">
+                <input type="date" class="form-control" id="JTI_end_date" name="JTI_end_date" placeholder="JTI End Date" value="<?php echo htmlspecialchars($JTI_end_date); ?>">
+                <label for="JTI_end_date">JTI End Date</label>
+              </div>
+            </div>
+            <div class="col-sm-6 col-md-4">
+              <div class="form-floating">
+                <input type="text" class="form-control" id="JTI_Team" name="JTI_Team" placeholder="JTI Team" value="<?php echo htmlspecialchars($JTI_Team); ?>">
+                <label for="JTI_Team">JTI Team</label>
+              </div>
+            </div>
+          </div>
+        </div>
         <div class="col-12">
           <h5 class="mt-4">Phone Numbers</h5>
           <div id="phones-container">
@@ -283,6 +325,28 @@ document.addEventListener('DOMContentLoaded', function () {
           uploadInput.value = '';
         });
     });
+  }
+});
+</script>
+
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+  function toggleJTIDetails() {
+    var container = document.getElementById('jti-details');
+    if (!container) return;
+    var show = document.getElementById('JTIformer').checked || document.getElementById('JTIcurrent').checked;
+    if (show) {
+      container.classList.remove('d-none');
+    } else {
+      container.classList.add('d-none');
+    }
+  }
+  var f = document.getElementById('JTIformer');
+  var c = document.getElementById('JTIcurrent');
+  if (f && c) {
+    f.addEventListener('change', toggleJTIDetails);
+    c.addEventListener('change', toggleJTIDetails);
+    toggleJTIDetails();
   }
 });
 </script>

--- a/admin/users/functions/save.php
+++ b/admin/users/functions/save.php
@@ -20,6 +20,13 @@ $organization_id = isset($_POST['organization_id']) && $_POST['organization_id']
 $agency_id = isset($_POST['agency_id']) && $_POST['agency_id'] !== '' ? (int)$_POST['agency_id'] : null;
 $division_id = isset($_POST['division_id']) && $_POST['division_id'] !== '' ? (int)$_POST['division_id'] : null;
 $dob = $_POST['dob'] ?? '';
+$JTIformer = isset($_POST['JTIformer']) ? 1 : 0;
+$JTIcurrent = isset($_POST['JTIcurrent']) ? 1 : 0;
+$JTI_start_date = $_POST['JTI_start_date'] ?? null;
+$JTI_end_date = $_POST['JTI_end_date'] ?? null;
+$JTI_Team = trim($_POST['JTI_Team'] ?? '');
+if ($JTI_start_date === '') { $JTI_start_date = null; }
+if ($JTI_end_date === '') { $JTI_end_date = null; }
 
 function get_status_id(PDO $pdo, string $code): int {
   $stmt = $pdo->prepare("SELECT li.id FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'USER_PROFILE_PIC_STATUS' AND li.code = :code LIMIT 1");
@@ -185,10 +192,15 @@ try {
   $pdo->beginTransaction();
   $person_id = 0;
   if ($isUpdate) {
-    $fields = 'email = :email, memo = :memo, user_updated = :uid';
+    $fields = 'email = :email, memo = :memo, JTIformer = :JTIformer, JTIcurrent = :JTIcurrent, JTI_start_date = :JTI_start_date, JTI_end_date = :JTI_end_date, JTI_Team = :JTI_Team, user_updated = :uid';
     $params = [
       ':email' => $email,
       ':memo' => $memo,
+      ':JTIformer' => $JTIformer,
+      ':JTIcurrent' => $JTIcurrent,
+      ':JTI_start_date' => $JTI_start_date,
+      ':JTI_end_date' => $JTI_end_date,
+      ':JTI_Team' => $JTI_Team,
       ':uid' => $this_user_id,
       ':id' => $id
     ];
@@ -233,12 +245,17 @@ try {
       admin_audit_log($pdo,$this_user_id,'person',$person_id,'CREATE',null,json_encode(['user_id'=>$id,'first_name'=>$first_name,'last_name'=>$last_name,'gender_id'=>$gender_id,'organization_id'=>$organization_id,'agency_id'=>$agency_id,'division_id'=>$division_id,'dob'=>$dob ?: null]),'Created person');
     }
   } else {
-    $stmt = $pdo->prepare('INSERT INTO users (user_id, user_updated, email, password, memo) VALUES (:uid, :uid, :email, :password, :memo)');
+    $stmt = $pdo->prepare('INSERT INTO users (user_id, user_updated, email, password, memo, JTIformer, JTIcurrent, JTI_start_date, JTI_end_date, JTI_Team) VALUES (:uid, :uid, :email, :password, :memo, :JTIformer, :JTIcurrent, :JTI_start_date, :JTI_end_date, :JTI_Team)');
     $stmt->execute([
       ':uid' => $this_user_id,
       ':email' => $email,
       ':password' => $hash,
-      ':memo' => $memo
+      ':memo' => $memo,
+      ':JTIformer' => $JTIformer,
+      ':JTIcurrent' => $JTIcurrent,
+      ':JTI_start_date' => $JTI_start_date,
+      ':JTI_end_date' => $JTI_end_date,
+      ':JTI_Team' => $JTI_Team
     ]);
     $id = (int)$pdo->lastInsertId();
 


### PR DESCRIPTION
## Summary
- add JTI employment columns to users schema
- collect and toggle JTI employment details on user edit form
- persist JTI employment fields in user save logic

## Testing
- `php -l admin/users/edit.php`
- `php -l admin/users/functions/save.php`
- `mysql -uroot atlis -e "ALTER TABLE users ADD COLUMN JTIformer TINYINT(1) DEFAULT 0, ADD COLUMN JTIcurrent TINYINT(1) DEFAULT 0, ADD COLUMN JTI_start_date DATE DEFAULT NULL, ADD COLUMN JTI_end_date DATE DEFAULT NULL, ADD COLUMN JTI_Team VARCHAR(255) DEFAULT NULL;"` *(fails: Can't connect to local server through socket '/run/mysqld/mysqld.sock')*

------
https://chatgpt.com/codex/tasks/task_e_68aa6978e5e48333834c5d5aa2d08859