### PR TITLE
Refactor calendar delete for is_private flag

### DIFF
--- a/module/calendar/functions/delete.php
+++ b/module/calendar/functions/delete.php
@@ -6,17 +6,14 @@ header('Content-Type: application/json');
 
 $id = (int)($_POST['id'] ?? 0);
 if ($id) {
-  $chk = $pdo->prepare('SELECT user_id, visibility_id FROM module_calendar_events WHERE id = ?');
+  $chk = $pdo->prepare('SELECT user_id, is_private FROM module_calendar_events WHERE id = ?');
   $chk->execute([$id]);
   $existing = $chk->fetch(PDO::FETCH_ASSOC);
   if (!$existing) {
     http_response_code(404);
     exit;
   }
-  $privStmt = $pdo->prepare('SELECT id FROM lookup_list_items WHERE list_id=38 AND code="PRIVATE"');
-  $privStmt->execute();
-  $privateId = $privStmt->fetchColumn();
-  if ($existing['visibility_id'] == $privateId && $existing['user_id'] != $this_user_id && !user_has_role('Admin')) {
+  if ($existing['is_private'] && $existing['user_id'] != $this_user_id && !user_has_role('Admin')) {
     http_response_code(403);
     exit;
   }


### PR DESCRIPTION
## Summary
- remove visibility lookup in calendar delete
- use is_private flag to enforce permissions

## Testing
- `php -l module/calendar/functions/delete.php`
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_68ac05b4d3048333a74de1a6ed31c914