### PR TITLE
Add placeholder SoW forms and feature schema

### DIFF
--- a/_SQL/finances_module.sql
+++ b/_SQL/finances_module.sql
@@ -314,3 +314,180 @@ CREATE TABLE admin_module_finances_sows_logins (
   FOREIGN KEY (sow_id) REFERENCES admin_module_finances_sows(id) ON DELETE CASCADE,
   FOREIGN KEY (relationship_type_id) REFERENCES lookup_list_items(id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- Lookup list for feature SoW statuses
+INSERT INTO lookup_lists (user_id, user_updated, name, description)
+VALUES (1,1,'FEATURE_SOW_STATUS','Statuses for feature-level SoWs');
+
+INSERT INTO lookup_list_items (user_id, user_updated, list_id, label, code, sort_order)
+SELECT 1,1,l.id,'Draft','DRAFT',1 FROM lookup_lists l WHERE l.name='FEATURE_SOW_STATUS';
+INSERT INTO lookup_list_items (user_id, user_updated, list_id, label, code, sort_order)
+SELECT 1,1,l.id,'On Hold','ON_HOLD',2 FROM lookup_lists l WHERE l.name='FEATURE_SOW_STATUS';
+INSERT INTO lookup_list_items (user_id, user_updated, list_id, label, code, sort_order)
+SELECT 1,1,l.id,'In Progress','IN_PROGRESS',3 FROM lookup_lists l WHERE l.name='FEATURE_SOW_STATUS';
+INSERT INTO lookup_list_items (user_id, user_updated, list_id, label, code, sort_order)
+SELECT 1,1,l.id,'Cancelled','CANCELLED',4 FROM lookup_lists l WHERE l.name='FEATURE_SOW_STATUS';
+INSERT INTO lookup_list_items (user_id, user_updated, list_id, label, code, sort_order)
+SELECT 1,1,l.id,'Complete','COMPLETE',5 FROM lookup_lists l WHERE l.name='FEATURE_SOW_STATUS';
+
+-- Base feature tables and versioning
+CREATE TABLE admin_feature_links (
+  id INT(11) AUTO_INCREMENT PRIMARY KEY,
+  user_id INT(11),
+  user_updated INT(11),
+  date_created DATETIME DEFAULT CURRENT_TIMESTAMP,
+  date_updated DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  memo TEXT DEFAULT NULL,
+  name VARCHAR(255) NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL,
+  FOREIGN KEY (user_updated) REFERENCES users(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE admin_feature_links_versions (
+  id INT(11) AUTO_INCREMENT PRIMARY KEY,
+  user_id INT(11),
+  user_updated INT(11),
+  date_created DATETIME DEFAULT CURRENT_TIMESTAMP,
+  date_updated DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  memo TEXT DEFAULT NULL,
+  link_id INT(11) NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  version INT(11) NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL,
+  FOREIGN KEY (user_updated) REFERENCES users(id) ON DELETE SET NULL,
+  FOREIGN KEY (link_id) REFERENCES admin_feature_links(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE admin_feature_notes (
+  id INT(11) AUTO_INCREMENT PRIMARY KEY,
+  user_id INT(11),
+  user_updated INT(11),
+  date_created DATETIME DEFAULT CURRENT_TIMESTAMP,
+  date_updated DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  memo TEXT DEFAULT NULL,
+  name VARCHAR(255) NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL,
+  FOREIGN KEY (user_updated) REFERENCES users(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE admin_feature_notes_versions (
+  id INT(11) AUTO_INCREMENT PRIMARY KEY,
+  user_id INT(11),
+  user_updated INT(11),
+  date_created DATETIME DEFAULT CURRENT_TIMESTAMP,
+  date_updated DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  memo TEXT DEFAULT NULL,
+  note_id INT(11) NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  version INT(11) NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL,
+  FOREIGN KEY (user_updated) REFERENCES users(id) ON DELETE SET NULL,
+  FOREIGN KEY (note_id) REFERENCES admin_feature_notes(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE admin_feature_questions (
+  id INT(11) AUTO_INCREMENT PRIMARY KEY,
+  user_id INT(11),
+  user_updated INT(11),
+  date_created DATETIME DEFAULT CURRENT_TIMESTAMP,
+  date_updated DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  memo TEXT DEFAULT NULL,
+  name VARCHAR(255) NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL,
+  FOREIGN KEY (user_updated) REFERENCES users(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE admin_feature_questions_versions (
+  id INT(11) AUTO_INCREMENT PRIMARY KEY,
+  user_id INT(11),
+  user_updated INT(11),
+  date_created DATETIME DEFAULT CURRENT_TIMESTAMP,
+  date_updated DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  memo TEXT DEFAULT NULL,
+  question_id INT(11) NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  version INT(11) NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL,
+  FOREIGN KEY (user_updated) REFERENCES users(id) ON DELETE SET NULL,
+  FOREIGN KEY (question_id) REFERENCES admin_feature_questions(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE admin_feature_logins (
+  id INT(11) AUTO_INCREMENT PRIMARY KEY,
+  user_id INT(11),
+  user_updated INT(11),
+  date_created DATETIME DEFAULT CURRENT_TIMESTAMP,
+  date_updated DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  memo TEXT DEFAULT NULL,
+  name VARCHAR(255) NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL,
+  FOREIGN KEY (user_updated) REFERENCES users(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE admin_feature_logins_versions (
+  id INT(11) AUTO_INCREMENT PRIMARY KEY,
+  user_id INT(11),
+  user_updated INT(11),
+  date_created DATETIME DEFAULT CURRENT_TIMESTAMP,
+  date_updated DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  memo TEXT DEFAULT NULL,
+  login_id INT(11) NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  version INT(11) NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL,
+  FOREIGN KEY (user_updated) REFERENCES users(id) ON DELETE SET NULL,
+  FOREIGN KEY (login_id) REFERENCES admin_feature_logins(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- Feature SoW tables
+CREATE TABLE admin_feature_sow (
+  id INT(11) AUTO_INCREMENT PRIMARY KEY,
+  user_id INT(11),
+  user_updated INT(11),
+  date_created DATETIME DEFAULT CURRENT_TIMESTAMP,
+  date_updated DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  memo TEXT DEFAULT NULL,
+  name VARCHAR(255) NOT NULL,
+  organization_id INT(11) DEFAULT NULL,
+  agency_id INT(11) DEFAULT NULL,
+  division_id INT(11) DEFAULT NULL,
+  status_id INT(11) DEFAULT NULL,
+  current_version_id INT(11) DEFAULT NULL,
+  client_signed TINYINT(1) DEFAULT 0,
+  client_signed_date DATETIME DEFAULT NULL,
+  atlis_signed TINYINT(1) DEFAULT 0,
+  atlis_signed_date DATETIME DEFAULT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL,
+  FOREIGN KEY (user_updated) REFERENCES users(id) ON DELETE SET NULL,
+  FOREIGN KEY (organization_id) REFERENCES module_organization(id) ON DELETE SET NULL,
+  FOREIGN KEY (agency_id) REFERENCES module_agency(id) ON DELETE SET NULL,
+  FOREIGN KEY (division_id) REFERENCES module_division(id) ON DELETE SET NULL,
+  FOREIGN KEY (status_id) REFERENCES lookup_list_items(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE admin_feature_sow_versions (
+  id INT(11) AUTO_INCREMENT PRIMARY KEY,
+  user_id INT(11),
+  user_updated INT(11),
+  date_created DATETIME DEFAULT CURRENT_TIMESTAMP,
+  date_updated DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  memo TEXT DEFAULT NULL,
+  sow_id INT(11) NOT NULL,
+  version INT(11) NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  organization_id INT(11) DEFAULT NULL,
+  agency_id INT(11) DEFAULT NULL,
+  division_id INT(11) DEFAULT NULL,
+  status_id INT(11) DEFAULT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL,
+  FOREIGN KEY (user_updated) REFERENCES users(id) ON DELETE SET NULL,
+  FOREIGN KEY (sow_id) REFERENCES admin_feature_sow(id) ON DELETE CASCADE,
+  FOREIGN KEY (organization_id) REFERENCES module_organization(id) ON DELETE SET NULL,
+  FOREIGN KEY (agency_id) REFERENCES module_agency(id) ON DELETE SET NULL,
+  FOREIGN KEY (division_id) REFERENCES module_division(id) ON DELETE SET NULL,
+  FOREIGN KEY (status_id) REFERENCES lookup_list_items(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+ALTER TABLE admin_feature_sow
+  ADD CONSTRAINT fk_admin_feature_sow_current_version FOREIGN KEY (current_version_id)
+  REFERENCES admin_feature_sow_versions(id);

--- a/admin/finances/sows/create.php
+++ b/admin/finances/sows/create.php
@@ -1,0 +1,25 @@
+<?php
+require '../../admin_header.php';
+require_permission('sow','create');
+
+$token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
+$_SESSION['csrf_token'] = $token;
+
+$allowedItems = get_lookup_items($pdo,'SOW_FILE_TYPE');
+$accept = implode(',', array_map(fn($i)=>'.'.strtolower($i['code']), $allowedItems));
+?>
+<h2 class="mb-4">Create Statement of Work</h2>
+<form action="functions/create.php" method="post" enctype="multipart/form-data">
+  <input type="hidden" name="csrf_token" value="<?= h($token) ?>">
+  <div class="mb-3">
+    <label class="form-label">Name</label>
+    <input type="text" name="title" class="form-control" placeholder="SoW Name">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Upload File</label>
+    <input type="hidden" name="MAX_FILE_SIZE" value="10485760"><!-- 10MB -->
+    <input type="file" name="file" class="form-control" accept="<?= h($accept) ?>">
+  </div>
+  <button class="btn btn-primary">Save</button>
+</form>
+<?php require '../../admin_footer.php'; ?>

--- a/admin/finances/sows/delete.php
+++ b/admin/finances/sows/delete.php
@@ -1,0 +1,16 @@
+<?php
+require '../../admin_header.php';
+require_permission('sow','delete');
+
+$token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
+$_SESSION['csrf_token'] = $token;
+$id = (int)($_GET['id'] ?? 0);
+?>
+<h2 class="mb-4">Delete Statement of Work</h2>
+<form action="functions/delete.php" method="post" onsubmit="return confirm('Are you sure?');">
+  <input type="hidden" name="csrf_token" value="<?= h($token) ?>">
+  <input type="hidden" name="id" value="<?= h($id) ?>">
+  <p>Confirm deletion of SoW ID <?= h($id) ?>.</p>
+  <button class="btn btn-danger">Delete</button>
+</form>
+<?php require '../../admin_footer.php'; ?>

--- a/admin/finances/sows/functions/upload_file.php
+++ b/admin/finances/sows/functions/upload_file.php
@@ -3,6 +3,11 @@ require '../../../../includes/php_header.php';
 require_permission('sow','read');
 require_permission('sow','update');
 
+// Maximum upload size for SoW files (10MB)
+if (!defined('SOW_MAX_FILE_SIZE')) {
+    define('SOW_MAX_FILE_SIZE', 10 * 1024 * 1024);
+}
+
 $sid = (int)($_POST['sow_id'] ?? 0);
 $file_type_id = (int)($_POST['file_type_id'] ?? 0);
 $description = trim($_POST['description'] ?? '');
@@ -13,9 +18,9 @@ if($token !== ($_SESSION['csrf_token'] ?? '') || !$sid || !$file_type_id || !iss
   exit;
 }
 
-$max = 10 * 1024 * 1024; //10MB
-$allowedItems = get_lookup_items($pdo,'SOW_FILE_TYPE');
-$allowed = array_map(fn($i)=>strtolower($i['code']), $allowedItems);
+$allowedItems = get_lookup_items($pdo, 'SOW_FILE_TYPE');
+$allowed = array_map(fn($i) => strtolower($i['code']), $allowedItems);
+$max = SOW_MAX_FILE_SIZE;
 $file = $_FILES['file'];
 $ext = strtolower(pathinfo($file['name'], PATHINFO_EXTENSION));
 if(!in_array($ext,$allowed) || $file['size'] > $max){

--- a/admin/finances/sows/update.php
+++ b/admin/finances/sows/update.php
@@ -1,0 +1,24 @@
+<?php
+require '../../admin_header.php';
+require_permission('sow','update');
+
+$token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
+$_SESSION['csrf_token'] = $token;
+$id = (int)($_GET['id'] ?? 0);
+?>
+<h2 class="mb-4">Update Statement of Work</h2>
+<form action="functions/update.php" method="post" enctype="multipart/form-data">
+  <input type="hidden" name="csrf_token" value="<?= h($token) ?>">
+  <input type="hidden" name="id" value="<?= h($id) ?>">
+  <div class="mb-3">
+    <label class="form-label">Name</label>
+    <input type="text" name="title" class="form-control" placeholder="SoW Name">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Upload File</label>
+    <input type="hidden" name="MAX_FILE_SIZE" value="10485760"><!-- 10MB -->
+    <input type="file" name="file" class="form-control" accept=".pdf,.docx,.xlsx,.jpg,.png">
+  </div>
+  <button class="btn btn-primary">Update</button>
+</form>
+<?php require '../../admin_footer.php'; ?>


### PR DESCRIPTION
## Summary
- scaffold placeholder create, update, and delete forms for SoWs
- enforce 10MB limit and SOW_FILE_TYPE validation on SoW uploads
- add feature lookup lists and schema for SoW, links, notes, questions, and logins

## Testing
- `php -l admin/finances/sows/create.php`
- `php -l admin/finances/sows/update.php`
- `php -l admin/finances/sows/delete.php`
- `php -l admin/finances/sows/functions/upload_file.php`
- `composer validate --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68ac047ad1bc8333bac517779444ba3e