### PR TITLE
Add calendar event type and visibility options

### DIFF
--- a/_SQL/atlis.sql
+++ b/_SQL/atlis.sql
@@ -1421,12 +1421,12 @@ CREATE TABLE `module_calendar_events` (
   `memo` text DEFAULT NULL,
   `calendar_id` int(11) NOT NULL,
   `title` varchar(255) NOT NULL,
-  `start_time` datetime NOT NULL,
-  `end_time` datetime DEFAULT NULL,
+  `start_date` datetime NOT NULL,
+  `end_date` datetime DEFAULT NULL,
   `event_type_id` int(11) DEFAULT NULL,
-  `link_module` varchar(50) DEFAULT NULL,
-  `link_record_id` int(11) DEFAULT NULL,
-  `is_private` tinyint(1) DEFAULT 0
+  `visibility_id` int(11) DEFAULT NULL,
+  `related_module` varchar(50) DEFAULT NULL,
+  `related_id` int(11) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- --------------------------------------------------------
@@ -3183,7 +3183,8 @@ ALTER TABLE `module_calendar_events`
   ADD PRIMARY KEY (`id`),
   ADD KEY `fk_module_calendar_events_calendar_id` (`calendar_id`),
   ADD KEY `fk_module_calendar_events_event_type_id` (`event_type_id`),
-  ADD KEY `fk_module_calendar_events_link_record_id` (`link_record_id`),
+  ADD KEY `fk_module_calendar_events_visibility_id` (`visibility_id`),
+  ADD KEY `fk_module_calendar_events_related_id` (`related_id`),
   ADD KEY `fk_module_calendar_events_user_id` (`user_id`),
   ADD KEY `fk_module_calendar_events_user_updated` (`user_updated`);
 
@@ -4185,6 +4186,7 @@ ALTER TABLE `module_agency_persons`
 ALTER TABLE `module_calendar_events`
   ADD CONSTRAINT `fk_module_calendar_events_calendar_id` FOREIGN KEY (`calendar_id`) REFERENCES `module_calendar` (`id`) ON DELETE CASCADE,
   ADD CONSTRAINT `fk_module_calendar_events_event_type_id` FOREIGN KEY (`event_type_id`) REFERENCES `lookup_list_items` (`id`),
+  ADD CONSTRAINT `fk_module_calendar_events_visibility_id` FOREIGN KEY (`visibility_id`) REFERENCES `lookup_list_items` (`id`),
   ADD CONSTRAINT `fk_module_calendar_events_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
   ADD CONSTRAINT `fk_module_calendar_events_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`) ON DELETE SET NULL;
 

--- a/module/calendar/functions/create.php
+++ b/module/calendar/functions/create.php
@@ -9,19 +9,21 @@ $start = $_POST['start'] ?? null;
 $end = $_POST['end'] ?? null;
 $related_module = $_POST['related_module'] ?? null;
 $related_id = $_POST['related_id'] ?? null;
-$is_private = !empty($_POST['is_private']) ? 1 : 0;
+$event_type_id = $_POST['event_type_id'] ?? null;
+$visibility_id = $_POST['visibility_id'] ?? null;
 $attendees = $_POST['attendees'] ?? [];
 
 if ($title && $start) {
-  $stmt = $pdo->prepare('INSERT INTO module_calendar_events (user_id, title, start_date, end_date, related_module, related_id, is_private) VALUES (:uid, :title, :start, :end, :rel_module, :rel_id, :is_private)');
+  $stmt = $pdo->prepare('INSERT INTO module_calendar_events (user_id, title, start_date, end_date, event_type_id, visibility_id, related_module, related_id) VALUES (:uid, :title, :start, :end, :etype, :vis, :rel_module, :rel_id)');
   $stmt->execute([
     ':uid' => $this_user_id,
     ':title' => $title,
     ':start' => $start,
     ':end' => $end,
+    ':etype' => $event_type_id,
+    ':vis' => $visibility_id,
     ':rel_module' => $related_module,
-    ':rel_id' => $related_id,
-    ':is_private' => $is_private
+    ':rel_id' => $related_id
   ]);
   $eventId = $pdo->lastInsertId();
 

--- a/module/calendar/functions/delete.php
+++ b/module/calendar/functions/delete.php
@@ -6,14 +6,17 @@ header('Content-Type: application/json');
 
 $id = (int)($_POST['id'] ?? 0);
 if ($id) {
-  $chk = $pdo->prepare('SELECT user_id, is_private FROM module_calendar_events WHERE id = ?');
+  $chk = $pdo->prepare('SELECT user_id, visibility_id FROM module_calendar_events WHERE id = ?');
   $chk->execute([$id]);
   $existing = $chk->fetch(PDO::FETCH_ASSOC);
   if (!$existing) {
     http_response_code(404);
     exit;
   }
-  if ($existing['is_private'] && $existing['user_id'] != $this_user_id && !user_has_role('Admin')) {
+  $privStmt = $pdo->prepare('SELECT id FROM lookup_list_items WHERE list_id=38 AND code="PRIVATE"');
+  $privStmt->execute();
+  $privateId = $privStmt->fetchColumn();
+  if ($existing['visibility_id'] == $privateId && $existing['user_id'] != $this_user_id && !user_has_role('Admin')) {
     http_response_code(403);
     exit;
   }

--- a/module/calendar/functions/list.php
+++ b/module/calendar/functions/list.php
@@ -4,16 +4,20 @@ require_permission('calendar','read');
 
 header('Content-Type: application/json');
 
+$privStmt = $pdo->prepare('SELECT id FROM lookup_list_items WHERE list_id=38 AND code="PRIVATE"');
+$privStmt->execute();
+$privateId = $privStmt->fetchColumn();
+
 $events = [];
 if (user_has_role('Admin')) {
-  $stmt = $pdo->query('SELECT id, title, start_date, end_date, related_module, related_id, user_id, is_private FROM module_calendar_events');
+  $stmt = $pdo->query('SELECT id, title, start_date, end_date, related_module, related_id, user_id, event_type_id, visibility_id FROM module_calendar_events');
 } else {
-  $stmt = $pdo->prepare('SELECT id, title, start_date, end_date, related_module, related_id, user_id, is_private FROM module_calendar_events WHERE is_private = 0 OR user_id = :uid');
-  $stmt->execute([':uid' => $this_user_id]);
+  $stmt = $pdo->prepare('SELECT id, title, start_date, end_date, related_module, related_id, user_id, event_type_id, visibility_id FROM module_calendar_events WHERE visibility_id != :private OR user_id = :uid');
+  $stmt->execute([':private' => $privateId, ':uid' => $this_user_id]);
 }
 
 while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-  if ($row['is_private'] && $row['user_id'] != $this_user_id && !user_has_role('Admin')) {
+  if ($row['visibility_id'] == $privateId && $row['user_id'] != $this_user_id && !user_has_role('Admin')) {
     continue;
   }
   $events[] = [
@@ -22,7 +26,9 @@ while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
     'start' => $row['start_date'],
     'end' => $row['end_date'],
     'related_module' => $row['related_module'],
-    'related_id' => $row['related_id']
+    'related_id' => $row['related_id'],
+    'event_type_id' => $row['event_type_id'],
+    'visibility_id' => $row['visibility_id']
   ];
 }
 


### PR DESCRIPTION
## Summary
- add database support for calendar event types and visibility
- expose event type and visibility fields in calendar forms
- persist chosen options via updated CRUD endpoints

## Testing
- `php -l module/calendar/functions/create.php`
- `php -l module/calendar/functions/update.php`
- `php -l module/calendar/functions/list.php`
- `php -l module/calendar/functions/delete.php`
- `php -l includes/calendar.php`


------
https://chatgpt.com/codex/tasks/task_e_68ab8762c18c8333a7399bf30a4f3752