### PR TITLE
Add answer file deletion and gated file controls

### DIFF
--- a/module/project/functions/delete_answer.php
+++ b/module/project/functions/delete_answer.php
@@ -9,6 +9,17 @@ if ($answer_id && $project_id) {
   $stmt->execute([':id' => $answer_id]);
   $answer = $stmt->fetch(PDO::FETCH_ASSOC);
   if ($answer && ($is_admin || (int)$answer['user_id'] === (int)$this_user_id)) {
+    $stmtF = $pdo->prepare('SELECT id, file_path, file_name FROM module_projects_files WHERE answer_id = :aid');
+    $stmtF->execute([':aid' => $answer_id]);
+    $files = $stmtF->fetchAll(PDO::FETCH_ASSOC);
+    foreach ($files as $file) {
+      $pdo->prepare('DELETE FROM module_projects_files WHERE id = :id')->execute([':id' => $file['id']]);
+      $fullPath = dirname(__DIR__,3) . $file['file_path'];
+      if (is_file($fullPath)) {
+        unlink($fullPath);
+      }
+      admin_audit_log($pdo, $this_user_id, 'module_projects_files', $file['id'], 'DELETE', json_encode(['file' => $file['file_name']]), '');
+    }
     $pdo->prepare('DELETE FROM module_projects_answers WHERE id = :id')->execute([':id' => $answer_id]);
     admin_audit_log($pdo, $this_user_id, 'module_projects_answers', $answer_id, 'DELETE', '', $answer['answer_text']);
   }

--- a/module/project/include/details_view.php
+++ b/module/project/include/details_view.php
@@ -273,13 +273,12 @@ if (!empty($current_project)) {
                             <a href="#" data-bs-toggle="modal" data-bs-target="#fileModal" data-file-src="<?php echo getURLDir(); ?><?= h($f['file_path']) ?>" data-file-type="<?= h($f['file_type']) ?>" data-file-code="<?= h($f['type_code'] ?? '') ?>">
                               <img class="img-fluid rounded" src="<?php echo getURLDir(); ?><?= h($f['file_path']) ?>" alt="<?= h($f['file_name']) ?>">
                             </a>
-                            <?php if ($is_admin || ($f['user_id'] ?? 0) == $this_user_id): ?>
+                            <?php if (user_has_permission('project','create|update|delete') && ($is_admin || ($f['user_id'] ?? 0) == $this_user_id)): ?>
                               <form action="functions/delete_file.php" method="post" class="position-absolute top-0 end-0 m-2" onsubmit="return confirm('Delete this file?');">
                                 <input type="hidden" name="id" value="<?= (int)$f['id'] ?>">
                                 <input type="hidden" name="project_id" value="<?= (int)$current_project['id'] ?>">
                                 <button class="btn btn-danger btn-sm" type="submit"><span class="fa-solid fa-trash"></span></button>
                               </form>
-
                             <?php endif; ?>
                           </div>
                         <?php endforeach; ?>
@@ -298,10 +297,18 @@ if (!empty($current_project)) {
                                 <a class="text-body-highlight" href="#" data-bs-toggle="modal" data-bs-target="#fileModal" data-file-src="<?php echo getURLDir(); ?><?= h($f['file_path']) ?>" data-file-type="<?= h($f['file_type']) ?>" data-file-code="<?= h($f['type_code'] ?? '') ?>"><?= h($f['file_name']) ?></a>
                               </p>
                             </div>
-                            <div class="d-flex fs-9 text-body-tertiary mb-0 flex-wrap"><span><?= h($f['file_size']) ?></span><span class="text-body-quaternary mx-1">| </span><span class="text-nowrap"><?= h($f['file_type']) ?></span><span class="text-body-quaternary mx-1">| </span><span class="text-nowrap"><?= h($f['date_created']) ?></span><span class="text-body-quaternary mx-1">|</span><span class="text-nowrap">by <?= h($f['user_name'] ?? '') ?></span></div>
+                            <?php if (user_has_permission('project','create|update|delete') && ($is_admin || ($f['user_id'] ?? 0) == $this_user_id)): ?>
+                            <form action="functions/delete_file.php" method="post" onsubmit="return confirm('Delete this file?');">
+                              <input type="hidden" name="id" value="<?= (int)$f['id'] ?>">
+                              <input type="hidden" name="project_id" value="<?= (int)$current_project['id'] ?>">
+                              <button class="btn btn-danger btn-sm" type="submit"><span class="fa-solid fa-trash"></span></button>
+                            </form>
+                            <?php endif; ?>
                           </div>
+                          <div class="d-flex fs-9 text-body-tertiary mb-0 flex-wrap"><span><?= h($f['file_size']) ?></span><span class="text-body-quaternary mx-1">| </span><span class="text-nowrap"><?= h($f['file_type']) ?></span><span class="text-body-quaternary mx-1">| </span><span class="text-nowrap"><?= h($f['date_created']) ?></span><span class="text-body-quaternary mx-1">|</span><span class="text-nowrap">by <?= h($f['user_name'] ?? '') ?></span></div>
                         </div>
-                      <?php endforeach; ?>
+                      </div>
+                    <?php endforeach; ?>
                     <?php endif; ?>
 
                   <?php if (empty($imageFiles) && empty($otherFiles)): ?>
@@ -472,6 +479,13 @@ if (!empty($current_project)) {
                                       <a class="text-body-highlight" href="#" data-bs-toggle="modal" data-bs-target="#fileModal" data-file-src="<?php echo getURLDir(); ?><?= h($f['file_path']) ?>" data-file-type="<?= h($f['file_type']) ?>" data-file-code="<?= h($f['type_code'] ?? '') ?>"><?= h($f['file_name']) ?></a>
                                     <?php endif; ?>
                                   </p>
+                                  <?php if (user_has_permission('project','create|update|delete') && ($is_admin || ($f['user_id'] ?? 0) == $this_user_id)): ?>
+                                  <form action="functions/delete_file.php" method="post" class="ms-2" onsubmit="return confirm('Delete this file?');">
+                                    <input type="hidden" name="id" value="<?= (int)$f['id'] ?>">
+                                    <input type="hidden" name="project_id" value="<?= (int)$current_project['id'] ?>">
+                                    <button class="btn btn-danger btn-sm" type="submit"><span class="fa-solid fa-trash"></span></button>
+                                  </form>
+                                  <?php endif; ?>
                                 </div>
                               </li>
                             <?php endforeach; ?>

--- a/module/task/functions/delete_answer.php
+++ b/module/task/functions/delete_answer.php
@@ -9,6 +9,17 @@ if ($answer_id && $task_id) {
   $stmt->execute([':id' => $answer_id]);
   $answer = $stmt->fetch(PDO::FETCH_ASSOC);
   if ($answer && ($is_admin || (int)$answer['user_id'] === (int)$this_user_id)) {
+    $stmtF = $pdo->prepare('SELECT id, file_path, file_name FROM module_tasks_files WHERE answer_id = :aid');
+    $stmtF->execute([':aid' => $answer_id]);
+    $files = $stmtF->fetchAll(PDO::FETCH_ASSOC);
+    foreach ($files as $file) {
+      $pdo->prepare('DELETE FROM module_tasks_files WHERE id = :id')->execute([':id' => $file['id']]);
+      $fullPath = __DIR__ . '/../../..' . $file['file_path'];
+      if (is_file($fullPath)) {
+        unlink($fullPath);
+      }
+      admin_audit_log($pdo, $this_user_id, 'module_tasks_files', $file['id'], 'DELETE', '', json_encode(['file' => $file['file_name']]));
+    }
     $pdo->prepare('DELETE FROM module_tasks_answers WHERE id = :id')->execute([':id' => $answer_id]);
     admin_audit_log($pdo, $this_user_id, 'module_tasks_answers', $answer_id, 'DELETE', '', $answer['answer_text']);
   }

--- a/module/task/include/details_view.php
+++ b/module/task/include/details_view.php
@@ -162,6 +162,13 @@ require_once __DIR__ . '/../../../includes/functions.php';
                                     <a class="text-body-highlight" href="<?php echo getURLDir(); ?><?= h($f['file_path']) ?>"><?= h($f['file_name']) ?></a>
                                   <?php endif; ?>
                                 </p>
+                                <?php if (user_has_permission('task','create|update|delete') && ($is_admin || ($f['user_id'] ?? 0) == $this_user_id)): ?>
+                                <form action="functions/delete_file.php" method="post" class="ms-2" onsubmit="return confirm('Delete this file?');">
+                                  <input type="hidden" name="id" value="<?= (int)$f['id']; ?>">
+                                  <input type="hidden" name="task_id" value="<?= (int)$current_task['id']; ?>">
+                                  <button class="btn btn-danger btn-sm" type="submit"><span class="fa-solid fa-trash"></span></button>
+                                </form>
+                                <?php endif; ?>
                               </div>
                             </li>
                           <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- Remove files tied to answers in task and project modules and log each deletion
- Allow deleting note attachments with permission checks
- Add gated delete controls for project files

## Testing
- `php -l module/task/functions/delete_answer.php`
- `php -l module/project/functions/delete_answer.php`
- `php -l module/task/include/details_view.php`
- `php -l module/project/include/details_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68aaadad3d788333b02fa58dc27d959e