### PR TITLE
Showcase all custom Phoenix colors

### DIFF
--- a/admin/branding/index.php
+++ b/admin/branding/index.php
@@ -6,18 +6,22 @@ require_permission('branding','read');
 $cssPath = __DIR__ . '/../../assets/css/user.css';
 $css = file_get_contents($cssPath);
 $block = '';
-if (preg_match('/\/\* ===== Additional Custom Color Themes ===== \*\/(.*?)(?:\/\*|$)/s', $css, $m)) {
+// Capture the entire :root { ... } section following the Additional Custom Color Themes comment
+if (preg_match('/\/\* ===== Additional Custom Color Themes ===== \*\/.*?(\:root\s*{[^}]*})/s', $css, $m)) {
     $block = $m[1];
 }
 $customColors = [];
 if ($block) {
-    if (preg_match_all('/--([a-z0-9]+):\s*(#[0-9a-fA-F]{3,8});/i', $block, $matches)) {
-        $customColors = array_combine($matches[1], $matches[2]);
+    // Match variables like --sunset: but ignore --sunset-hover
+    if (preg_match_all('/--([a-z0-9]+):/i', $block, $matches)) {
+        $customColors = array_unique($matches[1]);
     }
 }
+// Ensure the primary brand color is included
+$customColors[] = 'atlis';
+$customColors = array_values(array_unique($customColors));
 
 $bootstrapColors = ['primary','secondary','success','danger','warning','info','light','dark'];
-$phoenixColors = ['atlis'];
 ?>
 <h2 class="mb-4">Branding Colors</h2>
 
@@ -37,23 +41,9 @@ $phoenixColors = ['atlis'];
 
 <h3>Custom Colors</h3>
 <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-3 mb-5">
-<?php foreach ($customColors as $name => $hex): 
+<?php foreach ($customColors as $name):
     $label = ucfirst($name);
     $html = '<span class="badge rounded-pill badge-phoenix badge-phoenix-' . $name . '">' . $label . '</span>';
-?>
-  <div class="col">
-    <?= $html ?>
-    <button class="btn btn-sm btn-link p-0 ms-1 copy-snippet" data-snippet="<?= htmlspecialchars($html, ENT_QUOTES) ?>" title="Copy HTML"><span class="fa-regular fa-copy"></span></button>
-    <code class="d-block mt-1"><?= htmlspecialchars($html) ?></code>
-  </div>
-<?php endforeach; ?>
-</div>
-
-<h3>Phoenix Variations</h3>
-<div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-3 mb-5">
-<?php foreach ($phoenixColors as $color): 
-    $label = ucfirst($color);
-    $html = '<span class="badge rounded-pill badge-phoenix badge-phoenix-' . $color . '">' . $label . '</span>';
 ?>
   <div class="col">
     <?= $html ?>


### PR DESCRIPTION
## Summary
- Capture the full Additional Custom Color Themes block from `user.css`
- Extract unique base color names and include the `atlis` brand color
- Render Phoenix badges with copy-to-clipboard snippets for every custom color

## Testing
- `php -l admin/branding/index.php`
- `php -r '$css=file_get_contents("assets/css/user.css");if(preg_match("/\/\* ===== Additional Custom Color Themes ===== \*\/.*?(\:root\s*{[^}]*})/s",$css,$m)){ $block=$m[1];} else $block="";$custom=[]; if($block && preg_match_all("/--([a-z0-9]+):/i",$block,$matches)){ $custom=array_unique($matches[1]);} $custom[]="atlis"; $custom=array_values(array_unique($custom)); print_r($custom);'`

------
https://chatgpt.com/codex/tasks/task_e_68aabb1fb02c8333bba204eccf28d7c2