### PR TITLE
Refactor calendar events to use start/end dates and visibility lookup

### DIFF
--- a/module/calendar/functions/create.php
+++ b/module/calendar/functions/create.php
@@ -6,28 +6,28 @@ header('Content-Type: application/json');
 
 $title = trim($_POST['title'] ?? '');
 
-$start_time = $_POST['start_time'] ?? null;
-$end_time = $_POST['end_time'] ?? null;
-$link_module = $_POST['link_module'] ?? null;
-$link_record_id = $_POST['link_record_id'] ?? null;
+$start_date = $_POST['start_date'] ?? $_POST['startDate'] ?? null;
+$end_date = $_POST['end_date'] ?? $_POST['endDate'] ?? null;
+$related_module = $_POST['related_module'] ?? $_POST['link_module'] ?? null;
+$related_id = $_POST['related_id'] ?? $_POST['link_record_id'] ?? null;
 $calendar_id = (int)($_POST['calendar_id'] ?? 0);
 $event_type_id = $_POST['event_type_id'] ?? null;
-$is_private = !empty($_POST['is_private']) ? 1 : 0;
+$visibility_id = (int)($_POST['visibility_id'] ?? 0);
 $attendees = $_POST['attendees'] ?? [];
 
-if ($title && $start_time && $calendar_id) {
-  $stmt = $pdo->prepare('INSERT INTO module_calendar_events (user_id, calendar_id, title, start_time, end_time, event_type_id, link_module, link_record_id, is_private) VALUES (:uid, :calendar_id, :title, :start_time, :end_time, :event_type_id, :link_module, :link_record_id, :is_private)');
+if ($title && $start_date && $calendar_id) {
+  $stmt = $pdo->prepare('INSERT INTO module_calendar_events (user_id, calendar_id, title, start_date, end_date, event_type_id, related_module, related_id, visibility_id) VALUES (:uid, :calendar_id, :title, :start_date, :end_date, :event_type_id, :related_module, :related_id, :visibility_id)');
 
   $stmt->execute([
     ':uid' => $this_user_id,
     ':calendar_id' => $calendar_id,
     ':title' => $title,
-    ':start_time' => $start_time,
-    ':end_time' => $end_time,
+    ':start_date' => $start_date,
+    ':end_date' => $end_date,
     ':event_type_id' => $event_type_id,
-    ':link_module' => $link_module,
-    ':link_record_id' => $link_record_id,
-    ':is_private' => $is_private
+    ':related_module' => $related_module,
+    ':related_id' => $related_id,
+    ':visibility_id' => $visibility_id
 
   ]);
   $eventId = $pdo->lastInsertId();
@@ -39,7 +39,7 @@ if ($title && $start_time && $calendar_id) {
     }
   }
 
-  echo json_encode(['success' => true, 'id' => $eventId]);
+  echo json_encode(['success' => true, 'id' => $eventId, 'visibility_id' => $visibility_id]);
   exit;
 }
 

--- a/module/calendar/functions/update.php
+++ b/module/calendar/functions/update.php
@@ -7,17 +7,17 @@ header('Content-Type: application/json');
 $id = (int)($_POST['id'] ?? 0);
 $title = trim($_POST['title'] ?? '');
 
-$start_time = $_POST['start_time'] ?? null;
-$end_time = $_POST['end_time'] ?? null;
-$link_module = $_POST['link_module'] ?? null;
-$link_record_id = $_POST['link_record_id'] ?? null;
+$start_date = $_POST['start_date'] ?? $_POST['startDate'] ?? null;
+$end_date = $_POST['end_date'] ?? $_POST['endDate'] ?? null;
+$related_module = $_POST['related_module'] ?? $_POST['link_module'] ?? null;
+$related_id = $_POST['related_id'] ?? $_POST['link_record_id'] ?? null;
 $calendar_id = (int)($_POST['calendar_id'] ?? 0);
 $event_type_id = $_POST['event_type_id'] ?? null;
-$is_private = !empty($_POST['is_private']) ? 1 : 0;
+$visibility_id = (int)($_POST['visibility_id'] ?? 0);
 $attendees = $_POST['attendees'] ?? [];
 
-if ($id && $title && $start_time && $calendar_id) {
-  $chk = $pdo->prepare('SELECT user_id, is_private FROM module_calendar_events WHERE id = ?');
+if ($id && $title && $start_date && $calendar_id) {
+  $chk = $pdo->prepare('SELECT user_id, visibility_id FROM module_calendar_events WHERE id = ?');
   $chk->execute([$id]);
   $existing = $chk->fetch(PDO::FETCH_ASSOC);
   if (!$existing) {
@@ -32,8 +32,8 @@ if ($id && $title && $start_time && $calendar_id) {
     exit;
   }
 
-  $stmt = $pdo->prepare('UPDATE module_calendar_events SET user_updated=?, calendar_id=?, title=?, start_time=?, end_time=?, event_type_id=?, link_module=?, link_record_id=?, is_private=? WHERE id=?');
-  $stmt->execute([$this_user_id, $calendar_id, $title, $start_time, $end_time, $event_type_id, $link_module, $link_record_id, $is_private, $id]);
+  $stmt = $pdo->prepare('UPDATE module_calendar_events SET user_updated=?, calendar_id=?, title=?, start_date=?, end_date=?, event_type_id=?, related_module=?, related_id=?, visibility_id=? WHERE id=?');
+  $stmt->execute([$this_user_id, $calendar_id, $title, $start_date, $end_date, $event_type_id, $related_module, $related_id, $visibility_id, $id]);
 
   $pdo->prepare('DELETE FROM module_calendar_event_attendees WHERE event_id=?')->execute([$id]);
   if (is_array($attendees)) {
@@ -43,7 +43,7 @@ if ($id && $title && $start_time && $calendar_id) {
     }
   }
 
-  echo json_encode(['success' => true]);
+  echo json_encode(['success' => true, 'visibility_id' => $visibility_id]);
   exit;
 }
 


### PR DESCRIPTION
## Summary
- rename event time fields to start/end dates
- replace is_private flag with visibility_id
- persist visibility_id in responses for frontend use

## Testing
- `php -l module/calendar/functions/create.php`
- `php -l module/calendar/functions/update.php`


------
https://chatgpt.com/codex/tasks/task_e_68abeb5d9b9083338362c48adc292855