### PR TITLE
Remove unsupported file lookup when deleting project answers

### DIFF
--- a/module/project/functions/delete_answer.php
+++ b/module/project/functions/delete_answer.php
@@ -9,17 +9,6 @@ if ($answer_id && $project_id) {
   $stmt->execute([':id' => $answer_id]);
   $answer = $stmt->fetch(PDO::FETCH_ASSOC);
   if ($answer && ($is_admin || (int)$answer['user_id'] === (int)$this_user_id)) {
-    $stmtF = $pdo->prepare('SELECT id, file_path, file_name FROM module_projects_files WHERE answer_id = :aid');
-    $stmtF->execute([':aid' => $answer_id]);
-    $files = $stmtF->fetchAll(PDO::FETCH_ASSOC);
-    foreach ($files as $file) {
-      $pdo->prepare('DELETE FROM module_projects_files WHERE id = :id')->execute([':id' => $file['id']]);
-      $fullPath = dirname(__DIR__,3) . $file['file_path'];
-      if (is_file($fullPath)) {
-        unlink($fullPath);
-      }
-      admin_audit_log($pdo, $this_user_id, 'module_projects_files', $file['id'], 'DELETE', '', json_encode(['file' => $file['file_name']]));
-    }
     $pdo->prepare('DELETE FROM module_projects_answers WHERE id = :id')->execute([':id' => $answer_id]);
     admin_audit_log($pdo, $this_user_id, 'module_projects_answers', $answer_id, 'DELETE', '', $answer['answer_text']);
   }


### PR DESCRIPTION
## Summary
- Clean delete_answer.php by removing incorrect reference to module_projects_files.answer_id
- Retain answer deletion and audit logging only

## Testing
- `php -l module/project/functions/delete_answer.php`


------
https://chatgpt.com/codex/tasks/task_e_68aad411c72c833398dc7347bc8eae0a