### PR TITLE
Refactor lookup lists admin page to use API fetch and vanilla JS

### DIFF
--- a/admin/lookup-lists/index.php
+++ b/admin/lookup-lists/index.php
@@ -2,10 +2,9 @@
 require '../admin_header.php';
 
 $token = generate_csrf_token();
-$stmt = $pdo->query('SELECT l.id, l.name, l.description, l.memo, l.date_updated, COUNT(li.id) AS item_count FROM lookup_lists l LEFT JOIN lookup_list_items li ON li.list_id = l.id GROUP BY l.id ORDER BY l.date_updated DESC');
-$lists = $stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <h2 class="mb-4">Lookup Lists</h2>
+<div id="mainAlert"></div>
 <button id="addListBtn" class="btn btn-sm btn-success mb-3">Add Lookup List</button>
 <div id="lookup-lists" data-list='{"valueNames":["id","name","description","item-count", "date_updated"],"page":25,"pagination":true}'>
   <div class="row justify-content-between g-2 mb-3">
@@ -25,21 +24,7 @@ $lists = $stmt->fetchAll(PDO::FETCH_ASSOC);
           <th>Actions</th>
         </tr>
       </thead>
-      <tbody class="list fw-bold">
-        <?php foreach($lists as $l): ?>
-          <tr data-id="<?= htmlspecialchars($l['id']); ?>">
-            <td class="id"><?= htmlspecialchars($l['id']); ?></td>
-            <td class="name"><a href="items.php?list_id=<?= $l['id']; ?>"><?= htmlspecialchars($l['name']); ?></a></td>
-            <td class="description"><?= htmlspecialchars($l['description']); ?></td>
-            <td class="date_updated"><?= htmlspecialchars($l['date_updated']); ?></td>
-            <td class="item-count"><span class="badge rounded-pill text-bg-dark"><?= (int)$l['item_count']; ?></span></td>
-            <td>
-              <button class="btn btn-sm btn-warning edit-list" data-id="<?= $l['id']; ?>" data-name="<?= htmlspecialchars($l['name'], ENT_QUOTES); ?>" data-description="<?= htmlspecialchars($l['description'], ENT_QUOTES); ?>" data-memo="<?= h($l['memo']); ?>">Edit</button>
-              <button class="btn btn-sm btn-danger delete-list" data-id="<?= $l['id']; ?>">Delete</button>
-            </td>
-          </tr>
-        <?php endforeach; ?>
-      </tbody>
+      <tbody class="list fw-bold" id="listsTableBody"></tbody>
     </table>
   </div>
   <div class="d-flex justify-content-between align-items-center mt-3">
@@ -83,86 +68,130 @@ $lists = $stmt->fetchAll(PDO::FETCH_ASSOC);
 </div>
 
 
-<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 <script>
-$(function(){
-  var csrfToken = '<?= $token; ?>';
-  var listModal = new bootstrap.Modal(document.getElementById('listModal'));
+document.addEventListener('DOMContentLoaded', function () {
+  const csrfToken = '<?= $token; ?>';
+  const listModal = new bootstrap.Modal(document.getElementById('listModal'));
+  const listForm = document.getElementById('listForm');
+  const listAlert = document.getElementById('listAlert');
+  const mainAlert = document.getElementById('mainAlert');
+  const listsTableBody = document.getElementById('listsTableBody');
+  const listModalLabel = document.getElementById('listModalLabel');
+  const listLoading = document.getElementById('listLoading');
+  let listJs;
 
-  $('#addListBtn').on('click', function(){
-    $('#listForm')[0].reset();
-    $('#list-id').val('');
-    $('#listModalLabel').text('Add Lookup List');
-    $('#listAlert').html('');
-    listModal.show();
-  });
+  function showAlert(container, message, type = 'danger') {
+    container.innerHTML = `<div class="alert alert-${type} alert-dismissible fade show" role="alert">${message}<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button></div>`;
+  }
 
-  $('#lookup-lists').on('click', '.edit-list', function(){
-    var btn = $(this);
-    $('#list-id').val(btn.data('id'));
-    $('#list-name').val(btn.data('name'));
-    $('#list-description').val(btn.data('description'));
-    $('#list-memo').val(btn.data('memo'));
-    $('#listModalLabel').text('Edit Lookup List');
-    $('#listAlert').html('');
-    listModal.show();
-  });
+  function escapeHtml(text = '') {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+  }
 
-    $('#listForm').on('submit', function(e){
-      e.preventDefault();
-      $('#listLoading').removeClass('d-none');
-      var action = $('#list-id').val() ? 'update' : 'create';
-      var memoVal = $('#list-memo').val();
-      $.post('../api/lookup-lists.php', $(this).serialize() + '&entity=list&action=' + action, function(res){
-        $('#listLoading').addClass('d-none');
-        if(res.success){
-          $('#listAlert').html('<div class="alert alert-success">'+res.message+'</div>');
-          var l = res.list;
-          var row = $('#lookup-lists tbody tr').filter(function(){ return $(this).data('id') == l.id; });
-          if(row.length){
-            row.find('.name a').text(l.name);
-            row.find('.description').text(l.description);
-            row.find('.edit-list').data('name', l.name).data('description', l.description).data('memo', memoVal);
-          }else{
-            var html = '<tr data-id="'+l.id+'">'
-              +'<td class="id">'+l.id+'</td>'
-              +'<td class="name"><a href="items.php?list_id='+l.id+'">'+l.name+'</a></td>'
-              +'<td class="description">'+l.description+'</td>'
-              +'<td class="item-count">0</td>'
-              +'<td>'
-              +'<button class="btn btn-sm btn-warning edit-list" data-id="'+l.id+'" data-name="'+l.name+'" data-description="'+l.description+'">Edit</button> '
-              +'<button class="btn btn-sm btn-danger delete-list" data-id="'+l.id+'">Delete</button>'
-              +'</td></tr>';
-            var $new = $(html);
-            $new.find('.edit-list').data('memo', memoVal);
-            $('#lookup-lists tbody').append($new);
-          }
-        }else{
-          $('#listAlert').html('<div class="alert alert-danger">'+res.error+'</div>');
+  function renderLists(lists) {
+    listsTableBody.innerHTML = '';
+    lists.forEach(l => {
+      const tr = document.createElement('tr');
+      tr.dataset.id = l.id;
+      tr.innerHTML = `
+        <td class="id">${escapeHtml(l.id)}</td>
+        <td class="name"><a href="items.php?list_id=${l.id}">${escapeHtml(l.name)}</a></td>
+        <td class="description">${escapeHtml(l.description || '')}</td>
+        <td class="date_updated">${escapeHtml(l.date_updated || '')}</td>
+        <td class="item-count"><span class="badge rounded-pill text-bg-dark">${parseInt(l.item_count,10) || 0}</span></td>
+        <td>
+          <button class="btn btn-sm btn-warning edit-list" data-id="${l.id}" data-name="${escapeHtml(l.name)}" data-description="${escapeHtml(l.description || '')}" data-memo="${escapeHtml(l.memo || '')}">Edit</button>
+          <button class="btn btn-sm btn-danger delete-list" data-id="${l.id}">Delete</button>
+        </td>`;
+      listsTableBody.appendChild(tr);
+    });
+    if (!listJs) {
+      const options = JSON.parse(document.getElementById('lookup-lists').dataset.list);
+      listJs = new window.List('lookup-lists', options);
+    } else {
+      listJs.reIndex();
+    }
+  }
+
+  function loadLists() {
+    fetch('../api/lookup-lists.php?entity=list&action=list')
+      .then(res => res.json())
+      .then(data => {
+        if (data.success) {
+          renderLists(data.lists || []);
+        } else {
+          showAlert(mainAlert, data.error);
         }
-      }, 'json').fail(function(){
-        $('#listLoading').addClass('d-none');
-        $('#listAlert').html('<div class="alert alert-danger">Server error.</div>');
-      });
-    });
+      })
+      .catch(() => showAlert(mainAlert, 'Server error'));
+  }
 
-  $('#lookup-lists').on('click', '.delete-list', function(){
-    if(!confirm('Delete this list?')) return;
-    var row = $(this).closest('tr');
-    var id = $(this).data('id');
-    $.post('../api/lookup-lists.php', {entity:'list', action:'delete', id:id, csrf_token:csrfToken}, function(res){
-      if(res.success){
-        row.remove();
-      }else{
-        $('#listAlert').html('<div class="alert alert-danger">'+res.error+'</div>');
-        listModal.show();
-      }
-    }, 'json').fail(function(){
-      $('#listAlert').html('<div class="alert alert-danger">Server error.</div>');
-      listModal.show();
-    });
+  document.getElementById('addListBtn').addEventListener('click', () => {
+    listForm.reset();
+    document.getElementById('list-id').value = '';
+    listModalLabel.textContent = 'Add Lookup List';
+    listAlert.innerHTML = '';
+    listModal.show();
   });
-});
 
+  listsTableBody.addEventListener('click', e => {
+    const target = e.target;
+    if (target.classList.contains('edit-list')) {
+      document.getElementById('list-id').value = target.dataset.id;
+      document.getElementById('list-name').value = target.dataset.name || '';
+      document.getElementById('list-description').value = target.dataset.description || '';
+      document.getElementById('list-memo').value = target.dataset.memo || '';
+      listModalLabel.textContent = 'Edit Lookup List';
+      listAlert.innerHTML = '';
+      listModal.show();
+    } else if (target.classList.contains('delete-list')) {
+      if (!confirm('Delete this list?')) return;
+      const id = target.dataset.id;
+      const formData = new FormData();
+      formData.append('entity', 'list');
+      formData.append('action', 'delete');
+      formData.append('id', id);
+      formData.append('csrf_token', csrfToken);
+      fetch('../api/lookup-lists.php', { method: 'POST', body: formData })
+        .then(res => res.json())
+        .then(data => {
+          if (data.success) {
+            loadLists();
+          } else {
+            showAlert(mainAlert, data.error);
+          }
+        })
+        .catch(() => showAlert(mainAlert, 'Server error'));
+    }
+  });
+
+  listForm.addEventListener('submit', e => {
+    e.preventDefault();
+    listLoading.classList.remove('d-none');
+    const action = document.getElementById('list-id').value ? 'update' : 'create';
+    const formData = new FormData(listForm);
+    formData.append('entity', 'list');
+    formData.append('action', action);
+    fetch('../api/lookup-lists.php', { method: 'POST', body: formData })
+      .then(res => res.json())
+      .then(data => {
+        listLoading.classList.add('d-none');
+        if (data.success) {
+          showAlert(listAlert, data.message, 'success');
+          loadLists();
+        } else {
+          showAlert(listAlert, data.error);
+        }
+      })
+      .catch(() => {
+        listLoading.classList.add('d-none');
+        showAlert(listAlert, 'Server error');
+      });
+  });
+
+  loadLists();
+});
 </script>
 <?php require '../admin_footer.php'; ?>


### PR DESCRIPTION
## Summary
- Load lookup lists via fetch from API and render rows with vanilla JavaScript
- Refresh table after create, update, or delete operations to keep counts and timestamps current
- Replace jQuery handlers with Bootstrap utilities and reusable alert helper

## Testing
- `php -l admin/lookup-lists/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac0f9b2a388333b1043a28fbd08435