### PR TITLE
Ensure meeting attachments update after upload

### DIFF
--- a/admin/meetings/functions/get_attachments.php
+++ b/admin/meetings/functions/get_attachments.php
@@ -5,13 +5,14 @@ require_permission('meeting', 'read');
 
 header('Content-Type: application/json');
 
-if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+if (in_array($_SERVER['REQUEST_METHOD'], ['GET', 'POST'], true)) {
+    $req = $_SERVER['REQUEST_METHOD'] === 'POST' ? $_POST : $_GET;
+    if (!verify_csrf_token($req['csrf_token'] ?? '')) {
         echo json_encode(['success' => false, 'message' => 'Invalid CSRF token']);
         exit;
     }
 
-    $meeting_id = (int)($_POST['meeting_id'] ?? 0);
+    $meeting_id = (int)($req['meeting_id'] ?? 0);
 
     try {
         $files = [];
@@ -26,7 +27,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 ];
             }
         }
-        echo json_encode(['success' => true, 'data' => $files]);
+        echo json_encode(['success' => true, 'files' => $files]);
     } catch (Exception $e) {
         echo json_encode(['success' => false, 'message' => $e->getMessage()]);
     }

--- a/admin/meetings/functions/upload_file.php
+++ b/admin/meetings/functions/upload_file.php
@@ -77,7 +77,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             ];
         }
 
-        echo json_encode(['success' => true, 'data' => $files]);
+        echo json_encode(['success' => true, 'files' => $files]);
     } catch (Exception $e) {
         http_response_code(400);
         echo json_encode(['success' => false, 'message' => $e->getMessage()]);

--- a/admin/meetings/include/details_view.php
+++ b/admin/meetings/include/details_view.php
@@ -469,6 +469,7 @@ document.addEventListener('DOMContentLoaded', function(){
     });
 
   var attendeesList = document.getElementById('attendeesList');
+  var attachmentsList = document.getElementById('attachmentsList');
 
   function renderAttendees(attendees){
     attendeesData = attendees;
@@ -488,6 +489,20 @@ document.addEventListener('DOMContentLoaded', function(){
       });
     } else {
       attendeesList.innerHTML = '<li class="list-group-item">No attendees.</li>';
+    }
+  }
+
+  function renderAttachments(files){
+    attachmentsList.innerHTML = '';
+    if(files && files.length){
+      files.forEach(function(f){
+        var li = document.createElement('li');
+        li.className = 'list-group-item';
+        li.innerHTML = '<a href="' + esc(f.url) + '" target="_blank">' + esc(f.name) + '</a>';
+        attachmentsList.appendChild(li);
+      });
+    } else {
+      attachmentsList.innerHTML = '<li class="list-group-item">No attachments.</li>';
     }
   }
 
@@ -595,16 +610,10 @@ document.addEventListener('DOMContentLoaded', function(){
   fetch('functions/get_attachments.php?meeting_id=' + meetingId + '&csrf_token=' + csrfToken)
     .then(r=>r.json())
     .then(function(data){
-      var list = document.getElementById('attachmentsList');
-      if(data.success && data.files.length){
-        data.files.forEach(function(f){
-          var li = document.createElement('li');
-          li.className = 'list-group-item';
-          li.innerHTML = '<a href="' + esc(f.url) + '" target="_blank">' + esc(f.name) + '</a>';
-          list.appendChild(li);
-        });
+      if(data.success){
+        renderAttachments(data.files);
       } else {
-        list.innerHTML = '<li class="list-group-item">No attachments.</li>';
+        renderAttachments([]);
       }
     })
     .catch(function(){ alert('Failed to load attachments'); });
@@ -618,16 +627,7 @@ document.addEventListener('DOMContentLoaded', function(){
         .then(r=>r.json())
         .then(function(res){
           if(res.success && res.files){
-            var list = document.getElementById('attachmentsList');
-            if(list.children.length === 1 && list.firstElementChild.textContent === 'No attachments.'){
-              list.innerHTML = '';
-            }
-            res.files.forEach(function(f){
-              var li = document.createElement('li');
-              li.className = 'list-group-item';
-              li.innerHTML = '<a href="' + esc(f.url) + '" target="_blank">' + esc(f.name) + '</a>';
-              list.appendChild(li);
-            });
+            renderAttachments(res.files);
             uploadForm.reset();
           } else {
             alert(res.message || 'Upload failed');


### PR DESCRIPTION
## Summary
- Return uploaded file list from meeting upload endpoint
- Allow fetching meeting attachments via GET or POST and return file list
- Refresh attachment list after uploading in meeting details

## Testing
- `php -l admin/meetings/functions/upload_file.php`
- `php -l admin/meetings/functions/get_attachments.php`
- `php -l admin/meetings/include/details_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68abc02fbe8c8333bb3abdd881f4f549