### PR TITLE
Fix answer deletion file query

### DIFF
--- a/module/task/functions/delete_answer.php
+++ b/module/task/functions/delete_answer.php
@@ -9,17 +9,6 @@ if ($answer_id && $task_id) {
   $stmt->execute([':id' => $answer_id]);
   $answer = $stmt->fetch(PDO::FETCH_ASSOC);
   if ($answer && ($is_admin || (int)$answer['user_id'] === (int)$this_user_id)) {
-    $stmtF = $pdo->prepare('SELECT id, file_path, file_name FROM module_tasks_files WHERE answer_id = :aid');
-    $stmtF->execute([':aid' => $answer_id]);
-    $files = $stmtF->fetchAll(PDO::FETCH_ASSOC);
-    foreach ($files as $file) {
-      $pdo->prepare('DELETE FROM module_tasks_files WHERE id = :id')->execute([':id' => $file['id']]);
-      $fullPath = __DIR__ . '/../../..' . $file['file_path'];
-      if (is_file($fullPath)) {
-        unlink($fullPath);
-      }
-      admin_audit_log($pdo, $this_user_id, 'module_tasks_files', $file['id'], 'DELETE', '', json_encode(['file' => $file['file_name']]));
-    }
     $pdo->prepare('DELETE FROM module_tasks_answers WHERE id = :id')->execute([':id' => $answer_id]);
     admin_audit_log($pdo, $this_user_id, 'module_tasks_answers', $answer_id, 'DELETE', '', $answer['answer_text']);
   }


### PR DESCRIPTION
## Summary
- remove invalid file deletion logic referencing nonexistent `answer_id`
- rely on audit log to track answer removals

## Testing
- `php -l module/task/functions/delete_answer.php`


------
https://chatgpt.com/codex/tasks/task_e_68aad41363188333af1ca61990f8840f