### PR TITLE
Add calendar lookup items and refresh dropdowns

### DIFF
--- a/_SQL/20240914_calendar_event_options.sql
+++ b/_SQL/20240914_calendar_event_options.sql
@@ -1,0 +1,42 @@
+-- Populate calendar event types and visibility options
+INSERT INTO lookup_list_items (user_id, user_updated, list_id, label, code, sort_order, active_from) VALUES
+  (1,1,37,'Meeting','MEETING',1,CURDATE()),
+  (1,1,37,'Task','TASK',2,CURDATE()),
+  (1,1,37,'Reminder','REMINDER',3,CURDATE()),
+  (1,1,37,'Call','CALL',4,CURDATE());
+
+INSERT INTO lookup_list_items (user_id, user_updated, list_id, label, code, sort_order, active_from) VALUES
+  (1,1,38,'Public','PUBLIC',1,CURDATE()),
+  (1,1,38,'Private','PRIVATE',2,CURDATE());
+
+-- Attributes for calendar event types
+INSERT INTO lookup_list_item_attributes (user_id, user_updated, item_id, attr_code, attr_value)
+SELECT 1,1,id,'COLOR-CLASS','primary' FROM lookup_list_items WHERE list_id=37 AND code='MEETING';
+INSERT INTO lookup_list_item_attributes (user_id, user_updated, item_id, attr_code, attr_value)
+SELECT 1,1,id,'ICON-CLASS','fas fa-users' FROM lookup_list_items WHERE list_id=37 AND code='MEETING';
+
+INSERT INTO lookup_list_item_attributes (user_id, user_updated, item_id, attr_code, attr_value)
+SELECT 1,1,id,'COLOR-CLASS','warning' FROM lookup_list_items WHERE list_id=37 AND code='TASK';
+INSERT INTO lookup_list_item_attributes (user_id, user_updated, item_id, attr_code, attr_value)
+SELECT 1,1,id,'ICON-CLASS','fas fa-check' FROM lookup_list_items WHERE list_id=37 AND code='TASK';
+
+INSERT INTO lookup_list_item_attributes (user_id, user_updated, item_id, attr_code, attr_value)
+SELECT 1,1,id,'COLOR-CLASS','info' FROM lookup_list_items WHERE list_id=37 AND code='REMINDER';
+INSERT INTO lookup_list_item_attributes (user_id, user_updated, item_id, attr_code, attr_value)
+SELECT 1,1,id,'ICON-CLASS','fas fa-bell' FROM lookup_list_items WHERE list_id=37 AND code='REMINDER';
+
+INSERT INTO lookup_list_item_attributes (user_id, user_updated, item_id, attr_code, attr_value)
+SELECT 1,1,id,'COLOR-CLASS','success' FROM lookup_list_items WHERE list_id=37 AND code='CALL';
+INSERT INTO lookup_list_item_attributes (user_id, user_updated, item_id, attr_code, attr_value)
+SELECT 1,1,id,'ICON-CLASS','fas fa-phone' FROM lookup_list_items WHERE list_id=37 AND code='CALL';
+
+-- Attributes for calendar visibility options
+INSERT INTO lookup_list_item_attributes (user_id, user_updated, item_id, attr_code, attr_value)
+SELECT 1,1,id,'COLOR-CLASS','success' FROM lookup_list_items WHERE list_id=38 AND code='PUBLIC';
+INSERT INTO lookup_list_item_attributes (user_id, user_updated, item_id, attr_code, attr_value)
+SELECT 1,1,id,'ICON-CLASS','fas fa-globe' FROM lookup_list_items WHERE list_id=38 AND code='PUBLIC';
+
+INSERT INTO lookup_list_item_attributes (user_id, user_updated, item_id, attr_code, attr_value)
+SELECT 1,1,id,'COLOR-CLASS','danger' FROM lookup_list_items WHERE list_id=38 AND code='PRIVATE';
+INSERT INTO lookup_list_item_attributes (user_id, user_updated, item_id, attr_code, attr_value)
+SELECT 1,1,id,'ICON-CLASS','fas fa-lock' FROM lookup_list_items WHERE list_id=38 AND code='PRIVATE';

--- a/includes/calendar.php
+++ b/includes/calendar.php
@@ -1,6 +1,7 @@
 <?php
-$eventTypes = $pdo->query("SELECT id,label FROM lookup_list_items WHERE list_id=37 ORDER BY sort_order,label")->fetchAll(PDO::FETCH_ASSOC);
-$visibilities = $pdo->query("SELECT id,label FROM lookup_list_items WHERE list_id=38 ORDER BY sort_order,label")->fetchAll(PDO::FETCH_ASSOC);
+require_once __DIR__ . '/lookup_helpers.php';
+$eventTypes = get_lookup_items($pdo, 37);
+$visibilities = get_lookup_items($pdo, 38);
 ?>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/main.min.css" />
 
@@ -80,7 +81,7 @@ $visibilities = $pdo->query("SELECT id,label FROM lookup_list_items WHERE list_i
             <label class="form-label" for="eventType">Event Type</label>
             <select class="form-select" id="eventType" name="event_type_id">
               <?php foreach ($eventTypes as $t): ?>
-                <option value="<?= (int)$t['id']; ?>"><?= h($t['label']); ?></option>
+                <option value="<?= (int)$t['id']; ?>" class="text-<?= h($t['color_class']); ?>" data-icon="<?= h($t['icon_class']); ?>"><?= h($t['label']); ?></option>
               <?php endforeach; ?>
             </select>
           </div>
@@ -88,7 +89,7 @@ $visibilities = $pdo->query("SELECT id,label FROM lookup_list_items WHERE list_i
             <label class="form-label" for="eventVisibility">Visibility</label>
             <select class="form-select" id="eventVisibility" name="visibility_id">
               <?php foreach ($visibilities as $v): ?>
-                <option value="<?= (int)$v['id']; ?>"><?= h($v['label']); ?></option>
+                <option value="<?= (int)$v['id']; ?>" class="text-<?= h($v['color_class']); ?>" data-icon="<?= h($v['icon_class']); ?>"><?= h($v['label']); ?></option>
               <?php endforeach; ?>
             </select>
           </div>
@@ -139,7 +140,7 @@ $visibilities = $pdo->query("SELECT id,label FROM lookup_list_items WHERE list_i
             <label class="form-label" for="editEventType">Event Type</label>
             <select class="form-select" id="editEventType" name="event_type_id">
               <?php foreach ($eventTypes as $t): ?>
-                <option value="<?= (int)$t['id']; ?>"><?= h($t['label']); ?></option>
+                <option value="<?= (int)$t['id']; ?>" class="text-<?= h($t['color_class']); ?>" data-icon="<?= h($t['icon_class']); ?>"><?= h($t['label']); ?></option>
               <?php endforeach; ?>
             </select>
           </div>
@@ -147,7 +148,7 @@ $visibilities = $pdo->query("SELECT id,label FROM lookup_list_items WHERE list_i
             <label class="form-label" for="editEventVisibility">Visibility</label>
             <select class="form-select" id="editEventVisibility" name="visibility_id">
               <?php foreach ($visibilities as $v): ?>
-                <option value="<?= (int)$v['id']; ?>"><?= h($v['label']); ?></option>
+                <option value="<?= (int)$v['id']; ?>" class="text-<?= h($v['color_class']); ?>" data-icon="<?= h($v['icon_class']); ?>"><?= h($v['label']); ?></option>
               <?php endforeach; ?>
             </select>
           </div>

--- a/includes/lookup_helpers.php
+++ b/includes/lookup_helpers.php
@@ -8,7 +8,7 @@
  *
  * @param PDO         $pdo  PDO connection.
  * @param int|string  $list Lookup list ID or name.
- * @return array              Array of items with id, label, code, color_class and is_default.
+ * @return array              Array of items with id, label, code, color_class, icon_class and is_default.
  */
 function get_lookup_items(PDO $pdo, int|string $list): array {
     $param = is_numeric($list) ? ':list_id' : ':list_name';
@@ -16,17 +16,20 @@ function get_lookup_items(PDO $pdo, int|string $list): array {
 
     $sql = "SELECT li.id, li.label, li.code, li.code AS value,
                    COALESCE(color_attr.attr_value, 'secondary') AS color_class,
+                   COALESCE(icon_attr.attr_value, '') AS icon_class,
                    COALESCE(def_attr.attr_value = 'true', 0) AS is_default
             FROM lookup_list_items li
             JOIN lookup_lists l ON li.list_id = l.id
             LEFT JOIN lookup_list_item_attributes color_attr
                    ON li.id = color_attr.item_id AND color_attr.attr_code = 'COLOR-CLASS'
+            LEFT JOIN lookup_list_item_attributes icon_attr
+                   ON li.id = icon_attr.item_id AND icon_attr.attr_code = 'ICON-CLASS'
             LEFT JOIN lookup_list_item_attributes def_attr
                    ON li.id = def_attr.item_id AND def_attr.attr_code = 'DEFAULT'
             WHERE $where
               AND li.active_from <= CURDATE()
               AND (li.active_to IS NULL OR li.active_to >= CURDATE())
-            ORDER BY li.id DESC, li.label";
+            ORDER BY li.sort_order, li.label";
 
     $stmt = $pdo->prepare($sql);
     $params = is_numeric($list) ? [':list_id' => $list] : [':list_name' => $list];

--- a/module/calendar/include/calendar_view.php
+++ b/module/calendar/include/calendar_view.php
@@ -4,8 +4,8 @@ $calendars = [];
 $stmt = $pdo->query('SELECT id, name FROM module_calendar ORDER BY name');
 $calendars = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
-$visibilities = $pdo->query("SELECT id,label FROM lookup_list_items WHERE list_id=38 ORDER BY sort_order,label")->fetchAll(PDO::FETCH_ASSOC);
-$event_types = $pdo->query("SELECT id,label FROM lookup_list_items WHERE list_id=37 ORDER BY sort_order,label")->fetchAll(PDO::FETCH_ASSOC);
+$visibilities = get_lookup_items($pdo, 38);
+$event_types = get_lookup_items($pdo, 37);
 $selected_calendar_id = $_SESSION['selected_calendar_id'] ?? 0;
 $default_visibility_id = $visibilities[0]['id'] ?? 0;
 $default_event_type_id = $event_types[0]['id'] ?? 0;
@@ -66,7 +66,7 @@ $default_event_type_id = $event_types[0]['id'] ?? 0;
             <label class="form-label" for="addEventType">Event Type</label>
             <select class="form-select" id="addEventType" name="event_type_id">
               <?php foreach ($event_types as $et): ?>
-                <option value="<?= (int)$et['id']; ?>"><?= h($et['label']); ?></option>
+                <option value="<?= (int)$et['id']; ?>" class="text-<?= h($et['color_class']); ?>" data-icon="<?= h($et['icon_class']); ?>"><?= h($et['label']); ?></option>
               <?php endforeach; ?>
             </select>
           </div>
@@ -74,7 +74,7 @@ $default_event_type_id = $event_types[0]['id'] ?? 0;
             <label class="form-label" for="addEventVisibility">Visibility</label>
             <select class="form-select" id="addEventVisibility" name="visibility_id">
               <?php foreach ($visibilities as $v): ?>
-                <option value="<?= (int)$v['id']; ?>"><?= h($v['label']); ?></option>
+                <option value="<?= (int)$v['id']; ?>" class="text-<?= h($v['color_class']); ?>" data-icon="<?= h($v['icon_class']); ?>"><?= h($v['label']); ?></option>
               <?php endforeach; ?>
             </select>
           </div>
@@ -118,7 +118,7 @@ $default_event_type_id = $event_types[0]['id'] ?? 0;
             <label class="form-label" for="editEventType">Event Type</label>
             <select class="form-select" id="editEventType" name="event_type_id">
               <?php foreach ($event_types as $et): ?>
-                <option value="<?= (int)$et['id']; ?>"><?= h($et['label']); ?></option>
+                <option value="<?= (int)$et['id']; ?>" class="text-<?= h($et['color_class']); ?>" data-icon="<?= h($et['icon_class']); ?>"><?= h($et['label']); ?></option>
               <?php endforeach; ?>
             </select>
           </div>
@@ -126,7 +126,7 @@ $default_event_type_id = $event_types[0]['id'] ?? 0;
             <label class="form-label" for="editEventVisibility">Visibility</label>
             <select class="form-select" id="editEventVisibility" name="visibility_id">
               <?php foreach ($visibilities as $v): ?>
-                <option value="<?= (int)$v['id']; ?>"><?= h($v['label']); ?></option>
+                <option value="<?= (int)$v['id']; ?>" class="text-<?= h($v['color_class']); ?>" data-icon="<?= h($v['icon_class']); ?>"><?= h($v['label']); ?></option>
               <?php endforeach; ?>
             </select>
           </div>


### PR DESCRIPTION
## Summary
- populate calendar event types and visibility lists with icons and color classes
- expose lookup item icon and color data via `get_lookup_items`
- display color-coded event type and visibility options in calendar dropdowns

## Testing
- `php -l includes/lookup_helpers.php`
- `php -l includes/calendar.php`
- `php -l module/calendar/include/calendar_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac19ebb89083338bce058fdabde84f