### PR TITLE
feat: enable self assignment and inline badge editing

### DIFF
--- a/module/task/include/details_view.php
+++ b/module/task/include/details_view.php
@@ -30,24 +30,26 @@ require_once __DIR__ . '/../../../includes/functions.php';
       <p class="text-body-secondary mb-0"><?php echo implode(' / ', array_map('h', $hierarchyParts)); ?></p>
     <?php endif; ?>
     <p class="mb-3 mt-3">
-      <?= render_status_badge($statusMap, $current_task['status'], 'fs-8', ['id' => 'statusBadge']) ?>
-      <?= render_status_badge($priorityMap, $current_task['priority'], 'fs-8', ['id' => 'priorityBadge']) ?>
-      <?php if (user_has_permission('task','update')): ?>
-      <form id="taskUpdateForm" class="d-inline ms-2">
-        <input type="hidden" name="id" value="<?php echo (int)$current_task['id']; ?>">
-        <select class="form-select form-select-sm d-inline w-auto" name="status">
+      <div class="dropdown d-inline">
+        <?= render_status_badge($statusMap, $current_task['status'], 'fs-8' . (user_has_permission('task','update') ? ' dropdown-toggle' : ''), array_merge(['id' => 'statusBadge'], user_has_permission('task','update') ? ['data-bs-toggle' => 'dropdown', 'role' => 'button'] : [])) ?>
+        <?php if (user_has_permission('task','update')): ?>
+        <ul class="dropdown-menu">
           <?php foreach ($statusMap as $sid => $s): ?>
-            <option value="<?php echo (int)$sid; ?>" data-color="<?php echo h($s['color_class']); ?>" <?php echo ((int)$current_task['status'] === (int)$sid) ? 'selected' : ''; ?>><?php echo h($s['label']); ?></option>
+            <li><a class="dropdown-item task-field-option" data-field="status" data-value="<?= (int)$sid; ?>" data-color="<?= h($s['color_class']); ?>"><?= h($s['label']); ?></a></li>
           <?php endforeach; ?>
-        </select>
-        <select class="form-select form-select-sm d-inline w-auto ms-1" name="priority">
+        </ul>
+        <?php endif; ?>
+      </div>
+      <div class="dropdown d-inline ms-2">
+        <?= render_status_badge($priorityMap, $current_task['priority'], 'fs-8' . (user_has_permission('task','update') ? ' dropdown-toggle' : ''), array_merge(['id' => 'priorityBadge'], user_has_permission('task','update') ? ['data-bs-toggle' => 'dropdown', 'role' => 'button'] : [])) ?>
+        <?php if (user_has_permission('task','update')): ?>
+        <ul class="dropdown-menu">
           <?php foreach ($priorityMap as $pid => $p): ?>
-            <option value="<?php echo (int)$pid; ?>" data-color="<?php echo h($p['color_class']); ?>" <?php echo ((int)$current_task['priority'] === (int)$pid) ? 'selected' : ''; ?>><?php echo h($p['label']); ?></option>
+            <li><a class="dropdown-item task-field-option" data-field="priority" data-value="<?= (int)$pid; ?>" data-color="<?= h($p['color_class']); ?>"><?= h($p['label']); ?></a></li>
           <?php endforeach; ?>
-        </select>
-        <button class="btn btn-atlis btn-sm ms-1" type="submit">Update</button>
-      </form>
-      <?php endif; ?>
+        </ul>
+        <?php endif; ?>
+      </div>
     </p>
     <?php if (!empty($current_task['completed_by_name'])): ?>
       <p class="text-body-secondary mb-3">Completed by <?php echo h($current_task['completed_by_name']); ?></p>
@@ -63,9 +65,16 @@ require_once __DIR__ . '/../../../includes/functions.php';
         <div class="d-flex align-items-center mb-4">
           <h4 class="text-body-emphasis mb-0 me-2">Assigned</h4>
           <?php if (user_has_permission('task','update')): ?>
-            <button class="bg-transparent border-0 text-success fs-9" type="button" data-bs-toggle="modal" data-bs-target="#assignUserModal" aria-label="Assign user">
+            <button class="bg-transparent border-0 text-success fs-9 me-1" type="button" data-bs-toggle="modal" data-bs-target="#assignUserModal" aria-label="Assign user">
               <span class="fa-solid fa-plus"></span>
             </button>
+          <?php endif; ?>
+          <?php if (user_has_permission('task','update') && !$alreadyAssigned && (empty($current_task['project_id']) || !empty($current_task['project_assigned']))): ?>
+            <form method="post" action="functions/assign_user.php" class="d-inline">
+              <input type="hidden" name="task_id" value="<?= (int)$current_task['id']; ?>">
+              <input type="hidden" name="user_id" value="<?= (int)$this_user_id; ?>">
+              <button class="btn btn-success btn-sm p-1" type="submit"><span class="fa-solid fa-user-plus"></span></button>
+            </form>
           <?php endif; ?>
         </div>
         <?php if (!empty($assignedUsers)): ?>
@@ -424,34 +433,39 @@ require_once __DIR__ . '/../../../includes/functions.php';
       });
     }
 
-    var updateForm = document.getElementById('taskUpdateForm');
-    if (updateForm) {
-      updateForm.addEventListener('submit', function (e) {
+    var taskId = <?= (int)$current_task['id']; ?>;
+    document.querySelectorAll('.task-field-option').forEach(function (opt) {
+      opt.addEventListener('click', function (e) {
         e.preventDefault();
-        var formData = new FormData(updateForm);
-        fetch('functions/update.php', {
+        var field = opt.getAttribute('data-field');
+        var value = opt.getAttribute('data-value');
+        fetch('functions/update_field.php', {
           method: 'POST',
-          body: formData
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: new URLSearchParams({ id: taskId, field: field, value: value })
         })
         .then(function (res) { return res.json(); })
         .then(function (data) {
           if (data.success && data.task) {
-            var statusBadge = document.getElementById('statusBadge');
-            var priorityBadge = document.getElementById('priorityBadge');
-            if (statusBadge) {
-              statusBadge.className = 'badge badge-phoenix fs-8 badge-phoenix-' + (data.task.status_color || 'secondary');
-              var sLabel = statusBadge.querySelector('.badge-label');
-              if (sLabel) { sLabel.textContent = data.task.status_label || ''; }
-            }
-            if (priorityBadge) {
-              priorityBadge.className = 'badge badge-phoenix fs-8 badge-phoenix-' + (data.task.priority_color || 'secondary');
-              var pLabel = priorityBadge.querySelector('.badge-label');
-              if (pLabel) { pLabel.textContent = data.task.priority_label || ''; }
+            if (field === 'status') {
+              var statusBadge = document.getElementById('statusBadge');
+              if (statusBadge) {
+                statusBadge.className = 'badge badge-phoenix fs-8 badge-phoenix-' + (data.task.status_color || 'secondary') + ' dropdown-toggle';
+                var sLabel = statusBadge.querySelector('.badge-label');
+                if (sLabel) { sLabel.textContent = data.task.status_label || ''; }
+              }
+            } else if (field === 'priority') {
+              var priorityBadge = document.getElementById('priorityBadge');
+              if (priorityBadge) {
+                priorityBadge.className = 'badge badge-phoenix fs-8 badge-phoenix-' + (data.task.priority_color || 'secondary') + ' dropdown-toggle';
+                var pLabel = priorityBadge.querySelector('.badge-label');
+                if (pLabel) { pLabel.textContent = data.task.priority_label || ''; }
+              }
             }
           }
         });
       });
-    }
+    });
 
     var editBtn = document.getElementById('editTaskBtn');
     if (editBtn) {

--- a/module/task/index.php
+++ b/module/task/index.php
@@ -256,19 +256,20 @@ if ($action === 'details') {
             ' d.name AS division_name,' .
             ' a.name AS agency_name,' .
             ' o.name AS organization_name,' .
+            ' CASE WHEN mpa.project_id IS NULL THEN 0 ELSE 1 END AS project_assigned,' .
             ' CONCAT(cbp.first_name, " ", cbp.last_name) AS completed_by_name' .
      ' FROM module_tasks t' .
      ' LEFT JOIN module_projects p ON t.project_id = p.id' .
+     ' LEFT JOIN module_projects_assignments mpa ON t.project_id = mpa.project_id AND mpa.assigned_user_id = :uid' .
      ' LEFT JOIN module_division d ON t.division_id = d.id' .
      ' LEFT JOIN module_agency a ON t.agency_id = a.id' .
      ' LEFT JOIN module_organization o ON a.organization_id = o.id' .
      ' LEFT JOIN users cb ON t.completed_by = cb.id' .
      ' LEFT JOIN person cbp ON cb.id = cbp.user_id' .
      ' WHERE t.id = :id';
-  $taskParams = [':id' => $task_id];
+  $taskParams = [':id' => $task_id, ':uid' => $this_user_id];
   if (!user_has_role('Admin')) {
     $taskSql .= ' AND (p.id IS NULL OR p.is_private = 0 OR p.user_id = :uid) AND (t.project_id IS NOT NULL OR t.is_private = 0 OR t.user_id = :uid)';
-    $taskParams[':uid'] = $this_user_id;
   }
   $stmt = $pdo->prepare($taskSql);
   $stmt->execute($taskParams);
@@ -281,11 +282,13 @@ if ($action === 'details') {
   $availableUsers = [];
   $questions = [];
   $questionAnswers = [];
+  $alreadyAssigned = false;
   if ($current_task) {
 
       $assignedStmt = $pdo->prepare('SELECT mta.assigned_user_id AS user_id, upp.file_path AS user_pic, CONCAT(p.first_name, " ", p.last_name) AS name FROM module_task_assignments mta JOIN users u ON mta.assigned_user_id = u.id LEFT JOIN users_profile_pics upp ON u.current_profile_pic_id = upp.id LEFT JOIN person p ON u.id = p.user_id WHERE mta.task_id = :id');
-      $assignedStmt->execute([':id' => $task_id]);
+    $assignedStmt->execute([':id' => $task_id]);
     $assignedUsers = $assignedStmt->fetchAll(PDO::FETCH_ASSOC);
+    $alreadyAssigned = in_array($this_user_id, array_column($assignedUsers, 'user_id'));
 
     $assignedIds = array_column($assignedUsers, 'user_id');
     if (!empty($current_task['project_id'])) {


### PR DESCRIPTION
## Summary
- track whether current user belongs to a task's project and expose `project_assigned`
- add self-assign button on task details
- convert status and priority badges into dropdowns with inline updates

## Testing
- `php -l module/task/index.php`
- `php -l module/task/include/details_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68aaca3086948333a030b1460f9510ca