### PR TITLE
Use is_private column for calendar event listings

### DIFF
--- a/module/calendar/functions/list.php
+++ b/module/calendar/functions/list.php
@@ -6,25 +6,21 @@ header('Content-Type: application/json');
 
 $calendar_id = isset($_GET['calendar_id']) ? (int)$_GET['calendar_id'] : 0;
 
-$privStmt = $pdo->prepare('SELECT id FROM lookup_list_items WHERE list_id=38 AND code="PRIVATE"');
-$privStmt->execute();
-$privateId = $privStmt->fetchColumn();
-
 $events = [];
 if (user_has_role('Admin')) {
   if ($calendar_id) {
-    $stmt = $pdo->prepare('SELECT id, calendar_id, title, start_date, end_date, related_module, related_id, user_id, event_type_id, visibility_id FROM module_calendar_events WHERE calendar_id = :calid');
+    $stmt = $pdo->prepare('SELECT id, calendar_id, title, start_time, end_time, link_module, link_record_id, user_id, event_type_id, is_private FROM module_calendar_events WHERE calendar_id = :calid');
     $stmt->execute([':calid' => $calendar_id]);
   } else {
-    $stmt = $pdo->query('SELECT id, calendar_id, title, start_date, end_date, related_module, related_id, user_id, event_type_id, visibility_id FROM module_calendar_events');
+    $stmt = $pdo->query('SELECT id, calendar_id, title, start_time, end_time, link_module, link_record_id, user_id, event_type_id, is_private FROM module_calendar_events');
   }
 } else {
   if ($calendar_id) {
-    $stmt = $pdo->prepare('SELECT id, calendar_id, title, start_date, end_date, related_module, related_id, user_id, event_type_id, visibility_id FROM module_calendar_events WHERE (visibility_id != :private OR user_id = :uid) AND calendar_id = :calid');
-    $stmt->execute([':private' => $privateId, ':uid' => $this_user_id, ':calid' => $calendar_id]);
+    $stmt = $pdo->prepare('SELECT id, calendar_id, title, start_time, end_time, link_module, link_record_id, user_id, event_type_id, is_private FROM module_calendar_events WHERE (is_private = 0 OR user_id = :uid) AND calendar_id = :calid');
+    $stmt->execute([':uid' => $this_user_id, ':calid' => $calendar_id]);
   } else {
-    $stmt = $pdo->prepare('SELECT id, calendar_id, title, start_date, end_date, related_module, related_id, user_id, event_type_id, visibility_id FROM module_calendar_events WHERE visibility_id != :private OR user_id = :uid');
-    $stmt->execute([':private' => $privateId, ':uid' => $this_user_id]);
+    $stmt = $pdo->prepare('SELECT id, calendar_id, title, start_time, end_time, link_module, link_record_id, user_id, event_type_id, is_private FROM module_calendar_events WHERE is_private = 0 OR user_id = :uid');
+    $stmt->execute([':uid' => $this_user_id]);
   }
 
 }
@@ -34,10 +30,10 @@ while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
     'id' => (int)$row['id'],
     'calendar_id' => (int)$row['calendar_id'],
     'title' => $row['title'],
-    'start' => $row['start_date'],
-    'end' => $row['end_date'],
-    'related_module' => $row['related_module'],
-    'related_id' => $row['related_id'],
+    'start' => $row['start_time'],
+    'end' => $row['end_time'],
+    'related_module' => $row['link_module'],
+    'related_id' => $row['link_record_id'],
     'event_type_id' => $row['event_type_id'],
     'is_private' => (int)$row['is_private']
   ];


### PR DESCRIPTION
## Summary
- Query calendar events using start_time/end_time/link_module/link_record_id/is_private
- Return JSON fields start, end, related_module, related_id, and is_private
- Filter visibility using is_private instead of visibility_id

## Testing
- `php -l module/calendar/functions/list.php`
- `php -r 'chdir("module/calendar/functions"); session_start(); $_SESSION["user_logged_in"]=true; $_SESSION["type"]="ADMIN"; $_SESSION["this_user_email"]="Dave@AtlisTechnologies.com"; $_SERVER["HTTP_USER_AGENT"]="CLI"; $_SERVER["REQUEST_URI"]="/module/calendar/functions/list.php"; $_SERVER["HTTP_HOST"]="localhost"; parse_str("calendar_id=0", $_GET); include "list.php";'`

------
https://chatgpt.com/codex/tasks/task_e_68abefeb16048333a595e62feb42f81d