### PR TITLE
Use fetch for lookup list items and add status filter

### DIFF
--- a/admin/lookup-lists/items.php
+++ b/admin/lookup-lists/items.php
@@ -37,105 +37,6 @@ if($_SERVER['REQUEST_METHOD']==='POST'){
 
     audit_log($pdo,$this_user_id,'lookup_list_item_attributes',$delId,'DELETE','Deleted item attribute');
     $message='Attribute deleted.';
-
-  }elseif(isset($_POST['attr_item_id'])){
-    $attr_id=(int)($_POST['attr_id'] ?? 0);
-    $item_id=(int)$_POST['attr_item_id'];
-    $key=trim($_POST['attr_code'] ?? '');
-    $value=trim($_POST['attr_value'] ?? '');
-    if($key===''){ $error='Key is required.'; }
-    if(!$error){
-      if($attr_id){
-        try{
-          $stmt=$pdo->prepare('UPDATE lookup_list_item_attributes SET attr_code=:k, attr_value=:v, user_updated=:uid WHERE id=:id');
-          $stmt->execute([':k'=>$key,':v'=>$value,':uid'=>$this_user_id,':id'=>$attr_id]);
-
-          // UPDATE THE LOOKUP LIST date_updated
-          $stmt=$pdo->prepare('UPDATE lookup_lists SET date_updated=NOW(), user_updated = :uid  WHERE id = :id');
-          $stmt->execute([':id'=>$list_id, ':uid'=>$this_user_id]);
-
-          audit_log($pdo,$this_user_id,'lookup_list_item_attributes',$attr_id,'UPDATE','Updated item attribute');
-          $message='Attribute updated.';
-        }catch(PDOException $e){
-          error_log($e->getMessage());
-          if($e->getCode()==='23000'){
-            $error='Attribute already exists for this item.';
-          }else{
-            $error='Database error.';
-          }
-        }
-      }else{
-        try{
-          $stmt=$pdo->prepare('INSERT INTO lookup_list_item_attributes (user_id,user_updated,item_id,attr_code,attr_value) VALUES (:uid,:uid,:item_id,:k,:v)');
-          $stmt->execute([':uid'=>$this_user_id,':item_id'=>$item_id,':k'=>$key,':v'=>$value]);
-
-          // UPDATE THE LOOKUP LIST date_updated
-          $stmt=$pdo->prepare('UPDATE lookup_lists SET date_updated=NOW(), user_updated = :uid  WHERE id = :id');
-          $stmt->execute([':id'=>$list_id, ':uid'=>$this_user_id]);
-
-          $attr_id=$pdo->lastInsertId();
-          audit_log($pdo,$this_user_id,'lookup_list_item_attributes',$attr_id,'CREATE','Created item attribute');
-          $message='Attribute added.';
-        }catch(PDOException $e){
-          error_log($e->getMessage());
-          if($e->getCode()==='23000'){
-            $error='Attribute already exists for this item.';
-          }else{
-            $error='Database error.';
-          }
-        }
-      }
-    }
-  }else{
-    $item_id=(int)($_POST['id'] ?? 0);
-    $label=trim($_POST['label'] ?? '');
-    $code = strtoupper(str_replace(' ', '_', trim($_POST['code'] ?? '')));
-    $active_from = $_POST['active_from'] ?? date('Y-m-d', strtotime('-1 day'));
-    $active_to=$_POST['active_to'] ?? null;
-    if($active_to==='' || $active_to==='0000-00-00'){
-      $active_to=null;
-    }
-    if($code===''){
-      $error='Code is required.';
-    }elseif($label===''){
-      $error='Label is required.';
-    }
-    if(!$error){
-      if($item_id){
-        $stmt=$pdo->prepare('SELECT id FROM lookup_list_items WHERE list_id=:list_id AND (label=:label OR code=:code) AND id<>:id');
-        $stmt->execute([':list_id'=>$list_id,':label'=>$label,':code'=>$code,':id'=>$item_id]);
-      }else{
-        $stmt=$pdo->prepare('SELECT id FROM lookup_list_items WHERE list_id=:list_id AND (label=:label OR code=:code)');
-        $stmt->execute([':list_id'=>$list_id,':label'=>$label,':code'=>$code]);
-      }
-      if($stmt->fetch()){
-        $error='Label or code already exists.';
-      }
-    }
-    if(!$error){
-      if($item_id){
-        $stmt=$pdo->prepare('UPDATE lookup_list_items SET label=:label, code=:code, active_from=:active_from, active_to=:active_to, user_updated=:uid WHERE id=:id');
-        $stmt->execute([':label'=>$label, ':code'=>$code, ':active_from'=>$active_from, ':active_to'=>$active_to, ':uid'=>$this_user_id, ':id'=>$item_id]);
-
-        // UPDATE THE LOOKUP LIST date_updated
-        $stmt=$pdo->prepare('UPDATE lookup_lists SET date_updated=NOW(), user_updated = :uid  WHERE id = :id');
-        $stmt->execute([':id'=>$list_id, ':uid'=>$this_user_id]);
-
-        audit_log($pdo,$this_user_id,'lookup_list_items',$item_id,'UPDATE','Updated lookup list item');
-        $message='Item updated.';
-      }else{
-        $stmt=$pdo->prepare('INSERT INTO lookup_list_items (user_id,user_updated,list_id,label,code,active_from,active_to) VALUES (:uid,:uid,:list_id,:label,:code,:active_from,:active_to)');
-        $stmt->execute([':uid'=>$this_user_id, ':list_id'=>$list_id, ':label'=>$label, ':code'=>$code, ':active_from'=>$active_from, ':active_to'=>$active_to]);
-
-        // UPDATE THE LOOKUP LIST date_updated
-        $stmt=$pdo->prepare('UPDATE lookup_lists SET date_updated=NOW(), user_updated = :uid  WHERE id = :id');
-        $stmt->execute([':id'=>$list_id, ':uid'=>$this_user_id]);
-
-        $item_id=$pdo->lastInsertId();
-        audit_log($pdo,$this_user_id,'lookup_list_items',$item_id,'CREATE','Created lookup list item');
-        $message='Item added.';
-      }
-    }
   }
 }
 
@@ -169,8 +70,9 @@ if($items){
 
 <?= flash_message($error, 'danger'); ?>
 <?= flash_message($message); ?>
-<form method="post" class="row g-2 mb-3">
+<form id="itemForm" class="row g-2 mb-3">
   <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+  <input type="hidden" name="list_id" value="<?= $list_id; ?>">
   <input type="hidden" name="id" value="<?= h($_POST['id'] ?? ''); ?>">
   <div class="col-md-2"><input class="form-control" name="code" placeholder="Code" value="<?= h($_POST['code'] ?? ''); ?>" required></div>
   <div class="col-md-3"><input class="form-control" name="label" placeholder="Label" value="<?= h($_POST['label'] ?? ''); ?>" required></div>
@@ -182,6 +84,14 @@ if($items){
   <div class="row justify-content-between g-2 mb-3">
     <div class="col-auto">
       <input class="form-control form-control-sm search" placeholder="Search" />
+    </div>
+    <div class="col-auto">
+      <select id="statusFilter" class="form-select form-select-sm">
+        <option value="active" selected>Active</option>
+        <option value="inactive">Inactive</option>
+        <option value="future">Future</option>
+        <option value="all">All</option>
+      </select>
     </div>
   </div>
   <div class="table-responsive">
@@ -198,7 +108,7 @@ if($items){
             <td>
               <?php foreach(($it['attrs'] ?? []) as $a): ?>
                 <div class="mb-1">
-                  <form method="post" class="d-inline">
+                  <form class="d-inline attr-form">
                     <input type="hidden" name="csrf_token" value="<?= $token; ?>">
                     <input type="hidden" name="attr_item_id" value="<?= $it['id']; ?>">
                     <input type="hidden" name="attr_id" value="<?= $a['id']; ?>">
@@ -206,14 +116,14 @@ if($items){
                     <input class="form-control form-control-sm d-inline w-auto" name="attr_value" value="<?= h($a['attr_value']); ?>">
                     <button class="btn btn-sm btn-warning">Update</button>
                   </form>
-                  <form method="post" class="d-inline">
+                  <form class="d-inline attr-delete-form">
                     <input type="hidden" name="csrf_token" value="<?= $token; ?>">
                     <input type="hidden" name="attr_delete_id" value="<?= $a['id']; ?>">
-                    <button class="btn btn-sm btn-danger" onclick="return confirm('Delete attribute?');">Delete</button>
+                    <button class="btn btn-sm btn-danger">Delete</button>
                   </form>
                 </div>
               <?php endforeach; ?>
-              <form method="post" class="d-inline">
+              <form class="d-inline attr-form">
                 <input type="hidden" name="csrf_token" value="<?= $token; ?>">
                 <input type="hidden" name="attr_item_id" value="<?= $it['id']; ?>">
                 <input class="form-control form-control-sm d-inline w-auto" name="attr_code" placeholder="Code" required>
@@ -260,8 +170,11 @@ if($items){
 </div>
   <script src="../../vendors/sortablejs/Sortable.min.js"></script>
 <script>
+const listId=<?= $list_id; ?>;
+const csrfToken='<?= $token; ?>';
+
 function fillForm(id,code,label,active_from,active_to){
-  const f=document.forms[0];
+  const f=document.getElementById('itemForm');
   f.id.value=id;
   f.code.value=code;
   f.label.value=label;
@@ -271,16 +184,135 @@ function fillForm(id,code,label,active_from,active_to){
   btn.classList.remove('btn-success');
   btn.classList.add('btn-warning');
 }
-  const sortable = new Sortable(document.querySelector('#items tbody'), {
+
+let sortable;
+function initSortable(){
+  if(sortable){ sortable.destroy(); }
+  sortable = new Sortable(document.querySelector('#items tbody'), {
     handle: '.drag-handle',
     animation: 150,
     onEnd: function(){
+      const requests=[];
       document.querySelectorAll('#items tbody tr').forEach((row, index) => {
         row.querySelector('.order-number').textContent = index + 1;
-        fetch('../api/lookup-lists.php',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:new URLSearchParams({entity:'item',action:'update_sort',id:row.dataset.id,sort_order:index+1,csrf_token:'<?= $token; ?>'})});
+        requests.push(fetch('../api/lookup-lists.php',{
+          method:'POST',
+          headers:{'Content-Type':'application/x-www-form-urlencoded'},
+          body:new URLSearchParams({entity:'item',action:'update_sort',id:row.dataset.id,sort_order:index+1,csrf_token:csrfToken})
+        }).then(r=>r.json()));
       });
+      Promise.all(requests).then(rs=>{ if(rs.some(x=>!x.success)){ alert('Failed to update order'); }});
     }
   });
+}
+
+function esc(str){
+  return str.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+}
+
+function renderAttrs(it){
+  let html='';
+  (it.attrs||[]).forEach(a=>{
+    html+=`<div class="mb-1"><form class="d-inline attr-form">
+      <input type="hidden" name="csrf_token" value="${csrfToken}">
+      <input type="hidden" name="attr_item_id" value="${it.id}">
+      <input type="hidden" name="attr_id" value="${a.id}">
+      <input class="form-control form-control-sm d-inline w-auto" name="attr_code" value="${esc(a.attr_code)}" required>
+      <input class="form-control form-control-sm d-inline w-auto" name="attr_value" value="${esc(a.attr_value||'')}">
+      <button class="btn btn-sm btn-warning">Update</button>
+    </form>
+    <form class="d-inline attr-delete-form">
+      <input type="hidden" name="csrf_token" value="${csrfToken}">
+      <input type="hidden" name="attr_delete_id" value="${a.id}">
+      <button class="btn btn-sm btn-danger">Delete</button>
+    </form></div>`;
+  });
+  html+=`<form class="d-inline attr-form">
+    <input type="hidden" name="csrf_token" value="${csrfToken}">
+    <input type="hidden" name="attr_item_id" value="${it.id}">
+    <input class="form-control form-control-sm d-inline w-auto" name="attr_code" placeholder="Code" required>
+    <input class="form-control form-control-sm d-inline w-auto" name="attr_value" placeholder="Value">
+    <button class="btn btn-sm btn-success">Add</button>
+  </form>`;
+  return html;
+}
+
+function renderItem(it){
+  const tr=document.createElement('tr');
+  tr.dataset.id=it.id;
+  tr.innerHTML=`
+    <td class="sort_order"><span class="drag-handle bi bi-list"></span><span class="order-number ms-2">${it.sort_order}</span></td>
+    <td class="code">${esc(it.code)}</td>
+    <td class="label">${esc(it.label)}</td>
+    <td>${renderAttrs(it)}</td>
+    <td>
+      <button class="btn btn-sm btn-info" data-id="${it.id}" data-label="${esc(it.label)}" onclick="openRelationsModal(this.dataset.id,this.dataset.label);return false;">Relations</button>
+      <button class="btn btn-sm btn-warning" onclick="fillForm(${it.id},'${esc(it.code)}','${esc(it.label)}','${it.active_from}','${it.active_to}');return false;">Edit</button>
+      <form method="post" class="d-inline">
+        <input type="hidden" name="delete_id" value="${it.id}">
+        <input type="hidden" name="csrf_token" value="${csrfToken}">
+        <button class="btn btn-sm btn-danger" onclick="return confirm('Delete item?');">Delete</button>
+      </form>
+    </td>`;
+  return tr;
+}
+
+function loadItems(){
+  const status=document.getElementById('statusFilter').value;
+  fetch(`../api/lookup-lists.php?entity=item&action=list&list_id=${listId}&status=${status}`).then(r=>r.json()).then(d=>{
+    if(d.success){
+      const tbody=document.querySelector('#items tbody');
+      tbody.innerHTML='';
+      d.items.forEach(it=>tbody.appendChild(renderItem(it)));
+      initSortable();
+    }
+  });
+}
+
+document.getElementById('itemForm').addEventListener('submit',function(e){
+  e.preventDefault();
+  const data=new FormData(e.target);
+  const action=data.get('id')? 'update':'create';
+  data.append('entity','item');
+  data.append('action',action);
+  fetch('../api/lookup-lists.php',{method:'POST',body:new URLSearchParams(data)}).then(r=>r.json()).then(d=>{
+    if(d.success){
+      loadItems();
+      e.target.reset();
+      const btn=document.getElementById('saveBtn');
+      btn.classList.remove('btn-warning');
+      btn.classList.add('btn-success');
+    }else{
+      alert(d.error||'Error');
+    }
+  });
+});
+
+document.getElementById('items').addEventListener('submit',function(e){
+  const f=e.target;
+  if(f.classList.contains('attr-form')){
+    e.preventDefault();
+    const data=new FormData(f);
+    const action=data.get('attr_id')? 'update':'create';
+    data.append('entity','attribute');
+    data.append('action',action);
+    fetch('../api/lookup-lists.php',{method:'POST',body:new URLSearchParams(data)}).then(r=>r.json()).then(d=>{
+      if(d.success){ loadItems(); } else { alert(d.error||'Error'); }
+    });
+}else if(f.classList.contains('attr-delete-form')){
+    e.preventDefault();
+    if(!confirm('Delete attribute?')) return;
+    const data=new FormData(f);
+    data.append('entity','attribute');
+    data.append('action','delete');
+    fetch('../api/lookup-lists.php',{method:'POST',body:new URLSearchParams(data)}).then(r=>r.json()).then(d=>{
+      if(d.success){ loadItems(); } else { alert(d.error||'Error'); }
+    });
+  }
+});
+
+document.getElementById('statusFilter').addEventListener('change',loadItems);
+loadItems();
 
 let allItems=[];
 fetch('../api/lookup-lists.php?entity=item&action=all').then(r=>r.json()).then(d=>{ if(d.success){ allItems=d.items; }});
@@ -321,13 +353,13 @@ document.getElementById('addRelationBtn').addEventListener('click',()=>{
   const select=document.getElementById('relationSelect');
   const rid=parseInt(select.value);
   if(!rid) return;
-  fetch('../api/lookup-lists.php',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:new URLSearchParams({entity:'relation',action:'create',item_id:currentItem,related_item_id:rid,csrf_token:'<?= $token; ?>'})}).then(r=>r.json()).then(d=>{
+  fetch('../api/lookup-lists.php',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:new URLSearchParams({entity:'relation',action:'create',item_id:currentItem,related_item_id:rid,csrf_token:csrfToken})}).then(r=>r.json()).then(d=>{
     if(d.success){ loadRelations(); } else { alert(d.error||'Error'); }
   });
 });
 
 function removeRelation(rid){
-  fetch('../api/lookup-lists.php',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:new URLSearchParams({entity:'relation',action:'delete',item_id:currentItem,related_item_id:rid,csrf_token:'<?= $token; ?>'})}).then(r=>r.json()).then(d=>{
+  fetch('../api/lookup-lists.php',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:new URLSearchParams({entity:'relation',action:'delete',item_id:currentItem,related_item_id:rid,csrf_token:csrfToken})}).then(r=>r.json()).then(d=>{
     if(d.success){ loadRelations(); } else { alert(d.error||'Error'); }
   });
 }


### PR DESCRIPTION
## Summary
- add status filtering and attribute loading to lookup list item API with range validation and consistent JSON
- replace item and attribute form submissions with fetch, add status dropdown, and batch sort updates using Promise.all

## Testing
- `php -l admin/api/lookup-lists.php`
- `php -l admin/lookup-lists/items.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac0f9a13b0833393341f7cbf785efc