### PR TITLE
Add navigation link creation modal and seed finances permissions

### DIFF
--- a/_SQL/finances_nav_permissions.sql
+++ b/_SQL/finances_nav_permissions.sql
@@ -1,0 +1,16 @@
+-- Add Finances navigation link
+INSERT INTO admin_navigation_links (title, path, icon, sort_order, user_id, user_updated)
+VALUES ('Finances', 'finances/index.php', 'dollar-sign', 99, 1, 1);
+
+-- Seed read permissions for finances and statements of work
+INSERT INTO admin_permissions (user_id, user_updated, module, action) VALUES
+(1,1,'finances','read'),
+(1,1,'sow','read');
+
+-- Link permissions to the Finances permission group if it exists
+INSERT INTO admin_permission_group_permissions (user_id, user_updated, permission_group_id, permission_id)
+SELECT 1,1,pg.id,p.id FROM admin_permission_groups pg JOIN admin_permissions p
+  ON pg.name='Finances' AND p.module='finances' AND p.action='read';
+INSERT INTO admin_permission_group_permissions (user_id, user_updated, permission_group_id, permission_id)
+SELECT 1,1,pg.id,p.id FROM admin_permission_groups pg JOIN admin_permissions p
+  ON pg.name='Finances' AND p.module='sow' AND p.action='read';

--- a/admin/navigation.php
+++ b/admin/navigation.php
@@ -9,18 +9,37 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
         die('Invalid CSRF token');
     }
-    require_permission('navigation_links','update');
-    $order = isset($_POST['order']) ? explode(',', $_POST['order']) : [];
-    $pdo->beginTransaction();
-    $stmt = $pdo->prepare('UPDATE admin_navigation_links SET sort_order = :sort WHERE id = :id');
-    foreach ($order as $index => $id) {
-        $id = (int)$id;
-        if ($id > 0) {
-            $stmt->execute([':sort' => $index, ':id' => $id]);
+    if (isset($_POST['create_nav_link'])) {
+        require_permission('navigation_links','create');
+        $title = trim($_POST['name'] ?? '');
+        $path  = trim($_POST['path'] ?? '');
+        $icon  = trim($_POST['icon'] ?? '');
+        if ($title !== '' && $path !== '') {
+            $sort_order = $pdo->query('SELECT COALESCE(MAX(sort_order),0)+1 FROM admin_navigation_links')->fetchColumn();
+            $stmt = $pdo->prepare('INSERT INTO admin_navigation_links (title, path, icon, sort_order, user_id, user_updated) VALUES (:title,:path,:icon,:sort,:uid,:uid)');
+            $stmt->execute([
+                ':title' => $title,
+                ':path' => $path,
+                ':icon' => $icon,
+                ':sort' => $sort_order,
+                ':uid'  => $this_user_id
+            ]);
+            $message = 'Navigation link created.';
         }
+    } else {
+        require_permission('navigation_links','update');
+        $order = isset($_POST['order']) ? explode(',', $_POST['order']) : [];
+        $pdo->beginTransaction();
+        $stmt = $pdo->prepare('UPDATE admin_navigation_links SET sort_order = :sort WHERE id = :id');
+        foreach ($order as $index => $id) {
+            $id = (int)$id;
+            if ($id > 0) {
+                $stmt->execute([':sort' => $index, ':id' => $id]);
+            }
+        }
+        $pdo->commit();
+        $message = 'Navigation order updated.';
     }
-    $pdo->commit();
-    $message = 'Navigation order updated.';
 }
 
 $stmt = $pdo->query('SELECT id, title, path FROM admin_navigation_links ORDER BY sort_order');
@@ -31,6 +50,7 @@ $links = $stmt->fetchAll(PDO::FETCH_ASSOC);
 <?php if ($message): ?>
   <div class="alert alert-success"><?= htmlspecialchars($message); ?></div>
 <?php endif; ?>
+<button type="button" class="btn btn-success mb-3" data-bs-toggle="modal" data-bs-target="#createNavModal">Create Nav Link</button>
 <form method="post" id="navForm">
   <input type="hidden" name="csrf_token" value="<?= $token; ?>">
   <input type="hidden" name="order" id="navOrder">
@@ -44,6 +64,35 @@ $links = $stmt->fetchAll(PDO::FETCH_ASSOC);
   </ul>
   <button type="submit" class="btn btn-primary mt-3">Save Order</button>
 </form>
+<div class="modal fade" id="createNavModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <form method="post" class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Create Nav Link</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+        <div class="mb-3">
+          <label for="navName" class="form-label">Name</label>
+          <input type="text" id="navName" name="name" class="form-control" required>
+        </div>
+        <div class="mb-3">
+          <label for="navPath" class="form-label">Path</label>
+          <input type="text" id="navPath" name="path" class="form-control" required>
+        </div>
+        <div class="mb-3">
+          <label for="navIcon" class="form-label">Feather Icon</label>
+          <input type="text" id="navIcon" name="icon" class="form-control" required>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="submit" class="btn btn-primary" name="create_nav_link">Create</button>
+      </div>
+    </form>
+  </div>
+</div>
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.min.js"></script>
 <script>


### PR DESCRIPTION
## Summary
- Allow admins to add navigation links through a modal form
- Seed Finances navigation link and read permissions for finances and SOW

## Testing
- `php -l admin/navigation.php`
- `php -l admin/finances/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac04790d10833383f6b19824a9bf22