### PR TITLE
Fix syntax error in calendar events list

### DIFF
--- a/module/calendar/functions/list.php
+++ b/module/calendar/functions/list.php
@@ -38,7 +38,7 @@ while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
     'related_module' => $row['link_module'],
     'related_id' => $row['link_record_id'],
     'event_type_id' => $row['event_type_id'],
-    'visibility_id' => (int)$row['is_private']
+    'visibility_id' => (int)$row['is_private'],
     'is_private' => (int)$row['is_private']
   ];
 }


### PR DESCRIPTION
## Summary
- add missing comma in calendar events array builder

## Testing
- `php -l module/calendar/functions/list.php`
- `php list.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ac05b210e88333b90dc3f7effb6e7e