### PR TITLE
Implement attendee AJAX search and improve error handling

### DIFF
--- a/admin/meetings/functions/search_users.php
+++ b/admin/meetings/functions/search_users.php
@@ -1,0 +1,16 @@
+<?php
+require '../../../includes/php_header.php';
+require_permission('person', 'read');
+
+header('Content-Type: application/json');
+
+$q = trim($_GET['q'] ?? '');
+if ($q === '') {
+    echo json_encode([]);
+    exit;
+}
+
+$stmt = $pdo->prepare('SELECT u.id, COALESCE(CONCAT(p.first_name, " ", p.last_name), CONCAT(u.first_name, " ", u.last_name)) AS name FROM users u LEFT JOIN person p ON u.id = p.user_id WHERE COALESCE(CONCAT(p.first_name, " ", p.last_name), CONCAT(u.first_name, " ", u.last_name)) LIKE :q ORDER BY name LIMIT 10');
+$stmt->execute([':q' => "%" . $q . "%"]);
+
+echo json_encode($stmt->fetchAll(PDO::FETCH_ASSOC));


### PR DESCRIPTION
## Summary
- Replace attendee dropdown with AJAX-powered search field and prevent duplicate selections
- Add catch blocks with alerts to fetch chains for agenda, questions, attendees, attachments, and task/project creation
- Provide new `search_users.php` endpoint for user lookup

## Testing
- `php -l admin/meetings/include/details_view.php`
- `php -l admin/meetings/functions/search_users.php`


------
https://chatgpt.com/codex/tasks/task_e_68abb88c88148333a17bbce590524c79