### PR TITLE
Refactor products & services admin

### DIFF
--- a/admin/api/person-skills.php
+++ b/admin/api/person-skills.php
@@ -5,6 +5,10 @@ header('Content-Type: application/json');
 
 try {
     require_permission('person','read');
+    if($_SERVER['REQUEST_METHOD'] !== 'GET'){
+        echo json_encode(['success'=>false,'error'=>'Invalid method']);
+        exit;
+    }
     $person_id = isset($_GET['person_id']) ? (int)$_GET['person_id'] : 0;
     if($person_id <= 0){
         echo json_encode(['success'=>false,'error'=>'Invalid person_id']);
@@ -19,3 +23,4 @@ try {
     echo json_encode(['success'=>false,'error'=>'Server error']);
 }
 
+exit;

--- a/admin/products-services/edit.php
+++ b/admin/products-services/edit.php
@@ -1,8 +1,8 @@
 <?php
 require '../admin_header.php';
-require_permission('products_services','read');
 
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+require_permission('products_services', $id ? 'update' : 'create');
 $item = null;
 if($id){
   $stmt = $pdo->prepare('SELECT * FROM module_products_services WHERE id = :id');
@@ -44,69 +44,96 @@ if(isset($_GET['msg']) && $_GET['msg']==='saved'){ $message='Record saved.'; }
 </nav>
 <h2 class="mb-4"><?= $id ? 'Edit' : 'Add'; ?> Product/Service</h2>
 <?php if($message): ?><div class="alert alert-success"><?= h($message); ?></div><?php endif; ?>
-<form method="post" action="functions/save.php" class="row g-3">
+<form method="post" action="functions/save.php" class="row g-5">
   <input type="hidden" name="csrf_token" value="<?= $token; ?>">
   <?php if($id): ?><input type="hidden" name="id" value="<?= $id; ?>"><?php endif; ?>
   <input type="hidden" name="previous_price" value="<?= h($item['price'] ?? ''); ?>">
-  <div class="col-12">
-    <div class="form-floating">
-      <input class="form-control" id="psName" type="text" name="name" placeholder="Name" value="<?= h($item['name'] ?? ''); ?>" required>
-      <label for="psName">Name</label>
+
+  <div class="col-12 col-lg-8">
+    <div class="card mb-3">
+      <div class="card-body">
+        <div class="row g-3">
+          <div class="col-12">
+            <div class="form-floating">
+              <input class="form-control" id="psName" type="text" name="name" placeholder="Name" value="<?= h($item['name'] ?? ''); ?>" required>
+              <label for="psName">Name</label>
+            </div>
+          </div>
+          <div class="col-md-6">
+            <div class="form-floating">
+              <select class="form-select" id="psType" name="type_id" required>
+                <?php foreach($types as $t): ?>
+                <option value="<?= $t['id']; ?>" <?= ($item['type_id'] ?? '') == $t['id'] ? 'selected' : ''; ?>><?= h($t['label']); ?></option>
+                <?php endforeach; ?>
+              </select>
+              <label for="psType">Type</label>
+            </div>
+          </div>
+          <div class="col-md-6">
+            <div class="form-floating">
+              <select class="form-select" id="psStatus" name="status_id" required>
+                <?php foreach($statuses as $s): ?>
+                <option value="<?= $s['id']; ?>" <?= ($item['status_id'] ?? '') == $s['id'] ? 'selected' : ''; ?>><?= h($s['label']); ?></option>
+                <?php endforeach; ?>
+              </select>
+              <label for="psStatus">Status</label>
+            </div>
+          </div>
+          <div class="col-12">
+            <div class="form-floating form-floating-advance-select">
+              <label for="psCategories">Categories</label>
+              <select class="form-select" id="psCategories" name="category_ids[]" multiple data-choices="data-choices" data-options='{"removeItemButton":true,"placeholder":true}'>
+                <?php foreach($categories as $c): ?>
+                <option value="<?= $c['id']; ?>" <?= in_array($c['id'], $selectedCategories) ? 'selected' : ''; ?>><?= h($c['label']); ?></option>
+                <?php endforeach; ?>
+              </select>
+            </div>
+          </div>
+          <div class="col-12">
+            <div class="form-floating">
+              <textarea class="form-control" id="psDesc" name="description" placeholder="Description" style="height:100px"><?= h($item['description'] ?? ''); ?></textarea>
+              <label for="psDesc">Description</label>
+            </div>
+          </div>
+          <div class="col-12">
+            <div class="form-floating">
+              <input class="form-control" id="psPrice" type="number" step="0.01" min="0" name="price" placeholder="Price" value="<?= h($item['price'] ?? ''); ?>">
+              <label for="psPrice">Price</label>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="card mb-3">
+      <div class="card-body">
+        <label class="form-label">Assign People</label>
+        <div id="assignmentContainer"></div>
+        <button class="btn btn-sm btn-secondary mt-2" type="button" id="addAssignment">Add Person</button>
+      </div>
+    </div>
+
+    <div class="card mb-3">
+      <div class="card-body">
+        <div class="form-floating">
+          <textarea class="form-control" id="psMemo" name="memo" placeholder="Memo" style="height:100px"><?= h($item['memo'] ?? ''); ?></textarea>
+          <label for="psMemo">Memo</label>
+        </div>
+      </div>
     </div>
   </div>
-  <div class="col-md-6">
-    <div class="form-floating">
-      <select class="form-select" id="psType" name="type_id" required>
-        <?php foreach($types as $t): ?>
-          <option value="<?= $t['id']; ?>" <?= ($item['type_id'] ?? '') == $t['id'] ? 'selected' : ''; ?>><?= h($t['label']); ?></option>
-        <?php endforeach; ?>
-      </select>
-      <label for="psType">Type</label>
+
+  <div class="col-12 col-lg-4">
+    <div class="card mb-3">
+      <div class="card-body">
+        <label class="form-label">Attachments</label>
+        <div class="dropzone p-3 border border-dashed border-300 rounded-2 text-center" id="psDropzone" data-dropzone="data-dropzone">
+          <div class="dz-message">Drag files here or click to upload</div>
+        </div>
+      </div>
     </div>
   </div>
-  <div class="col-md-6">
-    <div class="form-floating">
-      <select class="form-select" id="psStatus" name="status_id" required>
-        <?php foreach($statuses as $s): ?>
-          <option value="<?= $s['id']; ?>" <?= ($item['status_id'] ?? '') == $s['id'] ? 'selected' : ''; ?>><?= h($s['label']); ?></option>
-        <?php endforeach; ?>
-      </select>
-      <label for="psStatus">Status</label>
-    </div>
-  </div>
-  <div class="col-12">
-    <div class="form-floating form-floating-advance-select">
-      <label for="psCategories">Categories</label>
-      <select class="form-select" id="psCategories" name="category_ids[]" multiple data-choices="data-choices" data-options='{"removeItemButton":true,"placeholder":true}'>
-        <?php foreach($categories as $c): ?>
-          <option value="<?= $c['id']; ?>" <?= in_array($c['id'], $selectedCategories) ? 'selected' : ''; ?>><?= h($c['label']); ?></option>
-        <?php endforeach; ?>
-      </select>
-    </div>
-  </div>
-  <div class="col-12">
-    <div class="form-floating">
-      <textarea class="form-control" id="psDesc" name="description" placeholder="Description" style="height:100px"><?= h($item['description'] ?? ''); ?></textarea>
-      <label for="psDesc">Description</label>
-    </div>
-  </div>
-  <div class="col-12">
-    <div class="form-floating">
-      <input class="form-control" id="psPrice" type="number" step="0.01" min="0" name="price" placeholder="Price" value="<?= h($item['price'] ?? ''); ?>">
-      <label for="psPrice">Price</label>
-    </div>
-  </div>
-  <div class="col-12">
-    <label class="form-label">Assign People</label>
-    <div id="assignmentContainer"></div>
-    <button class="btn btn-sm btn-secondary mt-2" type="button" id="addAssignment">Add Person</button>
-  </div>
-  <div class="col-12">
-    <div class="form-floating">
-      <textarea class="form-control" id="psMemo" name="memo" placeholder="Memo" style="height:100px"><?= h($item['memo'] ?? ''); ?></textarea>
-      <label for="psMemo">Memo</label>
-    </div>
-  </div>
+
   <div class="col-12">
     <button class="btn btn-primary" type="submit">Save</button>
     <a class="btn btn-secondary" href="index.php">Cancel</a>

--- a/admin/products-services/functions/delete.php
+++ b/admin/products-services/functions/delete.php
@@ -13,8 +13,18 @@ if(!verify_csrf_token($_POST['csrf_token'] ?? '')){
 
 $id = (int)($_POST['id'] ?? 0);
 if($id){
-  $pdo->prepare('DELETE FROM module_products_services WHERE id=:id')->execute([':id'=>$id]);
-  admin_audit_log($pdo,$this_user_id,'module_products_services',$id,'DELETE',null,null,'Deleted product/service');
+  try{
+    $pdo->beginTransaction();
+    $pdo->prepare('DELETE FROM module_products_services_category WHERE product_service_id=:id')->execute([':id'=>$id]);
+    $pdo->prepare('DELETE FROM module_products_services_person WHERE product_service_id=:id')->execute([':id'=>$id]);
+    $pdo->prepare('DELETE FROM module_products_services_price_history WHERE product_service_id=:id')->execute([':id'=>$id]);
+    $pdo->prepare('DELETE FROM module_products_services WHERE id=:id')->execute([':id'=>$id]);
+    $pdo->commit();
+    admin_audit_log($pdo,$this_user_id,'module_products_services',$id,'DELETE',null,null,'Deleted product/service');
+  }catch(Exception $e){
+    $pdo->rollBack();
+    throw $e;
+  }
 }
 
 header('Location: ../index.php?msg=deleted');


### PR DESCRIPTION
## Summary
- Replace products & services index with Phoenix card grid, search, filters, and pagination
- Revamp edit form with Phoenix cards, advanced category select, dropzone, and dynamic RBAC
- Persist category selections and price history with CSRF/RBAC validation
- Add person-skills API and harden delete with transactional cleanup and audit logging

## Testing
- `php -l admin/products-services/index.php`
- `php -l admin/products-services/edit.php`
- `php -l admin/products-services/functions/save.php`
- `php -l admin/products-services/functions/delete.php`
- `php -l admin/api/person-skills.php`


------
https://chatgpt.com/codex/tasks/task_e_68abc02b25688333828e9abf9b3ee32c