### PR TITLE
Add project pin capability and order projects by pin

### DIFF
--- a/_SQL/atlis.sql
+++ b/_SQL/atlis.sql
@@ -2382,6 +2382,25 @@ INSERT INTO `module_projects_questions` (`id`, `user_id`, `user_updated`, `date_
 -- --------------------------------------------------------
 
 --
+-- Table structure for table `module_projects_pins`
+--
+
+CREATE TABLE `module_projects_pins` (
+  `id` INT(11) AUTO_INCREMENT PRIMARY KEY,
+  `user_id` INT(11) NOT NULL,           -- FK to users.id
+  `user_updated` INT(11) DEFAULT NULL,
+  `date_created` DATETIME DEFAULT CURRENT_TIMESTAMP,
+  `date_updated` DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `memo` TEXT DEFAULT NULL,
+  `project_id` INT(11) NOT NULL,        -- FK to module_projects.id
+  UNIQUE KEY `uq_user_project` (`user_id`,`project_id`),
+  CONSTRAINT `fk_project_pin_user` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`),
+  CONSTRAINT `fk_project_pin_project` FOREIGN KEY (`project_id`) REFERENCES `module_projects`(`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+
+--
 -- Table structure for table `module_tasks`
 --
 

--- a/module/project/functions/toggle_pin.php
+++ b/module/project/functions/toggle_pin.php
@@ -1,0 +1,26 @@
+<?php
+require '../../../includes/php_header.php';
+require_permission('project','read');
+
+header('Content-Type: application/json');
+
+$project_id = (int)($_POST['project_id'] ?? 0);
+$pinned = false;
+
+if ($project_id) {
+    $check = $pdo->prepare('SELECT id FROM module_projects_pins WHERE user_id = :uid AND project_id = :pid');
+    $check->execute([':uid' => $this_user_id, ':pid' => $project_id]);
+    $pin_id = $check->fetchColumn();
+
+    if ($pin_id) {
+        $del = $pdo->prepare('DELETE FROM module_projects_pins WHERE id = :id');
+        $del->execute([':id' => $pin_id]);
+        $pinned = false;
+    } else {
+        $ins = $pdo->prepare('INSERT INTO module_projects_pins (user_id,user_updated,project_id) VALUES (:uid,:uid,:pid)');
+        $ins->execute([':uid' => $this_user_id, ':pid' => $project_id]);
+        $pinned = true;
+    }
+}
+
+echo json_encode(['pinned' => $pinned]);

--- a/module/project/include/card_view.php
+++ b/module/project/include/card_view.php
@@ -57,6 +57,9 @@ foreach ($projects as $proj) {
     <div class="card h-100 hover-actions-trigger">
       <div class="card-body position-relative">
         <div class="d-flex align-items-center">
+          <button class="btn btn-link p-0 me-2 pin-toggle" data-project-id="<?php echo (int)$project['id']; ?>" title="Toggle pin">
+            <span class="fa-solid fa-thumbtack <?php echo $project['pinned'] ? 'text-warning' : 'text-body-tertiary'; ?>"></span>
+          </button>
           <h4 class="mb-2 line-clamp-1 lh-sm flex-1 me-5"><a href="index.php?action=details&id=<?php echo (int)$project['id']; ?>"><?php echo h($project['name']); ?></a></h4>
           <div class="hover-actions top-0 end-0 mt-4 me-4"><a class="btn btn-primary btn-icon flex-shrink-0" href="index.php?action=details&id=<?php echo (int)$project['id']; ?>"><span class="fa-solid fa-chevron-right"></span></a></div>
         </div>
@@ -111,6 +114,34 @@ document.addEventListener('click', function (e) {
     var img = document.getElementById('modalImage');
     if (img) { img.src = src; }
   }
+});
+
+document.addEventListener('DOMContentLoaded', function () {
+  document.querySelectorAll('.pin-toggle').forEach(btn => {
+    btn.addEventListener('click', async e => {
+      e.preventDefault();
+      const projectId = btn.dataset.projectId;
+      const icon = btn.querySelector('span');
+      if (!projectId || !icon) return;
+      try {
+        const res = await fetch('functions/toggle_pin.php', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: new URLSearchParams({ project_id: projectId })
+        });
+        const data = await res.json();
+        if (data.pinned) {
+          icon.classList.add('text-warning');
+          icon.classList.remove('text-body-tertiary');
+        } else {
+          icon.classList.add('text-body-tertiary');
+          icon.classList.remove('text-warning');
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    });
+  });
 });
 </script>
 

--- a/module/project/include/list_view.php
+++ b/module/project/include/list_view.php
@@ -92,7 +92,10 @@
             </span>
           </td>
           <td class="align-middle text-end">
-            <div class="btn-reveal-trigger position-static">
+            <div class="btn-reveal-trigger position-static d-flex justify-content-end align-items-center gap-2">
+              <button class="btn btn-link p-0 pin-toggle" data-project-id="<?php echo (int)$project['id']; ?>" title="Toggle pin">
+                <span class="fa-solid fa-thumbtack <?php echo $project['pinned'] ? 'text-warning' : 'text-body-tertiary'; ?>"></span>
+              </button>
               <a class="btn btn-sm dropdown-toggle dropdown-caret-none transition-none btn-reveal fs-10" href="index.php?action=details&id=<?php echo $project['id']; ?>"><span class="fas fa-chevron-right fs-10"></span></a>
             </div>
           </td>
@@ -134,5 +137,31 @@ document.addEventListener('DOMContentLoaded', function () {
 
   statusFilter.addEventListener('change', applyFilters);
   priorityFilter.addEventListener('change', applyFilters);
+
+  document.querySelectorAll('.pin-toggle').forEach(btn => {
+    btn.addEventListener('click', async e => {
+      e.preventDefault();
+      const projectId = btn.dataset.projectId;
+      const icon = btn.querySelector('span');
+      if (!projectId || !icon) return;
+      try {
+        const res = await fetch('functions/toggle_pin.php', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: new URLSearchParams({ project_id: projectId })
+        });
+        const data = await res.json();
+        if (data.pinned) {
+          icon.classList.add('text-warning');
+          icon.classList.remove('text-body-tertiary');
+        } else {
+          icon.classList.add('text-body-tertiary');
+          icon.classList.remove('text-warning');
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    });
+  });
 });
 </script>

--- a/module/project/index.php
+++ b/module/project/index.php
@@ -45,7 +45,8 @@ $sql = "SELECT p.id,
                d.name AS division_name,
                COUNT(t.id) AS total_tasks,
                SUM(CASE WHEN t.completed = 1 THEN 1 ELSE 0 END) AS completed_tasks,
-               SUM(CASE WHEN t.completed = 0 OR t.completed IS NULL THEN 1 ELSE 0 END) AS in_progress
+               SUM(CASE WHEN t.completed = 0 OR t.completed IS NULL THEN 1 ELSE 0 END) AS in_progress,
+               pp.id AS pinned
         FROM module_projects p
         LEFT JOIN lookup_list_items li ON p.status = li.id
         LEFT JOIN lookup_list_item_attributes attr ON li.id = attr.item_id AND attr.attr_code = 'COLOR-CLASS'
@@ -53,11 +54,14 @@ $sql = "SELECT p.id,
         LEFT JOIN lookup_list_item_attributes pattr ON lp.id = pattr.item_id AND pattr.attr_code = 'COLOR-CLASS'
         LEFT JOIN module_agency a ON p.agency_id = a.id
         LEFT JOIN module_division d ON p.division_id = d.id
+        LEFT JOIN module_projects_pins pp ON pp.project_id = p.id AND pp.user_id = :uid
         LEFT JOIN module_tasks t ON t.project_id = p.id
         GROUP BY p.id
-        ORDER BY p.name";
+        ORDER BY (pp.id IS NOT NULL) DESC, p.name";
 
-$projects = $pdo->query($sql)->fetchAll(PDO::FETCH_ASSOC);
+$stmt = $pdo->prepare($sql);
+$stmt->execute([':uid' => $this_user_id]);
+$projects = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
 $assignStmt = $pdo->query("SELECT pa.project_id, pa.assigned_user_id, upp.file_path, CONCAT(per.first_name, ' ', per.last_name) AS name
                            FROM module_projects_assignments pa


### PR DESCRIPTION
## Summary
- create `module_projects_pins` table for tracking user project pins
- add endpoint to toggle project pin status
- sort project listing by current user's pins
- surface pin buttons in list and card views and toggle icon safely

## Testing
- `php -l module/project/functions/toggle_pin.php`
- `php -l module/project/include/card_view.php`
- `php -l module/project/include/list_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68a9601d02d483338a91472df05bdd76