### PR TITLE
Add products & services admin module with CRUD

### DIFF
--- a/_SQL/atlis.sql
+++ b/_SQL/atlis.sql
@@ -4306,6 +4306,96 @@ ALTER TABLE `users_profile_pics`
   ADD CONSTRAINT `fk_users_profile_pics_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
   ADD CONSTRAINT `fk_users_profile_pics_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`) ON DELETE SET NULL;
 COMMIT;
+-- --------------------------------------------------------
+--
+-- Table structure for table `module_products_services`
+--
+CREATE TABLE `module_products_services` (
+  `id` int(11) NOT NULL,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT CURRENT_TIMESTAMP,
+  `date_updated` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `memo` text DEFAULT NULL,
+  `name` varchar(255) NOT NULL,
+  `description` text DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+--
+-- Table structure for table `module_products_services_person`
+--
+CREATE TABLE `module_products_services_person` (
+  `id` int(11) NOT NULL,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT CURRENT_TIMESTAMP,
+  `date_updated` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `memo` text DEFAULT NULL,
+  `product_service_id` int(11) NOT NULL,
+  `person_id` int(11) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+--
+-- Dumping data for table `admin_navigation_links`
+--
+INSERT INTO `admin_navigation_links` (`id`, `title`, `path`, `icon`, `sort_order`, `user_id`, `user_updated`, `date_created`, `date_updated`, `memo`) VALUES
+(13, 'Products & Services', 'products-services/index.php', 'shopping-bag', 11, 1, 1, NOW(), NOW(), NULL);
+
+-- --------------------------------------------------------
+--
+-- Indexes for table `module_products_services`
+--
+ALTER TABLE `module_products_services`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `fk_module_products_services_user_id` (`user_id`),
+  ADD KEY `fk_module_products_services_user_updated` (`user_updated`);
+
+-- --------------------------------------------------------
+--
+-- Indexes for table `module_products_services_person`
+--
+ALTER TABLE `module_products_services_person`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `fk_mpsp_user_id` (`user_id`),
+  ADD KEY `fk_mpsp_user_updated` (`user_updated`),
+  ADD KEY `fk_mpsp_product_service_id` (`product_service_id`),
+  ADD KEY `fk_mpsp_person_id` (`person_id`);
+
+-- --------------------------------------------------------
+--
+-- AUTO_INCREMENT for table `module_products_services`
+--
+ALTER TABLE `module_products_services`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+-- --------------------------------------------------------
+--
+-- AUTO_INCREMENT for table `module_products_services_person`
+--
+ALTER TABLE `module_products_services_person`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+-- --------------------------------------------------------
+--
+-- Constraints for table `module_products_services`
+--
+ALTER TABLE `module_products_services`
+  ADD CONSTRAINT `fk_module_products_services_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  ADD CONSTRAINT `fk_module_products_services_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`) ON DELETE SET NULL;
+
+-- --------------------------------------------------------
+--
+-- Constraints for table `module_products_services_person`
+--
+ALTER TABLE `module_products_services_person`
+  ADD CONSTRAINT `fk_mpsp_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  ADD CONSTRAINT `fk_mpsp_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  ADD CONSTRAINT `fk_mpsp_product_service_id` FOREIGN KEY (`product_service_id`) REFERENCES `module_products_services` (`id`) ON DELETE CASCADE,
+  ADD CONSTRAINT `fk_mpsp_person_id` FOREIGN KEY (`person_id`) REFERENCES `person` (`id`) ON DELETE CASCADE;
+
+COMMIT;
 
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
 /*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;

--- a/admin/api/products-services.php
+++ b/admin/api/products-services.php
@@ -1,0 +1,61 @@
+<?php
+require_once __DIR__ . '/../../includes/admin_guard.php';
+require_once __DIR__ . '/../../includes/helpers.php';
+header('Content-Type: application/json');
+$action = $_REQUEST['action'] ?? '';
+
+try {
+  switch ($action) {
+    case 'list':
+      require_permission('products_services','read');
+      $stmt = $pdo->query('SELECT id, name, description FROM module_products_services ORDER BY name');
+      $items = $stmt->fetchAll(PDO::FETCH_ASSOC);
+      echo json_encode(['success'=>true,'items'=>$items]);
+      break;
+    case 'create':
+      verifyToken();
+      require_permission('products_services','create');
+      $name = trim($_POST['name'] ?? '');
+      $description = trim($_POST['description'] ?? '');
+      if($name===''){ echo json_encode(['success'=>false,'error'=>'Name required']); break; }
+      $stmt = $pdo->prepare('INSERT INTO module_products_services (user_id,user_updated,name,description) VALUES (:uid,:uid,:name,:descr)');
+      $stmt->execute([':uid'=>$this_user_id,':name'=>$name,':descr'=>$description]);
+      $id = $pdo->lastInsertId();
+      audit_log($pdo,$this_user_id,'module_products_services',$id,'CREATE','Created product/service');
+      echo json_encode(['success'=>true,'id'=>$id]);
+      break;
+    case 'update':
+      verifyToken();
+      require_permission('products_services','update');
+      $id = (int)($_POST['id'] ?? 0);
+      $name = trim($_POST['name'] ?? '');
+      $description = trim($_POST['description'] ?? '');
+      if($id<=0 || $name===''){ echo json_encode(['success'=>false,'error'=>'Invalid data']); break; }
+      $stmt = $pdo->prepare('UPDATE module_products_services SET name=:name, description=:descr, user_updated=:uid WHERE id=:id');
+      $stmt->execute([':name'=>$name,':descr'=>$description,':uid'=>$this_user_id,':id'=>$id]);
+      audit_log($pdo,$this_user_id,'module_products_services',$id,'UPDATE','Updated product/service');
+      echo json_encode(['success'=>true]);
+      break;
+    case 'delete':
+      verifyToken();
+      require_permission('products_services','delete');
+      $id = (int)($_POST['id'] ?? 0);
+      if($id<=0){ echo json_encode(['success'=>false,'error'=>'Invalid ID']); break; }
+      $pdo->prepare('DELETE FROM module_products_services WHERE id=:id')->execute([':id'=>$id]);
+      audit_log($pdo,$this_user_id,'module_products_services',$id,'DELETE','Deleted product/service');
+      echo json_encode(['success'=>true]);
+      break;
+    default:
+      echo json_encode(['success'=>false,'error'=>'Invalid action']);
+  }
+} catch (Exception $e) {
+  error_log($e->getMessage());
+  echo json_encode(['success'=>false,'error'=>'Server error']);
+}
+
+function verifyToken(){
+  if(!verify_csrf_token($_POST['csrf_token'] ?? '')){
+    echo json_encode(['success'=>false,'error'=>'Invalid CSRF token']);
+    exit;
+  }
+}

--- a/admin/products-services/edit.php
+++ b/admin/products-services/edit.php
@@ -1,0 +1,72 @@
+<?php
+require '../admin_header.php';
+require_permission('products_services','read');
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$item = null;
+if($id){
+  $stmt = $pdo->prepare('SELECT * FROM module_products_services WHERE id = :id');
+  $stmt->execute([':id'=>$id]);
+  $item = $stmt->fetch(PDO::FETCH_ASSOC);
+  if(!$item){ $id = 0; }
+}
+
+$stmt = $pdo->query('SELECT p.id, CONCAT(p.first_name," ",p.last_name) AS name, GROUP_CONCAT(li.label ORDER BY li.label SEPARATOR ", ") AS skills FROM person p LEFT JOIN person_skills ps ON p.id = ps.person_id LEFT JOIN lookup_list_items li ON ps.skill_id = li.id GROUP BY p.id ORDER BY p.first_name, p.last_name');
+$people = $stmt->fetchAll(PDO::FETCH_ASSOC);
+$assigned = [];
+if($id){
+  $stmt = $pdo->prepare('SELECT person_id FROM module_products_services_person WHERE product_service_id = :id');
+  $stmt->execute([':id'=>$id]);
+  $assigned = $stmt->fetchAll(PDO::FETCH_COLUMN);
+}
+
+$token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
+$_SESSION['csrf_token'] = $token;
+$message = '';
+if(isset($_GET['msg']) && $_GET['msg']==='saved'){ $message='Record saved.'; }
+?>
+<nav class="mb-3" aria-label="breadcrumb">
+  <ol class="breadcrumb mb-0">
+    <li class="breadcrumb-item"><a href="index.php">Products &amp; Services</a></li>
+    <li class="breadcrumb-item active" aria-current="page"><?= $id ? 'Edit' : 'Add'; ?></li>
+  </ol>
+</nav>
+<h2 class="mb-4"><?= $id ? 'Edit' : 'Add'; ?> Product/Service</h2>
+<?php if($message): ?><div class="alert alert-success"><?= h($message); ?></div><?php endif; ?>
+<form method="post" action="functions/save.php" class="row g-3">
+  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+  <?php if($id): ?><input type="hidden" name="id" value="<?= $id; ?>"><?php endif; ?>
+  <div class="col-12">
+    <div class="form-floating">
+      <input class="form-control" id="psName" type="text" name="name" placeholder="Name" value="<?= h($item['name'] ?? ''); ?>" required>
+      <label for="psName">Name</label>
+    </div>
+  </div>
+  <div class="col-12">
+    <div class="form-floating">
+      <textarea class="form-control" id="psDesc" name="description" placeholder="Description" style="height:100px"><?= h($item['description'] ?? ''); ?></textarea>
+      <label for="psDesc">Description</label>
+    </div>
+  </div>
+  <div class="col-12">
+    <div class="form-floating form-floating-advance-select">
+      <label for="personSelect">Assign People</label>
+      <select class="form-select" id="personSelect" name="persons[]" multiple data-choices="data-choices" data-options='{"removeItemButton":true,"placeholder":true}'>
+        <?php foreach($people as $p): ?>
+          <option value="<?= $p['id']; ?>" <?= in_array($p['id'],$assigned) ? 'selected' : ''; ?>><?= h($p['name'] . ($p['skills'] ? ' - '.$p['skills'] : '')); ?></option>
+        <?php endforeach; ?>
+      </select>
+    </div>
+  </div>
+  <div class="col-12">
+    <div class="form-floating">
+      <textarea class="form-control" id="psMemo" name="memo" placeholder="Memo" style="height:100px"><?= h($item['memo'] ?? ''); ?></textarea>
+      <label for="psMemo">Memo</label>
+    </div>
+  </div>
+  <div class="col-12">
+    <button class="btn btn-primary" type="submit">Save</button>
+    <a class="btn btn-secondary" href="index.php">Cancel</a>
+  </div>
+</form>
+<?php require '../admin_footer.php'; ?>

--- a/admin/products-services/functions/delete.php
+++ b/admin/products-services/functions/delete.php
@@ -1,0 +1,21 @@
+<?php
+require '../../admin_header.php';
+require_permission('products_services','delete');
+
+if($_SERVER['REQUEST_METHOD'] !== 'POST'){
+  header('Location: ../index.php');
+  exit;
+}
+
+if(!verify_csrf_token($_POST['csrf_token'] ?? '')){
+  die('Invalid CSRF token');
+}
+
+$id = (int)($_POST['id'] ?? 0);
+if($id){
+  $pdo->prepare('DELETE FROM module_products_services WHERE id=:id')->execute([':id'=>$id]);
+  admin_audit_log($pdo,$this_user_id,'module_products_services',$id,'DELETE',null,null,'Deleted product/service');
+}
+
+header('Location: ../index.php?msg=deleted');
+exit;

--- a/admin/products-services/functions/save.php
+++ b/admin/products-services/functions/save.php
@@ -1,0 +1,45 @@
+<?php
+require '../../admin_header.php';
+
+$token = $_POST['csrf_token'] ?? '';
+if (!verify_csrf_token($token)) {
+  die('Invalid CSRF token');
+}
+
+$id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+$name = trim($_POST['name'] ?? '');
+$description = trim($_POST['description'] ?? '');
+$memo = trim($_POST['memo'] ?? '');
+$persons = isset($_POST['persons']) && is_array($_POST['persons']) ? array_map('intval', $_POST['persons']) : [];
+
+if ($name === '') {
+  header('Location: ../index.php');
+  exit;
+}
+
+if ($id) {
+  require_permission('products_services','update');
+  $stmtOld = $pdo->prepare('SELECT name, description, memo FROM module_products_services WHERE id=:id');
+  $stmtOld->execute([':id'=>$id]);
+  $old = $stmtOld->fetch(PDO::FETCH_ASSOC);
+  $stmt = $pdo->prepare('UPDATE module_products_services SET name=:name, description=:descr, memo=:memo, user_updated=:uid WHERE id=:id');
+  $stmt->execute([':name'=>$name, ':descr'=>$description, ':memo'=>$memo, ':uid'=>$this_user_id, ':id'=>$id]);
+  admin_audit_log($pdo,$this_user_id,'module_products_services',$id,'UPDATE',json_encode($old),json_encode(['name'=>$name]),'Updated product/service');
+} else {
+  require_permission('products_services','create');
+  $stmt = $pdo->prepare('INSERT INTO module_products_services (user_id,user_updated,name,description,memo) VALUES (:uid,:uid,:name,:descr,:memo)');
+  $stmt->execute([':uid'=>$this_user_id, ':name'=>$name, ':descr'=>$description, ':memo'=>$memo]);
+  $id = $pdo->lastInsertId();
+  admin_audit_log($pdo,$this_user_id,'module_products_services',$id,'CREATE',null,json_encode(['name'=>$name]),'Created product/service');
+}
+
+$pdo->prepare('DELETE FROM module_products_services_person WHERE product_service_id=:id')->execute([':id'=>$id]);
+if($persons){
+  $ins = $pdo->prepare('INSERT INTO module_products_services_person (user_id,user_updated,product_service_id,person_id) VALUES (:uid,:uid,:psid,:pid)');
+  foreach($persons as $pid){
+    if($pid>0){ $ins->execute([':uid'=>$this_user_id, ':psid'=>$id, ':pid'=>$pid]); }
+  }
+}
+
+header('Location: ../edit.php?id='.$id.'&msg=saved');
+exit;

--- a/admin/products-services/index.php
+++ b/admin/products-services/index.php
@@ -1,0 +1,78 @@
+<?php
+require '../admin_header.php';
+require_permission('products_services','read');
+
+$token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
+$_SESSION['csrf_token'] = $token;
+$message = '';
+if(isset($_GET['msg'])){
+  if($_GET['msg'] === 'deleted') $message = 'Record deleted.';
+  if($_GET['msg'] === 'saved') $message = 'Record saved.';
+}
+
+$stmt = $pdo->query('SELECT id, name FROM module_products_services ORDER BY name');
+$items = $stmt->fetchAll(PDO::FETCH_ASSOC);
+?>
+<h2 class="mb-4">Products &amp; Services</h2>
+<?php if($message): ?><div class="alert alert-success"><?= h($message); ?></div><?php endif; ?>
+<div id="psList" data-list='{"valueNames":["id","name"],"page":25,"pagination":true}'>
+  <div class="row g-3 justify-content-between mb-4">
+    <div class="col-auto">
+      <?php if(user_has_permission('products_services','create')): ?>
+      <a class="btn btn-success" href="edit.php"><span class="fa-solid fa-plus"></span><span class="visually-hidden">Add</span></a>
+      <?php endif; ?>
+    </div>
+    <div class="col-auto">
+      <div class="search-box">
+        <form class="position-relative">
+          <input class="form-control search-input search" type="search" placeholder="Search" aria-label="Search" />
+          <span class="fas fa-search search-box-icon"></span>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div class="bg-body-emphasis border-top border-bottom border-translucent position-relative top-1 mx-n4 px-4 mx-lg-n6 px-lg-6">
+    <div class="row g-0 text-body-tertiary fw-bold fs-10 py-2">
+      <div class="col-auto px-2" style="width:120px;">Actions</div>
+      <div class="col px-2 sort" data-sort="id">ID</div>
+      <div class="col px-2 sort" data-sort="name">Name</div>
+    </div>
+    <div class="list">
+      <?php foreach($items as $i): ?>
+      <div class="row g-0 align-items-center border-bottom py-2">
+        <div class="col-auto px-2" style="width:120px;">
+          <?php if(user_has_permission('products_services','update')): ?>
+          <a class="btn btn-warning btn-sm me-1" href="edit.php?id=<?= $i['id']; ?>" title="Edit"><span class="fa-solid fa-pen"></span></a>
+          <?php endif; ?>
+          <?php if(user_has_permission('products_services','delete')): ?>
+          <form method="post" action="functions/delete.php" class="d-inline">
+            <input type="hidden" name="id" value="<?= $i['id']; ?>">
+            <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+            <button class="btn btn-danger btn-sm" onclick="return confirm('Delete this record?');" title="Delete"><span class="fa-solid fa-trash"></span></button>
+          </form>
+          <?php endif; ?>
+        </div>
+        <div class="col px-2 id"><?= h($i['id']); ?></div>
+        <div class="col px-2 name"><?= h($i['name']); ?></div>
+      </div>
+      <?php endforeach; ?>
+    </div>
+  </div>
+  <div class="row align-items-center justify-content-end py-3 pe-0 fs-9">
+    <div class="col-auto d-flex">
+      <p class="mb-0 d-none d-sm-block me-3 fw-semibold text-body" data-list-info></p>
+    </div>
+    <div class="col-auto d-flex">
+      <button class="page-link" data-list-pagination="prev"><span class="fas fa-chevron-left"></span></button>
+      <ul class="mb-0 pagination"></ul>
+      <button class="page-link pe-0" data-list-pagination="next"><span class="fas fa-chevron-right"></span></button>
+    </div>
+  </div>
+</div>
+<script>
+document.addEventListener('DOMContentLoaded',function(){
+  var el=document.getElementById('psList');
+  if(el){ var options=window.phoenix.utils.getData(el,'list'); new window.List(el,options); }
+});
+</script>
+<?php require '../admin_footer.php'; ?>


### PR DESCRIPTION
## Summary
- add Products & Services admin section with listing, editing and RBAC
- support CRUD endpoints and navigation link
- define database tables for products, service-person links, and navigation entry

## Testing
- `php -l admin/products-services/index.php`
- `php -l admin/products-services/edit.php`
- `php -l admin/products-services/functions/save.php`
- `php -l admin/products-services/functions/delete.php`
- `php -l admin/api/products-services.php`


------
https://chatgpt.com/codex/tasks/task_e_68aad335adcc833395409903d46eee2f