### PR TITLE
Remove duplicate avatar and unify avatar styling

### DIFF
--- a/module/project/include/details_view.php
+++ b/module/project/include/details_view.php
@@ -552,8 +552,7 @@ if (!empty($current_project)) {
                 <div class="border rounded-2 p-3 mb-3">
                   <?php $qpic = !empty($q['user_pic']) ? $q['user_pic'] : 'assets/img/team/avatar.webp'; ?>
                   <div class="d-flex align-items-center">
-                    <div class="avatar avatar-m"><img class="rounded-circle" src="<?php echo getURLDir() . h($qpic); ?>" alt="" /></div>
-                    <p class="mb-1 fw-semibold flex-grow-1 ms-2"><?= nl2br(h($q['question_text'])) ?></p>
+                  <p class="mb-1 fw-semibold flex-grow-1 ms-2"><?= nl2br(h($q['question_text'])) ?></p>
                     <?php if (user_has_permission('project','create|update|delete') && ($is_admin || ($q['user_id'] ?? 0) == $this_user_id)): ?>
                     <form action="functions/delete_question.php" method="post" class="ms-2" onsubmit="return confirm('Delete this question?');">
                       <input type="hidden" name="id" value="<?= (int)$q['id'] ?>">
@@ -564,7 +563,7 @@ if (!empty($current_project)) {
 
                   </div>
                   <div class="d-flex align-items-center fs-10 text-body-secondary mb-2">
-                    <div class="avatar avatar-m me-2"><img src="<?php echo getURLDir() . h($qpic); ?>" alt="" /></div>
+                    <div class="avatar avatar-m me-2"><img class="rounded-circle" src="<?php echo getURLDir() . h($qpic); ?>" alt="" /></div>
                     <div>
                       <div class="fw-bold text-body"><?= h($q['user_name'] ?? '') ?></div>
                       <div><?= h(date('d M, Y h:i A', strtotime($q['date_created']))) ?></div>
@@ -607,7 +606,7 @@ if (!empty($current_project)) {
                           </div>
                           <?php $apic = !empty($a['user_pic']) ? $a['user_pic'] : 'assets/img/team/avatar.webp'; ?>
                           <div class="d-flex align-items-center fs-10 text-body-secondary">
-                            <div class="avatar avatar-m me-2"><img src="<?php echo getURLDir() . h($apic); ?>" alt="" /></div>
+                            <div class="avatar avatar-m me-2"><img class="rounded-circle" src="<?php echo getURLDir() . h($apic); ?>" alt="" /></div>
                             <div>
                               <div class="fw-semibold text-body"><?= h($a['user_name'] ?? '') ?></div>
                               <div><?= h(date('d M, Y h:i A', strtotime($a['date_created']))) ?></div>


### PR DESCRIPTION
## Summary
- remove redundant avatar preceding question text
- ensure question and answer avatars use `rounded-circle` styling

## Testing
- `php -l module/project/include/details_view.php`

------
https://chatgpt.com/codex/tasks/task_e_68aaca151a74833380d2c67bf8faab8f