### PR TITLE
Refactor calendar events to use detailed timing and linkage fields

### DIFF
--- a/module/calendar/functions/create.php
+++ b/module/calendar/functions/create.php
@@ -5,22 +5,26 @@ require_permission('calendar','create');
 header('Content-Type: application/json');
 
 $title = trim($_POST['title'] ?? '');
-$start = $_POST['start'] ?? null;
-$end = $_POST['end'] ?? null;
-$related_module = $_POST['related_module'] ?? null;
-$related_id = $_POST['related_id'] ?? null;
+$start_time = $_POST['start_time'] ?? null;
+$end_time = $_POST['end_time'] ?? null;
+$link_module = $_POST['link_module'] ?? null;
+$link_record_id = $_POST['link_record_id'] ?? null;
+$calendar_id = (int)($_POST['calendar_id'] ?? 0);
+$event_type_id = $_POST['event_type_id'] ?? null;
 $is_private = !empty($_POST['is_private']) ? 1 : 0;
 $attendees = $_POST['attendees'] ?? [];
 
-if ($title && $start) {
-  $stmt = $pdo->prepare('INSERT INTO module_calendar_events (user_id, title, start_date, end_date, related_module, related_id, is_private) VALUES (:uid, :title, :start, :end, :rel_module, :rel_id, :is_private)');
+if ($title && $start_time && $calendar_id) {
+  $stmt = $pdo->prepare('INSERT INTO module_calendar_events (user_id, calendar_id, title, start_time, end_time, event_type_id, link_module, link_record_id, is_private) VALUES (:uid, :calendar_id, :title, :start_time, :end_time, :event_type_id, :link_module, :link_record_id, :is_private)');
   $stmt->execute([
     ':uid' => $this_user_id,
+    ':calendar_id' => $calendar_id,
     ':title' => $title,
-    ':start' => $start,
-    ':end' => $end,
-    ':rel_module' => $related_module,
-    ':rel_id' => $related_id,
+    ':start_time' => $start_time,
+    ':end_time' => $end_time,
+    ':event_type_id' => $event_type_id,
+    ':link_module' => $link_module,
+    ':link_record_id' => $link_record_id,
     ':is_private' => $is_private
   ]);
   $eventId = $pdo->lastInsertId();

--- a/module/calendar/functions/list.php
+++ b/module/calendar/functions/list.php
@@ -6,9 +6,9 @@ header('Content-Type: application/json');
 
 $events = [];
 if (user_has_role('Admin')) {
-  $stmt = $pdo->query('SELECT id, title, start_date, end_date, related_module, related_id, user_id, is_private FROM module_calendar_events');
+  $stmt = $pdo->query('SELECT id, calendar_id, title, start_time, end_time, event_type_id, link_module, link_record_id, user_id, is_private FROM module_calendar_events');
 } else {
-  $stmt = $pdo->prepare('SELECT id, title, start_date, end_date, related_module, related_id, user_id, is_private FROM module_calendar_events WHERE is_private = 0 OR user_id = :uid');
+  $stmt = $pdo->prepare('SELECT id, calendar_id, title, start_time, end_time, event_type_id, link_module, link_record_id, user_id, is_private FROM module_calendar_events WHERE is_private = 0 OR user_id = :uid');
   $stmt->execute([':uid' => $this_user_id]);
 }
 
@@ -18,11 +18,13 @@ while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
   }
   $events[] = [
     'id' => (int)$row['id'],
+    'calendar_id' => (int)$row['calendar_id'],
     'title' => $row['title'],
-    'start' => $row['start_date'],
-    'end' => $row['end_date'],
-    'related_module' => $row['related_module'],
-    'related_id' => $row['related_id']
+    'start' => $row['start_time'],
+    'end' => $row['end_time'],
+    'event_type_id' => $row['event_type_id'],
+    'link_module' => $row['link_module'],
+    'link_record_id' => $row['link_record_id']
   ];
 }
 

--- a/module/calendar/functions/update.php
+++ b/module/calendar/functions/update.php
@@ -6,14 +6,16 @@ header('Content-Type: application/json');
 
 $id = (int)($_POST['id'] ?? 0);
 $title = trim($_POST['title'] ?? '');
-$start = $_POST['start'] ?? null;
-$end = $_POST['end'] ?? null;
-$related_module = $_POST['related_module'] ?? null;
-$related_id = $_POST['related_id'] ?? null;
+$start_time = $_POST['start_time'] ?? null;
+$end_time = $_POST['end_time'] ?? null;
+$link_module = $_POST['link_module'] ?? null;
+$link_record_id = $_POST['link_record_id'] ?? null;
+$calendar_id = (int)($_POST['calendar_id'] ?? 0);
+$event_type_id = $_POST['event_type_id'] ?? null;
 $is_private = !empty($_POST['is_private']) ? 1 : 0;
 $attendees = $_POST['attendees'] ?? [];
 
-if ($id && $title && $start) {
+if ($id && $title && $start_time && $calendar_id) {
   $chk = $pdo->prepare('SELECT user_id, is_private FROM module_calendar_events WHERE id = ?');
   $chk->execute([$id]);
   $existing = $chk->fetch(PDO::FETCH_ASSOC);
@@ -26,8 +28,8 @@ if ($id && $title && $start) {
     exit;
   }
 
-  $stmt = $pdo->prepare('UPDATE module_calendar_events SET user_updated=?, title=?, start_date=?, end_date=?, related_module=?, related_id=?, is_private=? WHERE id=?');
-  $stmt->execute([$this_user_id, $title, $start, $end, $related_module, $related_id, $is_private, $id]);
+  $stmt = $pdo->prepare('UPDATE module_calendar_events SET user_updated=?, calendar_id=?, title=?, start_time=?, end_time=?, event_type_id=?, link_module=?, link_record_id=?, is_private=? WHERE id=?');
+  $stmt->execute([$this_user_id, $calendar_id, $title, $start_time, $end_time, $event_type_id, $link_module, $link_record_id, $is_private, $id]);
 
   $pdo->prepare('DELETE FROM module_calendar_attendees WHERE calendar_event_id=?')->execute([$id]);
   if (is_array($attendees)) {


### PR DESCRIPTION
## Summary
- Store calendar_id, start_time, end_time, event_type_id, link_module, and link_record_id for calendar events
- Update event creation and update endpoints for new fields
- Include additional event data in calendar event listings

## Testing
- `php -l module/calendar/functions/create.php`
- `php -l module/calendar/functions/update.php`
- `php -l module/calendar/functions/list.php`


------
https://chatgpt.com/codex/tasks/task_e_68ab875f33788333ace18324dbe96098