### PR TITLE
Add calendar sync permission and enforce in calendar linking scripts

### DIFF
--- a/_SQL/calendar_sync_permission.sql
+++ b/_SQL/calendar_sync_permission.sql
@@ -1,0 +1,16 @@
+-- Permission to sync calendars
+INSERT INTO admin_permissions (user_id, user_updated, module, action)
+VALUES (1,1,'calendar','sync');
+
+-- Attach permission to Calendar group
+INSERT INTO admin_permission_group_permissions (user_id, user_updated, permission_group_id, permission_id)
+SELECT 1,1,pg.id,p.id
+FROM admin_permission_groups pg
+JOIN admin_permissions p ON pg.name='Calendar' AND p.module='calendar' AND p.action='sync';
+
+-- Map Calendar group to appropriate roles
+INSERT INTO admin_role_permission_groups (user_id, user_updated, role_id, permission_group_id)
+SELECT 1,1,r.id,pg.id
+FROM admin_roles r
+JOIN admin_permission_groups pg ON pg.name='Calendar'
+WHERE r.name IN ('Admin','Principle Project Manager','Project Manager','Developer');

--- a/module/calendar/functions/create_calendar.php
+++ b/module/calendar/functions/create_calendar.php
@@ -1,6 +1,6 @@
 <?php
 require '../../../includes/php_header.php';
-require_permission('calendar','create');
+require_permission('calendar','sync');
 
 header('Content-Type: application/json');
 

--- a/module/calendar/functions/delete_calendar.php
+++ b/module/calendar/functions/delete_calendar.php
@@ -1,6 +1,6 @@
 <?php
 require '../../../includes/php_header.php';
-require_permission('calendar','delete');
+require_permission('calendar','sync');
 
 header('Content-Type: application/json');
 

--- a/module/calendar/functions/update_calendar.php
+++ b/module/calendar/functions/update_calendar.php
@@ -1,6 +1,6 @@
 <?php
 require '../../../includes/php_header.php';
-require_permission('calendar','update');
+require_permission('calendar','sync');
 
 header('Content-Type: application/json');
 


### PR DESCRIPTION
## Summary
- Add SQL migration to create `calendar:sync` permission and map it to the Calendar group and relevant roles
- Require the new `calendar:sync` permission in calendar account link scripts

## Testing
- `php -l module/calendar/functions/create_calendar.php`
- `php -l module/calendar/functions/update_calendar.php`
- `php -l module/calendar/functions/delete_calendar.php`


------
https://chatgpt.com/codex/tasks/task_e_68abfed9a41c83339a0a6c59a8ea0587