### PR TITLE
Add product/service statuses, categories and price tracking

### DIFF
--- a/_SQL/2025-XX-XX_products_services_enhancements.sql
+++ b/_SQL/2025-XX-XX_products_services_enhancements.sql
@@ -1,12 +1,22 @@
 -- Products & Services enhancements
 
+-- Lookup list for product/service statuses
+INSERT INTO `lookup_lists` (`user_id`,`user_updated`,`date_created`,`date_updated`,`memo`,`name`,`description`) VALUES
+  (1,1,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP,'','PRODUCT_SERVICE_STATUS','Status of products or services');
+
+INSERT INTO `lookup_list_items` (`user_id`,`user_updated`,`date_created`,`date_updated`,`memo`,`list_id`,`name`,`value`,`sort_order`,`date_effective`,`date_expired`) VALUES
+  (1,1,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP,NULL,(SELECT id FROM lookup_lists WHERE name='PRODUCT_SERVICE_STATUS'),'Active','ACTIVE',1,CURDATE(),NULL),
+  (1,1,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP,NULL,(SELECT id FROM lookup_lists WHERE name='PRODUCT_SERVICE_STATUS'),'Inactive','INACTIVE',2,CURDATE(),NULL);
+
 -- Lookup list for product/service categories
 INSERT INTO `lookup_lists` (`user_id`,`user_updated`,`date_created`,`date_updated`,`memo`,`name`,`description`) VALUES
   (1,1,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP,'','PRODUCT_SERVICE_CATEGORY','Categories for products and services');
 
 INSERT INTO `lookup_list_items` (`user_id`,`user_updated`,`date_created`,`date_updated`,`memo`,`list_id`,`name`,`value`,`sort_order`,`date_effective`,`date_expired`) VALUES
   (1,1,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP,NULL,(SELECT id FROM lookup_lists WHERE name='PRODUCT_SERVICE_CATEGORY'),'Consulting','CONSULTING',1,CURDATE(),NULL),
-  (1,1,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP,NULL,(SELECT id FROM lookup_lists WHERE name='PRODUCT_SERVICE_CATEGORY'),'Hardware','HARDWARE',2,CURDATE(),NULL);
+  (1,1,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP,NULL,(SELECT id FROM lookup_lists WHERE name='PRODUCT_SERVICE_CATEGORY'),'Hardware','HARDWARE',2,CURDATE(),NULL),
+  (1,1,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP,NULL,(SELECT id FROM lookup_lists WHERE name='PRODUCT_SERVICE_CATEGORY'),'Software','SOFTWARE',3,CURDATE(),NULL),
+  (1,1,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP,NULL,(SELECT id FROM lookup_lists WHERE name='PRODUCT_SERVICE_CATEGORY'),'Training','TRAINING',4,CURDATE(),NULL);
 
 -- Table linking products/services to categories
 CREATE TABLE `module_products_services_category` (
@@ -21,7 +31,10 @@ CREATE TABLE `module_products_services_category` (
   FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE SET NULL,
   FOREIGN KEY (`user_updated`) REFERENCES `users`(`id`) ON DELETE SET NULL,
   FOREIGN KEY (`product_service_id`) REFERENCES `module_products_services`(`id`) ON DELETE CASCADE,
-  FOREIGN KEY (`category_id`) REFERENCES `lookup_list_items`(`id`)
+  FOREIGN KEY (`category_id`) REFERENCES `lookup_list_items`(`id`),
+  KEY `idx_mpsc_product_service_id` (`product_service_id`),
+  KEY `idx_mpsc_category_id` (`category_id`),
+  UNIQUE KEY `uniq_mpsc_product_category` (`product_service_id`,`category_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- Table to track product/service price changes
@@ -39,5 +52,7 @@ CREATE TABLE `module_products_services_price_history` (
   FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE SET NULL,
   FOREIGN KEY (`user_updated`) REFERENCES `users`(`id`) ON DELETE SET NULL,
   FOREIGN KEY (`product_service_id`) REFERENCES `module_products_services`(`id`) ON DELETE CASCADE,
-  FOREIGN KEY (`changed_by`) REFERENCES `users`(`id`) ON DELETE SET NULL
+  FOREIGN KEY (`changed_by`) REFERENCES `users`(`id`) ON DELETE SET NULL,
+  KEY `idx_mpsph_product_service_id` (`product_service_id`),
+  KEY `idx_mpsph_changed_by` (`changed_by`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;


### PR DESCRIPTION
## Summary
- Add lookup lists for product/service statuses and categories
- Introduce join table for assigning multiple categories to offerings
- Add price history table with audit fields and indexes

## Testing
- `mysql --version`
- `mysql -e "SELECT 1;"` *(fails: Can't connect to local MySQL server)*

------
https://chatgpt.com/codex/tasks/task_e_68abc028b1988333b4712489e5fcfb71