### PR TITLE
Enhance product/service management with types, statuses, pricing, and skill assignments

### DIFF
--- a/admin/products-services/edit.php
+++ b/admin/products-services/edit.php
@@ -11,13 +11,29 @@ if($id){
   if(!$item){ $id = 0; }
 }
 
-$stmt = $pdo->query('SELECT p.id, CONCAT(p.first_name," ",p.last_name) AS name, GROUP_CONCAT(li.label ORDER BY li.label SEPARATOR ", ") AS skills FROM person p LEFT JOIN person_skills ps ON p.id = ps.person_id LEFT JOIN lookup_list_items li ON ps.skill_id = li.id GROUP BY p.id ORDER BY p.first_name, p.last_name');
+$types = get_lookup_items($pdo, 'PRODUCT_SERVICE_TYPE');
+$statuses = get_lookup_items($pdo, 'PRODUCT_SERVICE_STATUS');
+
+// Load people and their skills
+$stmt = $pdo->query('SELECT p.id, CONCAT(p.first_name, " ", p.last_name) AS name FROM person p ORDER BY p.first_name, p.last_name');
 $people = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+$ps = $pdo->query('SELECT ps.person_id, ps.skill_id, li.label FROM person_skills ps JOIN lookup_list_items li ON ps.skill_id = li.id ORDER BY ps.person_id, li.label');
+$personSkills = [];
+while($row = $ps->fetch(PDO::FETCH_ASSOC)){
+  $personSkills[$row['person_id']][] = ['skill_id'=>$row['skill_id'], 'label'=>$row['label']];
+}
+foreach($people as &$p){
+  $labels = array_column($personSkills[$p['id']] ?? [], 'label');
+  $p['skills'] = $labels ? implode(', ', $labels) : '';
+}
+unset($p);
+
 $assigned = [];
 if($id){
-  $stmt = $pdo->prepare('SELECT person_id FROM module_products_services_person WHERE product_service_id = :id');
+  $stmt = $pdo->prepare('SELECT person_id, skill_id FROM module_products_services_person WHERE product_service_id = :id');
   $stmt->execute([':id'=>$id]);
-  $assigned = $stmt->fetchAll(PDO::FETCH_COLUMN);
+  $assigned = $stmt->fetchAll(PDO::FETCH_ASSOC);
 }
 
 $token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
@@ -42,6 +58,26 @@ if(isset($_GET['msg']) && $_GET['msg']==='saved'){ $message='Record saved.'; }
       <label for="psName">Name</label>
     </div>
   </div>
+  <div class="col-md-6">
+    <div class="form-floating">
+      <select class="form-select" id="psType" name="type_id" required>
+        <?php foreach($types as $t): ?>
+          <option value="<?= $t['id']; ?>" <?= ($item['type_id'] ?? '') == $t['id'] ? 'selected' : ''; ?>><?= h($t['label']); ?></option>
+        <?php endforeach; ?>
+      </select>
+      <label for="psType">Type</label>
+    </div>
+  </div>
+  <div class="col-md-6">
+    <div class="form-floating">
+      <select class="form-select" id="psStatus" name="status_id" required>
+        <?php foreach($statuses as $s): ?>
+          <option value="<?= $s['id']; ?>" <?= ($item['status_id'] ?? '') == $s['id'] ? 'selected' : ''; ?>><?= h($s['label']); ?></option>
+        <?php endforeach; ?>
+      </select>
+      <label for="psStatus">Status</label>
+    </div>
+  </div>
   <div class="col-12">
     <div class="form-floating">
       <textarea class="form-control" id="psDesc" name="description" placeholder="Description" style="height:100px"><?= h($item['description'] ?? ''); ?></textarea>
@@ -49,14 +85,15 @@ if(isset($_GET['msg']) && $_GET['msg']==='saved'){ $message='Record saved.'; }
     </div>
   </div>
   <div class="col-12">
-    <div class="form-floating form-floating-advance-select">
-      <label for="personSelect">Assign People</label>
-      <select class="form-select" id="personSelect" name="persons[]" multiple data-choices="data-choices" data-options='{"removeItemButton":true,"placeholder":true}'>
-        <?php foreach($people as $p): ?>
-          <option value="<?= $p['id']; ?>" <?= in_array($p['id'],$assigned) ? 'selected' : ''; ?>><?= h($p['name'] . ($p['skills'] ? ' - '.$p['skills'] : '')); ?></option>
-        <?php endforeach; ?>
-      </select>
+    <div class="form-floating">
+      <input class="form-control" id="psPrice" type="number" step="0.01" min="0" name="price" placeholder="Price" value="<?= h($item['price'] ?? ''); ?>">
+      <label for="psPrice">Price</label>
     </div>
+  </div>
+  <div class="col-12">
+    <label class="form-label">Assign People</label>
+    <div id="assignmentContainer"></div>
+    <button class="btn btn-sm btn-secondary mt-2" type="button" id="addAssignment">Add Person</button>
   </div>
   <div class="col-12">
     <div class="form-floating">
@@ -69,4 +106,55 @@ if(isset($_GET['msg']) && $_GET['msg']==='saved'){ $message='Record saved.'; }
     <a class="btn btn-secondary" href="index.php">Cancel</a>
   </div>
 </form>
+<script>
+const personSkills = <?= json_encode($personSkills); ?>;
+const peopleOptions = `<?php foreach($people as $p){ echo '<option value="'.$p['id'].'">'.h($p['name'] . ($p['skills'] ? ' - '.$p['skills'] : '')).'</option>'; } ?>`;
+const existingAssignments = <?= json_encode($assigned); ?>;
+function createRow(data){
+  const idx = document.querySelectorAll('#assignmentContainer .assignment-row').length;
+  const row = document.createElement('div');
+  row.className = 'row g-2 mb-2 assignment-row';
+  row.innerHTML = `
+    <div class="col-md-6">
+      <select class="form-select person-select" name="assignments[${idx}][person_id]" required>
+        <option value="">Select Person</option>${peopleOptions}
+      </select>
+    </div>
+    <div class="col-md-4">
+      <select class="form-select skill-select" name="assignments[${idx}][skill_id]" required>
+        <option value="">Select Skill</option>
+      </select>
+    </div>
+    <div class="col-md-2">
+      <button type="button" class="btn btn-danger remove-assignment">&times;</button>
+    </div>`;
+  document.getElementById('assignmentContainer').appendChild(row);
+  const personSelect = row.querySelector('.person-select');
+  const skillSelect = row.querySelector('.skill-select');
+  personSelect.addEventListener('change', () => {
+    const pid = personSelect.value;
+    skillSelect.innerHTML = '<option value="">Select Skill</option>';
+    if(personSkills[pid]){
+      personSkills[pid].forEach(s => {
+        const opt = document.createElement('option');
+        opt.value = s.skill_id;
+        opt.textContent = s.label;
+        skillSelect.appendChild(opt);
+      });
+    }
+    if(data && pid == data.person_id){
+      skillSelect.value = data.skill_id;
+    }
+  });
+  row.querySelector('.remove-assignment').addEventListener('click', () => row.remove());
+  if(data){
+    personSelect.value = data.person_id;
+    personSelect.dispatchEvent(new Event('change'));
+    skillSelect.value = data.skill_id;
+  }
+}
+existingAssignments.forEach(a => createRow(a));
+if(existingAssignments.length === 0){ createRow(); }
+document.getElementById('addAssignment').addEventListener('click', () => createRow());
+</script>
 <?php require '../admin_footer.php'; ?>

--- a/admin/products-services/functions/save.php
+++ b/admin/products-services/functions/save.php
@@ -8,36 +8,47 @@ if (!verify_csrf_token($token)) {
 
 $id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
 $name = trim($_POST['name'] ?? '');
+$type_id = isset($_POST['type_id']) ? (int)$_POST['type_id'] : 0;
+$status_id = isset($_POST['status_id']) ? (int)$_POST['status_id'] : 0;
 $description = trim($_POST['description'] ?? '');
+$price = isset($_POST['price']) && $_POST['price'] !== '' ? (float)$_POST['price'] : null;
 $memo = trim($_POST['memo'] ?? '');
-$persons = isset($_POST['persons']) && is_array($_POST['persons']) ? array_map('intval', $_POST['persons']) : [];
+$assignments = isset($_POST['assignments']) && is_array($_POST['assignments']) ? $_POST['assignments'] : [];
+$cleanAssignments = [];
+foreach($assignments as $a){
+  $pid = isset($a['person_id']) ? (int)$a['person_id'] : 0;
+  $sid = isset($a['skill_id']) ? (int)$a['skill_id'] : 0;
+  if($pid > 0 && $sid > 0){
+    $cleanAssignments[] = ['person_id'=>$pid,'skill_id'=>$sid];
+  }
+}
 
-if ($name === '') {
+if ($name === '' || !$type_id || !$status_id) {
   header('Location: ../index.php');
   exit;
 }
 
 if ($id) {
   require_permission('products_services','update');
-  $stmtOld = $pdo->prepare('SELECT name, description, memo FROM module_products_services WHERE id=:id');
+  $stmtOld = $pdo->prepare('SELECT name, type_id, status_id, description, price, memo FROM module_products_services WHERE id=:id');
   $stmtOld->execute([':id'=>$id]);
   $old = $stmtOld->fetch(PDO::FETCH_ASSOC);
-  $stmt = $pdo->prepare('UPDATE module_products_services SET name=:name, description=:descr, memo=:memo, user_updated=:uid WHERE id=:id');
-  $stmt->execute([':name'=>$name, ':descr'=>$description, ':memo'=>$memo, ':uid'=>$this_user_id, ':id'=>$id]);
-  admin_audit_log($pdo,$this_user_id,'module_products_services',$id,'UPDATE',json_encode($old),json_encode(['name'=>$name]),'Updated product/service');
+  $stmt = $pdo->prepare('UPDATE module_products_services SET name=:name, type_id=:type_id, status_id=:status_id, description=:descr, price=:price, memo=:memo, user_updated=:uid WHERE id=:id');
+  $stmt->execute([':name'=>$name, ':type_id'=>$type_id, ':status_id'=>$status_id, ':descr'=>$description, ':price'=>$price, ':memo'=>$memo, ':uid'=>$this_user_id, ':id'=>$id]);
+  admin_audit_log($pdo,$this_user_id,'module_products_services',$id,'UPDATE',json_encode($old),json_encode(['name'=>$name,'type_id'=>$type_id,'status_id'=>$status_id,'description'=>$description,'price'=>$price,'memo'=>$memo]),'Updated product/service');
 } else {
   require_permission('products_services','create');
-  $stmt = $pdo->prepare('INSERT INTO module_products_services (user_id,user_updated,name,description,memo) VALUES (:uid,:uid,:name,:descr,:memo)');
-  $stmt->execute([':uid'=>$this_user_id, ':name'=>$name, ':descr'=>$description, ':memo'=>$memo]);
+  $stmt = $pdo->prepare('INSERT INTO module_products_services (user_id,user_updated,name,type_id,status_id,description,price,memo) VALUES (:uid,:uid,:name,:type_id,:status_id,:descr,:price,:memo)');
+  $stmt->execute([':uid'=>$this_user_id, ':name'=>$name, ':type_id'=>$type_id, ':status_id'=>$status_id, ':descr'=>$description, ':price'=>$price, ':memo'=>$memo]);
   $id = $pdo->lastInsertId();
-  admin_audit_log($pdo,$this_user_id,'module_products_services',$id,'CREATE',null,json_encode(['name'=>$name]),'Created product/service');
+  admin_audit_log($pdo,$this_user_id,'module_products_services',$id,'CREATE',null,json_encode(['name'=>$name,'type_id'=>$type_id,'status_id'=>$status_id,'description'=>$description,'price'=>$price,'memo'=>$memo]),'Created product/service');
 }
 
 $pdo->prepare('DELETE FROM module_products_services_person WHERE product_service_id=:id')->execute([':id'=>$id]);
-if($persons){
-  $ins = $pdo->prepare('INSERT INTO module_products_services_person (user_id,user_updated,product_service_id,person_id) VALUES (:uid,:uid,:psid,:pid)');
-  foreach($persons as $pid){
-    if($pid>0){ $ins->execute([':uid'=>$this_user_id, ':psid'=>$id, ':pid'=>$pid]); }
+if($cleanAssignments){
+  $ins = $pdo->prepare('INSERT INTO module_products_services_person (user_id,user_updated,product_service_id,person_id,skill_id) VALUES (:uid,:uid,:psid,:pid,:sid)');
+  foreach($cleanAssignments as $a){
+    $ins->execute([':uid'=>$this_user_id, ':psid'=>$id, ':pid'=>$a['person_id'], ':sid'=>$a['skill_id']]);
   }
 }
 


### PR DESCRIPTION
## Summary
- add type, status, and price fields to product/service form
- replace people multiselect with person/skill assignment component
- persist type, status, price, and skill-linked assignments in backend

## Testing
- ✅ `php -l admin/products-services/edit.php`
- ✅ `php -l admin/products-services/functions/save.php`


------
https://chatgpt.com/codex/tasks/task_e_68abad416de883338765420eda5b6f53