### PR TITLE
Enhance task details summary grid

### DIFF
--- a/module/task/index.php
+++ b/module/task/index.php
@@ -251,6 +251,7 @@ if ($action === 'details') {
 
   $taskSql =
     'SELECT t.id, t.name, t.description, t.status, t.priority,' .
+            ' t.start_date, t.due_date, t.progress_percent, t.requirements, t.specifications,' .
             ' t.project_id, t.division_id, t.agency_id, t.completed, t.completed_by,' .
             ' p.name AS project_name,' .
             ' d.name AS division_name,' .


### PR DESCRIPTION
## Summary
- Include start, due, progress, requirements, and specifications in task details query
- Add Phoenix grid on task details page with editable dates, progress bar, and collapsible requirements/specifications
- Wire up inline date updates via AJAX

## Testing
- `php -l module/task/index.php`
- `php -l module/task/include/details_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68aaca33eaac8333893eb0d30541a43d