### PR TITLE
Align calendar event scripts with new schema

### DIFF
--- a/module/calendar/functions/create.php
+++ b/module/calendar/functions/create.php
@@ -6,28 +6,28 @@ header('Content-Type: application/json');
 
 $title = trim($_POST['title'] ?? '');
 
-$start_date = $_POST['start_date'] ?? $_POST['startDate'] ?? null;
-$end_date = $_POST['end_date'] ?? $_POST['endDate'] ?? null;
-$related_module = $_POST['related_module'] ?? $_POST['link_module'] ?? null;
-$related_id = $_POST['related_id'] ?? $_POST['link_record_id'] ?? null;
+$start_time = $_POST['start_time'] ?? $_POST['startTime'] ?? $_POST['start_date'] ?? $_POST['startDate'] ?? null;
+$end_time = $_POST['end_time'] ?? $_POST['endTime'] ?? $_POST['end_date'] ?? $_POST['endDate'] ?? null;
+$link_module = $_POST['link_module'] ?? $_POST['related_module'] ?? null;
+$link_record_id = $_POST['link_record_id'] ?? $_POST['related_id'] ?? null;
 $calendar_id = (int)($_POST['calendar_id'] ?? 0);
 $event_type_id = $_POST['event_type_id'] ?? null;
-$visibility_id = (int)($_POST['visibility_id'] ?? 0);
+$is_private = (int)($_POST['is_private'] ?? $_POST['visibility_id'] ?? 0);
 $attendees = $_POST['attendees'] ?? [];
 
-if ($title && $start_date && $calendar_id) {
-  $stmt = $pdo->prepare('INSERT INTO module_calendar_events (user_id, calendar_id, title, start_date, end_date, event_type_id, related_module, related_id, visibility_id) VALUES (:uid, :calendar_id, :title, :start_date, :end_date, :event_type_id, :related_module, :related_id, :visibility_id)');
+if ($title && $start_time && $calendar_id) {
+  $stmt = $pdo->prepare('INSERT INTO module_calendar_events (user_id, calendar_id, title, start_time, end_time, event_type_id, link_module, link_record_id, is_private) VALUES (:uid, :calendar_id, :title, :start_time, :end_time, :event_type_id, :link_module, :link_record_id, :is_private)');
 
   $stmt->execute([
     ':uid' => $this_user_id,
     ':calendar_id' => $calendar_id,
     ':title' => $title,
-    ':start_date' => $start_date,
-    ':end_date' => $end_date,
+    ':start_time' => $start_time,
+    ':end_time' => $end_time,
     ':event_type_id' => $event_type_id,
-    ':related_module' => $related_module,
-    ':related_id' => $related_id,
-    ':visibility_id' => $visibility_id
+    ':link_module' => $link_module,
+    ':link_record_id' => $link_record_id,
+    ':is_private' => $is_private
 
   ]);
   $eventId = $pdo->lastInsertId();
@@ -39,7 +39,7 @@ if ($title && $start_date && $calendar_id) {
     }
   }
 
-  echo json_encode(['success' => true, 'id' => $eventId, 'visibility_id' => $visibility_id]);
+  echo json_encode(['success' => true, 'id' => $eventId, 'is_private' => $is_private]);
   exit;
 }
 

--- a/module/calendar/functions/update.php
+++ b/module/calendar/functions/update.php
@@ -7,33 +7,30 @@ header('Content-Type: application/json');
 $id = (int)($_POST['id'] ?? 0);
 $title = trim($_POST['title'] ?? '');
 
-$start_date = $_POST['start_date'] ?? $_POST['startDate'] ?? null;
-$end_date = $_POST['end_date'] ?? $_POST['endDate'] ?? null;
-$related_module = $_POST['related_module'] ?? $_POST['link_module'] ?? null;
-$related_id = $_POST['related_id'] ?? $_POST['link_record_id'] ?? null;
+$start_time = $_POST['start_time'] ?? $_POST['startTime'] ?? $_POST['start_date'] ?? $_POST['startDate'] ?? null;
+$end_time = $_POST['end_time'] ?? $_POST['endTime'] ?? $_POST['end_date'] ?? $_POST['endDate'] ?? null;
+$link_module = $_POST['link_module'] ?? $_POST['related_module'] ?? null;
+$link_record_id = $_POST['link_record_id'] ?? $_POST['related_id'] ?? null;
 $calendar_id = (int)($_POST['calendar_id'] ?? 0);
 $event_type_id = $_POST['event_type_id'] ?? null;
-$visibility_id = (int)($_POST['visibility_id'] ?? 0);
+$is_private = (int)($_POST['is_private'] ?? $_POST['visibility_id'] ?? 0);
 $attendees = $_POST['attendees'] ?? [];
 
-if ($id && $title && $start_date && $calendar_id) {
-  $chk = $pdo->prepare('SELECT user_id, visibility_id FROM module_calendar_events WHERE id = ?');
+if ($id && $title && $start_time && $calendar_id) {
+  $chk = $pdo->prepare('SELECT user_id, is_private FROM module_calendar_events WHERE id = ?');
   $chk->execute([$id]);
   $existing = $chk->fetch(PDO::FETCH_ASSOC);
   if (!$existing) {
     http_response_code(404);
     exit;
   }
-  $privStmt = $pdo->prepare('SELECT id FROM lookup_list_items WHERE list_id=38 AND code="PRIVATE"');
-  $privStmt->execute();
-  $privateId = $privStmt->fetchColumn();
-  if ($existing['visibility_id'] == $privateId && $existing['user_id'] != $this_user_id && !user_has_role('Admin')) {
+  if ($existing['is_private'] && $existing['user_id'] != $this_user_id && !user_has_role('Admin')) {
     http_response_code(403);
     exit;
   }
 
-  $stmt = $pdo->prepare('UPDATE module_calendar_events SET user_updated=?, calendar_id=?, title=?, start_date=?, end_date=?, event_type_id=?, related_module=?, related_id=?, visibility_id=? WHERE id=?');
-  $stmt->execute([$this_user_id, $calendar_id, $title, $start_date, $end_date, $event_type_id, $related_module, $related_id, $visibility_id, $id]);
+  $stmt = $pdo->prepare('UPDATE module_calendar_events SET user_updated=?, calendar_id=?, title=?, start_time=?, end_time=?, event_type_id=?, link_module=?, link_record_id=?, is_private=? WHERE id=?');
+  $stmt->execute([$this_user_id, $calendar_id, $title, $start_time, $end_time, $event_type_id, $link_module, $link_record_id, $is_private, $id]);
 
   $pdo->prepare('DELETE FROM module_calendar_event_attendees WHERE event_id=?')->execute([$id]);
   if (is_array($attendees)) {
@@ -43,7 +40,7 @@ if ($id && $title && $start_date && $calendar_id) {
     }
   }
 
-  echo json_encode(['success' => true, 'visibility_id' => $visibility_id]);
+  echo json_encode(['success' => true, 'is_private' => $is_private]);
   exit;
 }
 


### PR DESCRIPTION
## Summary
- Rename event field variables (start/end times, link info, privacy flag)
- Adjust INSERT and UPDATE queries to use new column names
- Return `is_private` in responses

## Testing
- `php -r '$_POST=["title"=>"Test","start_time"=>"2024-01-01 09:00:00","calendar_id"=>1]; chdir("module/calendar/functions"); include "create.php";'` (fails: SQLSTATE[HY000] [2002] No such file or directory)
- `php -r '$_POST=["id"=>1,"title"=>"Test","start_time"=>"2024-01-01 09:00:00","calendar_id"=>1]; chdir("module/calendar/functions"); include "update.php";'` (fails: SQLSTATE[HY000] [2002] No such file or directory)

------
https://chatgpt.com/codex/tasks/task_e_68abefe9e5f08333826f6682123b0b68