### PR TITLE
Clarify calendar event form field names

### DIFF
--- a/module/calendar/include/calendar_view.php
+++ b/module/calendar/include/calendar_view.php
@@ -141,10 +141,12 @@ document.addEventListener('DOMContentLoaded', function() {
     events: '<?php echo getURLDir(); ?>module/calendar/functions/list.php?calendar_id=<?php echo $calendar_id; ?>',
     eventClick: function(info) {
       const form = document.getElementById('editEventForm');
+      // Populate edit form with selected event details
       form.id.value = info.event.id;
       form.title.value = info.event.title;
       form.start_date.value = dayjs(info.event.start).format('YYYY-MM-DD HH:mm');
       form.end_date.value = info.event.end ? dayjs(info.event.end).format('YYYY-MM-DD HH:mm') : '';
+      // Visibility uses visibility_id rather than legacy is_private flag
       form.visibility_id.value = info.event.extendedProps.visibility_id;
       bootstrap.Modal.getOrCreateInstance(document.getElementById('editEventModal')).show();
     },


### PR DESCRIPTION
## Summary
- Document usage of `start_date`/`end_date` and `visibility_id` in calendar event editor
- Ensure comments reflect replacement of legacy `is_private` field

## Testing
- `php -l module/calendar/include/calendar_view.php`
- `php -l module/calendar/functions/create.php`
- `php -l module/calendar/functions/update.php`
- `php -l module/calendar/functions/list.php`


------
https://chatgpt.com/codex/tasks/task_e_68abfec113908333b0992ab001df0c65