### PR TITLE
Use date and visibility fields in calendar edit form

### DIFF
--- a/module/calendar/functions/list.php
+++ b/module/calendar/functions/list.php
@@ -39,7 +39,7 @@ while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
     'related_module' => $row['related_module'],
     'related_id' => $row['related_id'],
     'event_type_id' => $row['event_type_id'],
-    'is_private' => (int)$row['is_private']
+    'visibility_id' => (int)$row['visibility_id']
   ];
 }
 

--- a/module/calendar/include/calendar_view.php
+++ b/module/calendar/include/calendar_view.php
@@ -143,9 +143,9 @@ document.addEventListener('DOMContentLoaded', function() {
       const form = document.getElementById('editEventForm');
       form.id.value = info.event.id;
       form.title.value = info.event.title;
-      form.start.value = dayjs(info.event.start).format('YYYY-MM-DD HH:mm');
-      form.end.value = info.event.end ? dayjs(info.event.end).format('YYYY-MM-DD HH:mm') : '';
-      form.is_private.checked = !!Number(info.event.extendedProps.is_private);
+      form.start_date.value = dayjs(info.event.start).format('YYYY-MM-DD HH:mm');
+      form.end_date.value = info.event.end ? dayjs(info.event.end).format('YYYY-MM-DD HH:mm') : '';
+      form.visibility_id.value = info.event.extendedProps.visibility_id;
       bootstrap.Modal.getOrCreateInstance(document.getElementById('editEventModal')).show();
     },
     dateClick: function(info) {


### PR DESCRIPTION
## Summary
- Populate edit event form using `start_date`, `end_date`, and `visibility_id`
- Return `visibility_id` in calendar events API

## Testing
- `php -l module/calendar/include/calendar_view.php`
- `php -l module/calendar/functions/list.php`
- `php module/calendar/functions/list.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68abefed0ef08333a4b697b81fd0fe77