### PR TITLE
Refine calendar event attendee schema and scripts

### DIFF
--- a/_SQL/atlis.sql
+++ b/_SQL/atlis.sql
@@ -1437,13 +1437,13 @@ CREATE TABLE `module_calendar_events` (
 
 CREATE TABLE `module_calendar_event_attendees` (
   `id` int(11) NOT NULL,
-  `user_id` int(11) NOT NULL,
+  `user_id` int(11) DEFAULT NULL,
   `user_updated` int(11) DEFAULT NULL,
   `date_created` datetime DEFAULT current_timestamp(),
   `date_updated` datetime DEFAULT current_timestamp() ON UPDATE current_timestamp(),
   `memo` text DEFAULT NULL,
   `event_id` int(11) NOT NULL,
-  `end_time` datetime DEFAULT NULL
+  `attendee_user_id` int(11) NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- --------------------------------------------------------
@@ -3192,10 +3192,11 @@ ALTER TABLE `module_calendar_events`
 --
 ALTER TABLE `module_calendar_event_attendees`
   ADD PRIMARY KEY (`id`),
-  ADD UNIQUE KEY `uk_module_calendar_event_attendees_event_user` (`event_id`,`user_id`),
+  ADD UNIQUE KEY `uk_module_calendar_event_attendees_event_user` (`event_id`,`attendee_user_id`),
   ADD KEY `fk_module_calendar_event_attendees_user_id` (`user_id`),
   ADD KEY `fk_module_calendar_event_attendees_user_updated` (`user_updated`),
-  ADD KEY `fk_module_calendar_event_attendees_event_id` (`event_id`);
+  ADD KEY `fk_module_calendar_event_attendees_event_id` (`event_id`),
+  ADD KEY `fk_module_calendar_event_attendees_attendee_user_id` (`attendee_user_id`);
 
 --
 -- Indexes for table `module_contractors`
@@ -4193,7 +4194,8 @@ ALTER TABLE `module_calendar_events`
 --
 ALTER TABLE `module_calendar_event_attendees`
   ADD CONSTRAINT `fk_module_calendar_event_attendees_event_id` FOREIGN KEY (`event_id`) REFERENCES `module_calendar_events` (`id`) ON DELETE CASCADE,
-  ADD CONSTRAINT `fk_module_calendar_event_attendees_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE,
+  ADD CONSTRAINT `fk_module_calendar_event_attendees_attendee_user_id` FOREIGN KEY (`attendee_user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE,
+  ADD CONSTRAINT `fk_module_calendar_event_attendees_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
   ADD CONSTRAINT `fk_module_calendar_event_attendees_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`) ON DELETE SET NULL;
 
 --

--- a/module/calendar/functions/create.php
+++ b/module/calendar/functions/create.php
@@ -26,7 +26,7 @@ if ($title && $start) {
   $eventId = $pdo->lastInsertId();
 
   if (is_array($attendees)) {
-    $aStmt = $pdo->prepare('INSERT INTO module_calendar_attendees (user_id, calendar_event_id, attendee_user_id) VALUES (:uid, :eid, :aid)');
+    $aStmt = $pdo->prepare('INSERT INTO module_calendar_event_attendees (user_id, event_id, attendee_user_id) VALUES (:uid, :eid, :aid)');
     foreach ($attendees as $aid) {
       $aStmt->execute([':uid' => $this_user_id, ':eid' => $eventId, ':aid' => $aid]);
     }

--- a/module/calendar/functions/delete.php
+++ b/module/calendar/functions/delete.php
@@ -17,7 +17,7 @@ if ($id) {
     http_response_code(403);
     exit;
   }
-  $pdo->prepare('DELETE FROM module_calendar_attendees WHERE calendar_event_id=?')->execute([$id]);
+  $pdo->prepare('DELETE FROM module_calendar_event_attendees WHERE event_id=?')->execute([$id]);
   $pdo->prepare('DELETE FROM module_calendar_events WHERE id=?')->execute([$id]);
   echo json_encode(['success' => true]);
   exit;

--- a/module/calendar/functions/update.php
+++ b/module/calendar/functions/update.php
@@ -29,9 +29,9 @@ if ($id && $title && $start) {
   $stmt = $pdo->prepare('UPDATE module_calendar_events SET user_updated=?, title=?, start_date=?, end_date=?, related_module=?, related_id=?, is_private=? WHERE id=?');
   $stmt->execute([$this_user_id, $title, $start, $end, $related_module, $related_id, $is_private, $id]);
 
-  $pdo->prepare('DELETE FROM module_calendar_attendees WHERE calendar_event_id=?')->execute([$id]);
+  $pdo->prepare('DELETE FROM module_calendar_event_attendees WHERE event_id=?')->execute([$id]);
   if (is_array($attendees)) {
-    $aStmt = $pdo->prepare('INSERT INTO module_calendar_attendees (user_id, calendar_event_id, attendee_user_id) VALUES (:uid, :eid, :aid)');
+    $aStmt = $pdo->prepare('INSERT INTO module_calendar_event_attendees (user_id, event_id, attendee_user_id) VALUES (:uid, :eid, :aid)');
     foreach ($attendees as $aid) {
       $aStmt->execute([':uid' => $this_user_id, ':eid' => $id, ':aid' => $aid]);
     }


### PR DESCRIPTION
## Summary
- Rename attendee columns in `module_calendar_event_attendees` and drop obsolete `end_time`
- Add unique index and foreign keys for event and attendee references
- Update calendar CRUD scripts to target new `module_calendar_event_attendees`

## Testing
- `php -l module/calendar/functions/create.php`
- `php -l module/calendar/functions/update.php`
- `php -l module/calendar/functions/delete.php`


------
https://chatgpt.com/codex/tasks/task_e_68ab876025b88333a8d480165b5c008f