### PR TITLE
Refactor organization management views with Phoenix components

### DIFF
--- a/admin/orgs/agency_edit.php
+++ b/admin/orgs/agency_edit.php
@@ -42,6 +42,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   if (!hash_equals($token, $_POST['csrf_token'] ?? '')) {
     die('Invalid CSRF token');
   }
+  if (isset($_POST['remove_file']) && $id) {
+    require_permission('agency','update');
+    $uploadDir = dirname(__DIR__, 3) . '/uploads/agency/';
+    if (!empty($file_path)) {
+      @unlink($uploadDir . $file_path);
+    }
+    $pdo->prepare('UPDATE module_agency SET file_name=NULL,file_path=NULL,file_size=NULL,file_type=NULL WHERE id=?')->execute([$id]);
+    admin_audit_log($pdo,$this_user_id,'module_agency',$id,'REMOVE_FILE',json_encode(['file_name'=>$file_name,'file_path'=>$file_path]),null,'Removed agency file');
+    header('Location: agency_edit.php?id='.$id);
+    exit;
+  }
+
   $organization_id = $_POST['organization_id'] !== '' ? (int)$_POST['organization_id'] : null;
   $name = trim($_POST['name'] ?? '');
   $main_person = $_POST['main_person'] !== '' ? (int)$_POST['main_person'] : null;
@@ -56,6 +68,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $id = $pdo->lastInsertId();
     admin_audit_log($pdo, $this_user_id, 'module_agency', $id, 'CREATE', null, json_encode(['organization_id'=>$organization_id,'name'=>$name,'main_person'=>$main_person,'status'=>$status]), 'Created agency');
   }
+
   // handle file upload (max 5MB)
   if (!empty($_FILES['upload_file']['name'])) {
     $maxSize = 5 * 1024 * 1024; // 5MB
@@ -124,103 +137,114 @@ require '../admin_header.php';
 ?>
 <h2 class="mb-4"><?= $id ? 'Edit' : 'Add'; ?> Agency</h2>
 
-<form method="post" enctype="multipart/form-data">
-  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
-  <div class="mb-3">
-    <label class="form-label">Organization</label>
-    <select name="organization_id" class="form-select" required>
-      <option value="">-- Select --</option>
-      <?php foreach($orgOptions as $oid => $oname): ?>
-        <option value="<?= $oid; ?>" <?= (int)$oid === (int)$organization_id ? 'selected' : ''; ?>><?= htmlspecialchars($oname); ?></option>
-      <?php endforeach; ?>
-    </select>
-  </div>
-  <div class="mb-3">
-    <label class="form-label">Name</label>
-    <input type="text" name="name" class="form-control" value="<?= htmlspecialchars($name); ?>" required>
-  </div>
-  <div class="mb-3">
-    <label class="form-label">Main Person</label>
-    <select name="main_person" class="form-select">
-      <option value="">-- None --</option>
-      <?php foreach($personOptions as $pid => $pname): ?>
-        <option value="<?= $pid; ?>" <?= (int)$pid === (int)$main_person ? 'selected' : ''; ?>><?= htmlspecialchars($pname); ?></option>
-      <?php endforeach; ?>
-    </select>
-  </div>
-  <div class="mb-3">
-    <label class="form-label">Status</label>
-    <select name="status" class="form-select">
-      <?php foreach($statusOptions as $sid => $slabel): ?>
-        <option value="<?= $sid; ?>" <?= (int)$sid === (int)$status ? 'selected' : ''; ?>><?= htmlspecialchars($slabel); ?></option>
-      <?php endforeach; ?>
-    </select>
-  </div>
-
-  <div class="mb-3">
-    <label class="form-label">Upload File</label>
-    <?php if ($file_path): ?>
-      <div class="mb-2">
-        <a href="/module/agency/download.php?id=<?= $id; ?>" target="_blank"><?= htmlspecialchars($file_name); ?></a>
+<div class="card mb-4">
+  <div class="card-body">
+    <form method="post" enctype="multipart/form-data" id="agencyForm">
+      <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+      <div class="mb-3">
+        <label class="form-label">Organization</label>
+        <select name="organization_id" class="form-select" required>
+          <option value="">-- Select --</option>
+          <?php foreach($orgOptions as $oid => $oname): ?>
+            <option value="<?= $oid; ?>" <?= (int)$oid === (int)$organization_id ? 'selected' : ''; ?>><?= htmlspecialchars($oname); ?></option>
+          <?php endforeach; ?>
+        </select>
       </div>
-    <?php endif; ?>
-    <input type="file" name="upload_file" class="form-control" accept="image/*,application/pdf">
+      <div class="mb-3">
+        <label class="form-label">Name</label>
+        <input type="text" name="name" class="form-control" value="<?= htmlspecialchars($name); ?>" required>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Main Person</label>
+        <select name="main_person" class="form-select">
+          <option value="">-- None --</option>
+          <?php foreach($personOptions as $pid => $pname): ?>
+            <option value="<?= $pid; ?>" <?= (int)$pid === (int)$main_person ? 'selected' : ''; ?>><?= htmlspecialchars($pname); ?></option>
+          <?php endforeach; ?>
+        </select>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Status</label>
+        <select name="status" class="form-select">
+          <?php foreach($statusOptions as $sid => $slabel): ?>
+            <option value="<?= $sid; ?>" <?= (int)$sid === (int)$status ? 'selected' : ''; ?>><?= htmlspecialchars($slabel); ?></option>
+          <?php endforeach; ?>
+        </select>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Upload File</label>
+        <?php if ($file_path): ?>
+          <div class="mb-2">
+            <a href="/module/agency/download.php?id=<?= $id; ?>" target="_blank"><?= htmlspecialchars($file_name); ?></a>
+            <button class="btn btn-outline-danger btn-sm ms-2" name="remove_file" value="1" formnovalidate>Remove File</button>
+            <?php if (strpos($file_type,'image/') === 0): ?>
+              <img src="/uploads/agency/<?= htmlspecialchars($file_path); ?>" class="img-fluid mt-2" alt="Preview">
+            <?php elseif ($file_type === 'application/pdf'): ?>
+              <embed src="/uploads/agency/<?= htmlspecialchars($file_path); ?>" type="application/pdf" class="w-100 mt-2" style="height:200px;"></embed>
+            <?php endif; ?>
+          </div>
+        <?php endif; ?>
+        <input type="file" name="upload_file" class="form-control" accept="image/*,application/pdf">
+      </div>
+      <button class="btn <?= $btnClass; ?>" type="submit">Save</button>
+      <a href="index.php" class="btn btn-secondary">Cancel</a>
+    </form>
   </div>
-
-  <button class="btn <?= $btnClass; ?>" type="submit">Save</button>
-  <a href="index.php" class="btn btn-secondary">Cancel</a>
-</form>
+</div>
 <?php if ($id): ?>
-  <hr class="my-4">
-  <h4>Assigned Persons</h4>
-  <table class="table table-sm">
-    <thead>
-      <tr><th>Name</th><th>Role</th><th>Lead</th><th></th></tr>
-    </thead>
-    <tbody>
-      <?php foreach($assignedPersons as $ap): ?>
-        <tr>
-          <td><?= htmlspecialchars($ap['name']); ?></td>
-          <td><?= htmlspecialchars($ap['role_label'] ?? ''); ?></td>
-          <td><?= $ap['is_lead'] ? 'Yes' : 'No'; ?></td>
-          <td>
-            <form method="post" action="functions/agency_remove_person.php" class="d-inline">
-              <input type="hidden" name="assignment_id" value="<?= $ap['id']; ?>">
-              <input type="hidden" name="agency_id" value="<?= $id; ?>">
-              <input type="hidden" name="csrf_token" value="<?= $token; ?>">
-              <button class="btn btn-sm btn-danger" onclick="return confirm('Remove this person?');">Remove</button>
-            </form>
-          </td>
-        </tr>
-      <?php endforeach; ?>
-    </tbody>
-  </table>
-  <form method="post" action="functions/agency_assign_person.php" class="row g-2">
-    <input type="hidden" name="csrf_token" value="<?= $token; ?>">
-    <input type="hidden" name="agency_id" value="<?= $id; ?>">
-    <div class="col-md-4">
-      <select name="person_id" class="form-select" required>
-        <option value="">-- Person --</option>
-        <?php foreach($personOptions as $pid=>$pname): ?>
-          <option value="<?= $pid; ?>"><?= htmlspecialchars($pname); ?></option>
-        <?php endforeach; ?>
-      </select>
+  <div class="card" id="persons">
+    <div class="card-header"><h4 class="mb-0">Assigned Persons</h4></div>
+    <div class="card-body">
+      <table class="table table-sm">
+        <thead>
+          <tr><th>Name</th><th>Role</th><th>Lead</th><th></th></tr>
+        </thead>
+        <tbody>
+          <?php foreach($assignedPersons as $ap): ?>
+            <tr>
+              <td><?= htmlspecialchars($ap['name']); ?></td>
+              <td><?= htmlspecialchars($ap['role_label'] ?? ''); ?></td>
+              <td><?= $ap['is_lead'] ? 'Yes' : 'No'; ?></td>
+              <td>
+                <form method="post" action="functions/agency_remove_person.php" class="d-inline">
+                  <input type="hidden" name="assignment_id" value="<?= $ap['id']; ?>">
+                  <input type="hidden" name="agency_id" value="<?= $id; ?>">
+                  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+                  <button class="btn btn-sm btn-danger" onclick="return confirm('Remove this person?');">Remove</button>
+                </form>
+              </td>
+            </tr>
+          <?php endforeach; ?>
+        </tbody>
+      </table>
+      <form method="post" action="functions/agency_assign_person.php" class="row g-2">
+        <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+        <input type="hidden" name="agency_id" value="<?= $id; ?>">
+        <div class="col-md-4">
+          <select name="person_id" class="form-select" required>
+            <option value="">-- Person --</option>
+            <?php foreach($personOptions as $pid=>$pname): ?>
+              <option value="<?= $pid; ?>"><?= htmlspecialchars($pname); ?></option>
+            <?php endforeach; ?>
+          </select>
+        </div>
+        <div class="col-md-4">
+          <select name="role_id" class="form-select">
+            <option value="">-- Role --</option>
+            <?php foreach($roleOptions as $rid=>$rlabel): ?>
+              <option value="<?= $rid; ?>"><?= htmlspecialchars($rlabel); ?></option>
+            <?php endforeach; ?>
+          </select>
+        </div>
+        <div class="col-md-2 form-check d-flex align-items-center">
+          <input class="form-check-input" type="checkbox" value="1" name="is_lead" id="agencyLeadChk">
+          <label class="form-check-label ms-2" for="agencyLeadChk">Lead</label>
+        </div>
+        <div class="col-md-2">
+          <button class="btn btn-primary" type="submit">Assign</button>
+        </div>
+      </form>
     </div>
-    <div class="col-md-4">
-      <select name="role_id" class="form-select">
-        <option value="">-- Role --</option>
-        <?php foreach($roleOptions as $rid=>$rlabel): ?>
-          <option value="<?= $rid; ?>"><?= htmlspecialchars($rlabel); ?></option>
-        <?php endforeach; ?>
-      </select>
-    </div>
-    <div class="col-md-2 form-check d-flex align-items-center">
-      <input class="form-check-input" type="checkbox" value="1" name="is_lead" id="agencyLeadChk">
-      <label class="form-check-label ms-2" for="agencyLeadChk">Lead</label>
-    </div>
-    <div class="col-md-2">
-      <button class="btn btn-primary" type="submit">Assign</button>
-    </div>
-  </form>
+  </div>
 <?php endif; ?>
 <?php require '../admin_footer.php'; ?>

--- a/admin/orgs/division_edit.php
+++ b/admin/orgs/division_edit.php
@@ -42,6 +42,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   if (!hash_equals($token, $_POST['csrf_token'] ?? '')) {
     die('Invalid CSRF token');
   }
+  if (isset($_POST['remove_file']) && $id) {
+    require_permission('division','update');
+    $uploadDir = dirname(__DIR__, 3) . '/uploads/division/';
+    if (!empty($file_path)) {
+      @unlink($uploadDir . $file_path);
+    }
+    $pdo->prepare('UPDATE module_division SET file_name=NULL,file_path=NULL,file_size=NULL,file_type=NULL WHERE id=?')->execute([$id]);
+    admin_audit_log($pdo,$this_user_id,'module_division',$id,'REMOVE_FILE',json_encode(['file_name'=>$file_name,'file_path'=>$file_path]),null,'Removed division file');
+    header('Location: division_edit.php?id='.$id);
+    exit;
+  }
+
   $agency_id = $_POST['agency_id'] !== '' ? (int)$_POST['agency_id'] : null;
   $name = trim($_POST['name'] ?? '');
   $main_person = $_POST['main_person'] !== '' ? (int)$_POST['main_person'] : null;
@@ -56,6 +68,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $id = $pdo->lastInsertId();
     admin_audit_log($pdo, $this_user_id, 'module_division', $id, 'CREATE', null, json_encode(['agency_id'=>$agency_id,'name'=>$name,'main_person'=>$main_person,'status'=>$status]), 'Created division');
   }
+
   // handle file upload (max 5MB)
   if (!empty($_FILES['upload_file']['name'])) {
     $maxSize = 5 * 1024 * 1024; // 5MB
@@ -122,101 +135,114 @@ if ($id) {
 require '../admin_header.php';
 ?>
 <h2 class="mb-4"><?= $id ? 'Edit' : 'Add'; ?> Division</h2>
-<form method="post" enctype="multipart/form-data">
-  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
-  <div class="mb-3">
-    <label class="form-label">Agency</label>
-    <select name="agency_id" class="form-select" required>
-      <option value="">-- Select --</option>
-      <?php foreach($agencyOptions as $aid => $aname): ?>
-        <option value="<?= $aid; ?>" <?= (int)$aid === (int)$agency_id ? 'selected' : ''; ?>><?= htmlspecialchars($aname); ?></option>
-      <?php endforeach; ?>
-    </select>
-  </div>
-  <div class="mb-3">
-    <label class="form-label">Name</label>
-    <input type="text" name="name" class="form-control" value="<?= htmlspecialchars($name); ?>" required>
-  </div>
-  <div class="mb-3">
-    <label class="form-label">Main Person</label>
-    <select name="main_person" class="form-select">
-      <option value="">-- None --</option>
-      <?php foreach($personOptions as $pid => $pname): ?>
-        <option value="<?= $pid; ?>" <?= (int)$pid === (int)$main_person ? 'selected' : ''; ?>><?= htmlspecialchars($pname); ?></option>
-      <?php endforeach; ?>
-    </select>
-  </div>
-  <div class="mb-3">
-    <label class="form-label">Status</label>
-    <select name="status" class="form-select">
-      <?php foreach($statusOptions as $sid => $slabel): ?>
-        <option value="<?= $sid; ?>" <?= (int)$sid === (int)$status ? 'selected' : ''; ?>><?= htmlspecialchars($slabel); ?></option>
-      <?php endforeach; ?>
-    </select>
-  </div>
-  <div class="mb-3">
-    <label class="form-label">Upload File</label>
-    <?php if ($file_path): ?>
-      <div class="mb-2">
-        <a href="/module/division/download.php?id=<?= $id; ?>" target="_blank"><?= htmlspecialchars($file_name); ?></a>
+<div class="card mb-4">
+  <div class="card-body">
+    <form method="post" enctype="multipart/form-data" id="divisionForm">
+      <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+      <div class="mb-3">
+        <label class="form-label">Agency</label>
+        <select name="agency_id" class="form-select" required>
+          <option value="">-- Select --</option>
+          <?php foreach($agencyOptions as $aid => $aname): ?>
+            <option value="<?= $aid; ?>" <?= (int)$aid === (int)$agency_id ? 'selected' : ''; ?>><?= htmlspecialchars($aname); ?></option>
+          <?php endforeach; ?>
+        </select>
       </div>
-    <?php endif; ?>
-    <input type="file" name="upload_file" class="form-control" accept="image/*,application/pdf">
+      <div class="mb-3">
+        <label class="form-label">Name</label>
+        <input type="text" name="name" class="form-control" value="<?= htmlspecialchars($name); ?>" required>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Main Person</label>
+        <select name="main_person" class="form-select">
+          <option value="">-- None --</option>
+          <?php foreach($personOptions as $pid => $pname): ?>
+            <option value="<?= $pid; ?>" <?= (int)$pid === (int)$main_person ? 'selected' : ''; ?>><?= htmlspecialchars($pname); ?></option>
+          <?php endforeach; ?>
+        </select>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Status</label>
+        <select name="status" class="form-select">
+          <?php foreach($statusOptions as $sid => $slabel): ?>
+            <option value="<?= $sid; ?>" <?= (int)$sid === (int)$status ? 'selected' : ''; ?>><?= htmlspecialchars($slabel); ?></option>
+          <?php endforeach; ?>
+        </select>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Upload File</label>
+        <?php if ($file_path): ?>
+          <div class="mb-2">
+            <a href="/module/division/download.php?id=<?= $id; ?>" target="_blank"><?= htmlspecialchars($file_name); ?></a>
+            <button class="btn btn-outline-danger btn-sm ms-2" name="remove_file" value="1" formnovalidate>Remove File</button>
+            <?php if (strpos($file_type,'image/') === 0): ?>
+              <img src="/uploads/division/<?= htmlspecialchars($file_path); ?>" class="img-fluid mt-2" alt="Preview">
+            <?php elseif ($file_type === 'application/pdf'): ?>
+              <embed src="/uploads/division/<?= htmlspecialchars($file_path); ?>" type="application/pdf" class="w-100 mt-2" style="height:200px;"></embed>
+            <?php endif; ?>
+          </div>
+        <?php endif; ?>
+        <input type="file" name="upload_file" class="form-control" accept="image/*,application/pdf">
+      </div>
+      <button class="btn <?= $btnClass; ?>" type="submit">Save</button>
+      <a href="index.php" class="btn btn-secondary">Cancel</a>
+    </form>
   </div>
-  <button class="btn <?= $btnClass; ?>" type="submit">Save</button>
-  <a href="index.php" class="btn btn-secondary">Cancel</a>
-</form>
+</div>
 <?php if ($id): ?>
-  <hr class="my-4">
-  <h4>Assigned Persons</h4>
-  <table class="table table-sm">
-    <thead>
-      <tr><th>Name</th><th>Role</th><th>Lead</th><th></th></tr>
-    </thead>
-    <tbody>
-      <?php foreach($assignedPersons as $ap): ?>
-        <tr>
-          <td><?= htmlspecialchars($ap['name']); ?></td>
-          <td><?= htmlspecialchars($ap['role_label'] ?? ''); ?></td>
-          <td><?= $ap['is_lead'] ? 'Yes' : 'No'; ?></td>
-          <td>
-            <form method="post" action="functions/division_remove_person.php" class="d-inline">
-              <input type="hidden" name="assignment_id" value="<?= $ap['id']; ?>">
-              <input type="hidden" name="division_id" value="<?= $id; ?>">
-              <input type="hidden" name="csrf_token" value="<?= $token; ?>">
-              <button class="btn btn-sm btn-danger" onclick="return confirm('Remove this person?');">Remove</button>
-            </form>
-          </td>
-        </tr>
-      <?php endforeach; ?>
-    </tbody>
-  </table>
-  <form method="post" action="functions/division_assign_person.php" class="row g-2">
-    <input type="hidden" name="csrf_token" value="<?= $token; ?>">
-    <input type="hidden" name="division_id" value="<?= $id; ?>">
-    <div class="col-md-4">
-      <select name="person_id" class="form-select" required>
-        <option value="">-- Person --</option>
-        <?php foreach($personOptions as $pid=>$pname): ?>
-          <option value="<?= $pid; ?>"><?= htmlspecialchars($pname); ?></option>
-        <?php endforeach; ?>
-      </select>
+  <div class="card" id="persons">
+    <div class="card-header"><h4 class="mb-0">Assigned Persons</h4></div>
+    <div class="card-body">
+      <table class="table table-sm">
+        <thead>
+          <tr><th>Name</th><th>Role</th><th>Lead</th><th></th></tr>
+        </thead>
+        <tbody>
+          <?php foreach($assignedPersons as $ap): ?>
+            <tr>
+              <td><?= htmlspecialchars($ap['name']); ?></td>
+              <td><?= htmlspecialchars($ap['role_label'] ?? ''); ?></td>
+              <td><?= $ap['is_lead'] ? 'Yes' : 'No'; ?></td>
+              <td>
+                <form method="post" action="functions/division_remove_person.php" class="d-inline">
+                  <input type="hidden" name="assignment_id" value="<?= $ap['id']; ?>">
+                  <input type="hidden" name="division_id" value="<?= $id; ?>">
+                  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+                  <button class="btn btn-sm btn-danger" onclick="return confirm('Remove this person?');">Remove</button>
+                </form>
+              </td>
+            </tr>
+          <?php endforeach; ?>
+        </tbody>
+      </table>
+      <form method="post" action="functions/division_assign_person.php" class="row g-2">
+        <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+        <input type="hidden" name="division_id" value="<?= $id; ?>">
+        <div class="col-md-4">
+          <select name="person_id" class="form-select" required>
+            <option value="">-- Person --</option>
+            <?php foreach($personOptions as $pid=>$pname): ?>
+              <option value="<?= $pid; ?>"><?= htmlspecialchars($pname); ?></option>
+            <?php endforeach; ?>
+          </select>
+        </div>
+        <div class="col-md-4">
+          <select name="role_id" class="form-select">
+            <option value="">-- Role --</option>
+            <?php foreach($roleOptions as $rid=>$rlabel): ?>
+              <option value="<?= $rid; ?>"><?= htmlspecialchars($rlabel); ?></option>
+            <?php endforeach; ?>
+          </select>
+        </div>
+        <div class="col-md-2 form-check d-flex align-items-center">
+          <input class="form-check-input" type="checkbox" value="1" name="is_lead" id="divisionLeadChk">
+          <label class="form-check-label ms-2" for="divisionLeadChk">Lead</label>
+        </div>
+        <div class="col-md-2">
+          <button class="btn btn-primary" type="submit">Assign</button>
+        </div>
+      </form>
     </div>
-    <div class="col-md-4">
-      <select name="role_id" class="form-select">
-        <option value="">-- Role --</option>
-        <?php foreach($roleOptions as $rid=>$rlabel): ?>
-          <option value="<?= $rid; ?>"><?= htmlspecialchars($rlabel); ?></option>
-        <?php endforeach; ?>
-      </select>
-    </div>
-    <div class="col-md-2 form-check d-flex align-items-center">
-      <input class="form-check-input" type="checkbox" value="1" name="is_lead" id="divisionLeadChk">
-      <label class="form-check-label ms-2" for="divisionLeadChk">Lead</label>
-    </div>
-    <div class="col-md-2">
-      <button class="btn btn-primary" type="submit">Assign</button>
-    </div>
-  </form>
+  </div>
 <?php endif; ?>
 <?php require '../admin_footer.php'; ?>

--- a/admin/orgs/index.php
+++ b/admin/orgs/index.php
@@ -145,117 +145,121 @@ $organizations = array_values($organizations);
 <?php if (user_has_permission('organization','create')): ?>
   <a href="organization_edit.php" class="btn btn-sm btn-success mb-3">Add Organization</a>
 <?php endif; ?>
-<div class="table-responsive">
-  <table class="table fs-9 mb-0 border-top border-translucent">
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Status</th>
-        <th>Actions</th>
-      </tr>
-    </thead>
-    <tbody>
-      <?php foreach ($organizations as $org): ?>
-        <tr>
-          <td class="ps-2"><?= htmlspecialchars($org['name']); ?>
-            <?php if (!empty($org['file_path'])): ?>
-              <br><a href="/module/organization/download.php?id=<?= $org['id']; ?>" target="_blank">View File</a>
-            <?php endif; ?>
-            <?php if (!empty($org['persons'])): ?>
-              <br><small>
-                <?php
-                  $parts = [];
-                  foreach ($org['persons'] as $p) {
-                    $label = $p['name'];
-                    if ($p['role_label']) $label .= ' ('.$p['role_label'].')';
-                    if ($p['is_lead']) $label .= ' [Lead]';
-                    $parts[] = htmlspecialchars($label);
-                  }
-                  echo implode(', ', $parts);
-                ?>
-              </small>
-            <?php endif; ?>
-          </td>
-          <td>
-            <?= render_status_badge($orgStatuses, $org['status']) ?>
-          </td>
-          <td>
-            <a class="btn btn-sm btn-warning" href="organization_edit.php?id=<?= $org['id']; ?>">Edit</a>
-            <?php if (user_has_permission('organization','delete')): ?>
-              <form method="post" class="d-inline">
-                <input type="hidden" name="delete_organization_id" value="<?= $org['id']; ?>">
-                <input type="hidden" name="csrf_token" value="<?= $token; ?>">
-                <button class="btn btn-sm btn-danger" onclick="return confirm('Delete this organization?');">Delete</button>
-              </form>
-            <?php endif; ?>
-            <?php if (user_has_permission('agency','create')): ?>
-              <a class="btn btn-sm btn-success" href="agency_edit.php?organization_id=<?= $org['id']; ?>">Add Agency</a>
-            <?php endif; ?>
-          </td>
-        </tr>
+
+<?php foreach ($organizations as $org): ?>
+  <div class="card mb-3">
+    <div class="card-header d-flex justify-content-between align-items-start">
+      <div>
+        <span class="fw-semibold"><?= htmlspecialchars($org['name']); ?></span>
+        <?php if (!empty($org['file_path'])): ?>
+          <br><a href="/module/organization/download.php?id=<?= $org['id']; ?>" target="_blank">View File</a>
+        <?php endif; ?>
+        <?php if (!empty($org['persons'])): ?>
+          <br><small>
+            <?php
+              $parts = [];
+              foreach ($org['persons'] as $p) {
+                $label = $p['name'];
+                if ($p['role_label']) $label .= ' ('.$p['role_label'].')';
+                if ($p['is_lead']) $label .= ' [Lead]';
+                $parts[] = htmlspecialchars($label);
+              }
+              echo implode(', ', $parts);
+            ?>
+          </small>
+        <?php endif; ?>
+      </div>
+      <div class="text-end">
+        <?= render_status_badge($orgStatuses, $org['status']) ?>
+        <div class="mt-2">
+          <a class="btn btn-sm btn-warning" href="organization_edit.php?id=<?= $org['id']; ?>">Edit</a>
+          <?php if (user_has_permission('organization','delete')): ?>
+            <form method="post" class="d-inline">
+              <input type="hidden" name="delete_organization_id" value="<?= $org['id']; ?>">
+              <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+              <button class="btn btn-sm btn-danger" onclick="return confirm('Delete this organization?');">Delete</button>
+            </form>
+          <?php endif; ?>
+          <?php if (user_has_permission('agency','create')): ?>
+            <a class="btn btn-sm btn-success" href="agency_edit.php?organization_id=<?= $org['id']; ?>">Add Agency</a>
+          <?php endif; ?>
+        </div>
+      </div>
+    </div>
+    <?php if (!empty($org['agencies'])): ?>
+      <div class="card-body">
         <?php foreach ($org['agencies'] as $agency): ?>
-          <tr class="bg-body-tertiary">
-            <td class="ps-8"><b>Agency:</b> <?= htmlspecialchars($agency['name']); ?>
-              <?php if (!empty($agency['file_path'])): ?>
-                <br><a href="/module/agency/download.php?id=<?= $agency['id']; ?>" target="_blank">View File</a>
-              <?php endif; ?>
-              <?php if (!empty($agency['persons'])): ?>
-                <br><small>
-                  <?php
-                    $parts = [];
-                    foreach ($agency['persons'] as $p) {
-                      $label = $p['name'];
-                      if ($p['role_label']) $label .= ' ('.$p['role_label'].')';
-                      if ($p['is_lead']) $label .= ' [Lead]';
-                      $parts[] = htmlspecialchars($label);
-                    }
-                    echo implode(', ', $parts);
-                  ?>
-                </small>
-              <?php endif; ?>
-            </td>
-            <td>
-              <?= render_status_badge($agencyStatuses, $agency['status']) ?>
-            </td>
-            <td>
-              <a class="btn btn-sm btn-warning" href="agency_edit.php?id=<?= $agency['id']; ?>">Edit</a>
-              <?php if (user_has_permission('agency','delete')): ?>
-                <form method="post" class="d-inline">
-                  <input type="hidden" name="delete_agency_id" value="<?= $agency['id']; ?>">
-                  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
-                  <button class="btn btn-sm btn-danger" onclick="return confirm('Delete this agency?');">Delete</button>
-                </form>
-              <?php endif; ?>
-              <?php if (user_has_permission('division','create')): ?>
-                <a class="btn btn-sm btn-success" href="division_edit.php?agency_id=<?= $agency['id']; ?>">Add Division</a>
-              <?php endif; ?>
-            </td>
-          </tr>
-          <?php foreach ($agency['divisions'] as $division): ?>
-            <tr class="bg-body-secondary">
-              <td class="ps-12"><b>Division:</b> <?= htmlspecialchars($division['name']); ?>
-                <?php if (!empty($division['file_path'])): ?>
-                  <br><a href="/module/division/download.php?id=<?= $division['id']; ?>" target="_blank">View File</a>
+          <div class="card mb-2">
+            <div class="card-header d-flex justify-content-between align-items-start">
+              <div>
+                <span class="fw-semibold">Agency: <?= htmlspecialchars($agency['name']); ?></span>
+                <?php if (!empty($agency['file_path'])): ?>
+                  <br><a href="/module/agency/download.php?id=<?= $agency['id']; ?>" target="_blank">View File</a>
                 <?php endif; ?>
-              </td>
-              <td>
-                <?= render_status_badge($divisionStatuses, $division['status']) ?>
-              </td>
-              <td>
-                <a class="btn btn-sm btn-warning" href="division_edit.php?id=<?= $division['id']; ?>">Edit</a>
-                <?php if (user_has_permission('division','delete')): ?>
-                  <form method="post" class="d-inline">
-                    <input type="hidden" name="delete_division_id" value="<?= $division['id']; ?>">
-                    <input type="hidden" name="csrf_token" value="<?= $token; ?>">
-                    <button class="btn btn-sm btn-danger" onclick="return confirm('Delete this division?');">Delete</button>
-                  </form>
+                <?php if (!empty($agency['persons'])): ?>
+                  <br><small>
+                    <?php
+                      $parts = [];
+                      foreach ($agency['persons'] as $p) {
+                        $label = $p['name'];
+                        if ($p['role_label']) $label .= ' ('.$p['role_label'].')';
+                        if ($p['is_lead']) $label .= ' [Lead]';
+                        $parts[] = htmlspecialchars($label);
+                      }
+                      echo implode(', ', $parts);
+                    ?>
+                  </small>
                 <?php endif; ?>
-              </td>
-            </tr>
-          <?php endforeach; ?>
+              </div>
+              <div class="text-end">
+                <?= render_status_badge($agencyStatuses, $agency['status']) ?>
+                <div class="mt-2">
+                  <a class="btn btn-sm btn-warning" href="agency_edit.php?id=<?= $agency['id']; ?>">Edit</a>
+                  <?php if (user_has_permission('agency','delete')): ?>
+                    <form method="post" class="d-inline">
+                      <input type="hidden" name="delete_agency_id" value="<?= $agency['id']; ?>">
+                      <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+                      <button class="btn btn-sm btn-danger" onclick="return confirm('Delete this agency?');">Delete</button>
+                    </form>
+                  <?php endif; ?>
+                  <?php if (user_has_permission('division','create')): ?>
+                    <a class="btn btn-sm btn-success" href="division_edit.php?agency_id=<?= $agency['id']; ?>">Add Division</a>
+                  <?php endif; ?>
+                </div>
+              </div>
+            </div>
+            <?php if (!empty($agency['divisions'])): ?>
+              <ul class="list-group list-group-flush">
+                <?php foreach ($agency['divisions'] as $division): ?>
+                  <li class="list-group-item d-flex justify-content-between align-items-start">
+                    <div>
+                      Division: <?= htmlspecialchars($division['name']); ?>
+                      <?php if (!empty($division['file_path'])): ?>
+                        <br><a href="/module/division/download.php?id=<?= $division['id']; ?>" target="_blank">View File</a>
+                      <?php endif; ?>
+                    </div>
+                    <div class="text-end">
+                      <?= render_status_badge($divisionStatuses, $division['status']) ?>
+                      <div class="mt-2">
+                        <a class="btn btn-sm btn-warning" href="division_edit.php?id=<?= $division['id']; ?>">Edit</a>
+                        <?php if (user_has_permission('division','delete')): ?>
+                          <form method="post" class="d-inline">
+                            <input type="hidden" name="delete_division_id" value="<?= $division['id']; ?>">
+                            <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+                            <button class="btn btn-sm btn-danger" onclick="return confirm('Delete this division?');">Delete</button>
+                          </form>
+                        <?php endif; ?>
+                      </div>
+                    </div>
+                  </li>
+                <?php endforeach; ?>
+              </ul>
+            <?php endif; ?>
+          </div>
         <?php endforeach; ?>
-      <?php endforeach; ?>
-    </tbody>
-  </table>
-</div>
+      </div>
+    <?php endif; ?>
+  </div>
+<?php endforeach; ?>
+
 <?php require '../admin_footer.php'; ?>


### PR DESCRIPTION
## Summary
- Display organizations, agencies and divisions using Phoenix card layout
- Restyle organization, agency and division forms with Phoenix cards, previews and file removal
- Retain person assignment widgets with CSRF protection

## Testing
- `php -l admin/orgs/index.php`
- `php -l admin/orgs/organization_edit.php`
- `php -l admin/orgs/agency_edit.php`
- `php -l admin/orgs/division_edit.php`


------
https://chatgpt.com/codex/tasks/task_e_68abb8ddc0c48333adfce0e48fa9cd01