### PR TITLE
Handle fetch errors in calendar view

### DIFF
--- a/module/calendar/include/calendar_view.php
+++ b/module/calendar/include/calendar_view.php
@@ -138,7 +138,19 @@ document.addEventListener('DOMContentLoaded', function() {
 
   const calendar = new FullCalendar.Calendar(calendarEl, {
     initialView: 'dayGridMonth',
-    events: '<?php echo getURLDir(); ?>module/calendar/functions/list.php?calendar_id=<?php echo $calendar_id; ?>',
+    events: function(fetchInfo, successCallback, failureCallback) {
+      fetch('<?php echo getURLDir(); ?>module/calendar/functions/list.php?calendar_id=<?php echo $calendar_id; ?>')
+        .then(r => {
+          if (!r.ok) throw new Error('HTTP ' + r.status);
+          return r.json();
+        })
+        .then(data => successCallback(data))
+        .catch(err => {
+          console.error('Failed to load events', err);
+          alert('Failed to load events: ' + err.message);
+          if (failureCallback) failureCallback(err);
+        });
+    },
     eventClick: function(info) {
       const form = document.getElementById('editEventForm');
       form.id.value = info.event.id;


### PR DESCRIPTION
## Summary
- add error handling for loading events in calendar

## Testing
- `php -l module/calendar/include/calendar_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68abfec1b92083339698b75aeb3c1f25