### PR TITLE
Add CSRF handling and modal editing for meetings

### DIFF
--- a/admin/meetings/functions/get_questions.php
+++ b/admin/meetings/functions/get_questions.php
@@ -7,7 +7,7 @@ header('Content-Type: application/json');
 $meeting_id = (int)($_GET['meeting_id'] ?? 0);
 
 if ($meeting_id) {
-    $stmt = $pdo->prepare('SELECT id, agenda_id, question_text AS question, answer_text AS answer FROM module_meeting_questions WHERE meeting_id = ? ORDER BY id');
+    $stmt = $pdo->prepare('SELECT id, meeting_id, agenda_id, question_text, answer_text, status_id FROM module_meeting_questions WHERE meeting_id = ? ORDER BY id');
     $stmt->execute([$meeting_id]);
     $questions = $stmt->fetchAll(PDO::FETCH_ASSOC);
     echo json_encode(['success' => true, 'questions' => $questions]);


### PR DESCRIPTION
## Summary
- load questions via new get_questions endpoint and include status and meeting IDs
- secure meeting interactions with CSRF tokens across forms and fetch calls
- add Bootstrap modal for agenda editing with status and task/project fields

## Testing
- `php -l admin/meetings/include/details_view.php`
- `php -l admin/meetings/functions/get_questions.php`


------
https://chatgpt.com/codex/tasks/task_e_68ab8758d06483338ec825c099c74d6c