### PR TITLE
Remove Meetings option from top navigation

### DIFF
--- a/includes/navigation.php
+++ b/includes/navigation.php
@@ -56,16 +56,6 @@
         <?php // ================ ?>
         <?php // END TASKS NAV LINK ?>
         <?php // ================ ?>
-        <?php // MEETINGS NAV LINK ?>
-        <?php if (user_has_permission('meeting','read')): ?>
-        <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle lh-1" href="<?php echo getURLDir(); ?>module/meeting/">
-            <span class="uil fs-8 me-2 fas fa-handshake"></span>Meetings</a>
-        </li>
-        <?php endif; ?>
-        <?php // ================ ?>
-        <?php // END MEETINGS NAV LINK ?>
-        <?php // ================ ?>
         <?php // CALENDAR NAV LINK ?>
         <?php if (user_has_permission('calendar','read')): ?>
         <li class="nav-item dropdown">


### PR DESCRIPTION
## Summary
- drop Meetings link and permission check from main navigation
- verify no other public menu references Meetings

## Testing
- `php -l includes/navigation.php`
- `rg -n "Meetings" includes`


------
https://chatgpt.com/codex/tasks/task_e_68aaad5a8c5483339fc9365064316373