### PR TITLE
Refactor calendar event fetchers for standalone execution

### DIFF
--- a/module/calendar/functions/google_events.php
+++ b/module/calendar/functions/google_events.php
@@ -1,6 +1,4 @@
 <?php
-require '../../../includes/php_header.php';
-require_permission('calendar','read');
 
 function fetch_google_events(PDO $pdo, int $userId): array {
     $cacheKey = 'google_calendar_events';
@@ -47,6 +45,8 @@ function fetch_google_events(PDO $pdo, int $userId): array {
 }
 
 if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
+    require '../../../includes/php_header.php';
+    require_permission('calendar','read');
     header('Content-Type: application/json');
     echo json_encode(fetch_google_events($pdo, $this_user_id));
 }

--- a/module/calendar/functions/microsoft_events.php
+++ b/module/calendar/functions/microsoft_events.php
@@ -1,6 +1,4 @@
 <?php
-require '../../../includes/php_header.php';
-require_permission('calendar','read');
 
 function fetch_microsoft_events(PDO $pdo, int $userId): array {
     $cacheKey = 'microsoft_calendar_events';
@@ -47,6 +45,8 @@ function fetch_microsoft_events(PDO $pdo, int $userId): array {
 }
 
 if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
+    require '../../../includes/php_header.php';
+    require_permission('calendar','read');
     header('Content-Type: application/json');
     echo json_encode(fetch_microsoft_events($pdo, $this_user_id));
 }


### PR DESCRIPTION
## Summary
- remove php_header includes from Google and Microsoft calendar event fetchers
- guard output so scripts can be included or executed directly

## Testing
- `php -l module/calendar/functions/google_events.php`
- `php -l module/calendar/functions/microsoft_events.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac05b71aec8333a442f9c4b13d1ce6