### PR TITLE
Use boolean privacy flag for calendar events

### DIFF
--- a/_SQL/20240508_calendar_events_is_private.sql
+++ b/_SQL/20240508_calendar_events_is_private.sql
@@ -1,0 +1,15 @@
+-- Replace visibility_id with is_private in module_calendar_events
+ALTER TABLE `module_calendar_events`
+  ADD COLUMN `is_private` tinyint(1) NOT NULL DEFAULT 0 AFTER `link_record_id`;
+
+UPDATE `module_calendar_events` m
+SET m.is_private = CASE
+  WHEN m.visibility_id IS NOT NULL AND EXISTS (
+    SELECT 1 FROM lookup_list_items l
+    WHERE l.id = m.visibility_id AND l.list_id = 38 AND l.code = 'PRIVATE'
+  ) THEN 1 ELSE 0 END;
+
+ALTER TABLE `module_calendar_events`
+  DROP FOREIGN KEY `fk_module_calendar_events_visibility_id`,
+  DROP KEY `fk_module_calendar_events_visibility_id`,
+  DROP COLUMN `visibility_id`;

--- a/_SQL/atlis.sql
+++ b/_SQL/atlis.sql
@@ -1550,16 +1550,16 @@ CREATE TABLE `module_calendar_events` (
   `event_type_id` int(11) DEFAULT NULL,
   `link_module` varchar(50) DEFAULT NULL,
   `link_record_id` int(11) DEFAULT NULL,
-  `visibility_id` int(11) DEFAULT NULL
+  `is_private` tinyint(1) NOT NULL DEFAULT 0
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --
 -- Dumping data for table `module_calendar_events`
 --
 
-INSERT INTO `module_calendar_events` (`id`, `user_id`, `user_updated`, `date_created`, `date_updated`, `memo`, `calendar_id`, `title`, `start_time`, `end_time`, `event_type_id`, `link_module`, `link_record_id`, `visibility_id`) VALUES
-(1, 1, NULL, '2025-08-25 00:10:22', '2025-08-25 00:10:22', NULL, 1, 'test', '2025-08-25 12:00:00', '2025-08-26 12:00:00', NULL, NULL, NULL, 198),
-(2, 1, NULL, '2025-08-25 00:11:09', '2025-08-25 00:11:09', NULL, 1, 'DAVE', '2025-08-25 12:30:00', '2025-08-25 11:45:00', NULL, NULL, NULL, 198);
+INSERT INTO `module_calendar_events` (`id`, `user_id`, `user_updated`, `date_created`, `date_updated`, `memo`, `calendar_id`, `title`, `start_time`, `end_time`, `event_type_id`, `link_module`, `link_record_id`, `is_private`) VALUES
+(1, 1, NULL, '2025-08-25 00:10:22', '2025-08-25 00:10:22', NULL, 1, 'test', '2025-08-25 12:00:00', '2025-08-26 12:00:00', NULL, NULL, NULL, 0),
+(2, 1, NULL, '2025-08-25 00:11:09', '2025-08-25 00:11:09', NULL, 1, 'DAVE', '2025-08-25 12:30:00', '2025-08-25 11:45:00', NULL, NULL, NULL, 0);
 
 -- --------------------------------------------------------
 
@@ -3425,7 +3425,6 @@ ALTER TABLE `module_calendar_events`
   ADD KEY `fk_module_calendar_events_calendar_id` (`calendar_id`),
   ADD KEY `fk_module_calendar_events_event_type_id` (`event_type_id`),
   ADD KEY `fk_module_calendar_events_link_record_id` (`link_record_id`),
-  ADD KEY `fk_module_calendar_events_visibility_id` (`visibility_id`),
   ADD KEY `fk_module_calendar_events_user_id` (`user_id`),
   ADD KEY `fk_module_calendar_events_user_updated` (`user_updated`);
 
@@ -4471,7 +4470,6 @@ ALTER TABLE `module_agency_persons`
 ALTER TABLE `module_calendar_events`
   ADD CONSTRAINT `fk_module_calendar_events_calendar_id` FOREIGN KEY (`calendar_id`) REFERENCES `module_calendar` (`id`) ON DELETE CASCADE,
   ADD CONSTRAINT `fk_module_calendar_events_event_type_id` FOREIGN KEY (`event_type_id`) REFERENCES `lookup_list_items` (`id`),
-  ADD CONSTRAINT `fk_module_calendar_events_visibility_id` FOREIGN KEY (`visibility_id`) REFERENCES `lookup_list_items` (`id`),
   ADD CONSTRAINT `fk_module_calendar_events_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
   ADD CONSTRAINT `fk_module_calendar_events_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`) ON DELETE SET NULL;
 

--- a/includes/calendar.php
+++ b/includes/calendar.php
@@ -1,6 +1,5 @@
 <?php
 $eventTypes = $pdo->query("SELECT id,label FROM lookup_list_items WHERE list_id=37 ORDER BY sort_order,label")->fetchAll(PDO::FETCH_ASSOC);
-$visibilities = $pdo->query("SELECT id,label FROM lookup_list_items WHERE list_id=38 ORDER BY sort_order,label")->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/main.min.css" />
 
@@ -84,13 +83,9 @@ $visibilities = $pdo->query("SELECT id,label FROM lookup_list_items WHERE list_i
               <?php endforeach; ?>
             </select>
           </div>
-          <div class="mb-3">
-            <label class="form-label" for="eventVisibility">Visibility</label>
-            <select class="form-select" id="eventVisibility" name="visibility_id">
-              <?php foreach ($visibilities as $v): ?>
-                <option value="<?= (int)$v['id']; ?>"><?= h($v['label']); ?></option>
-              <?php endforeach; ?>
-            </select>
+          <div class="form-check mb-3">
+            <input class="form-check-input" type="checkbox" id="eventPrivate" name="is_private" value="1">
+            <label class="form-check-label" for="eventPrivate">Private</label>
           </div>
         </div>
         <div class="modal-footer d-flex justify-content-end align-items-center border-0">
@@ -143,13 +138,9 @@ $visibilities = $pdo->query("SELECT id,label FROM lookup_list_items WHERE list_i
               <?php endforeach; ?>
             </select>
           </div>
-          <div class="mb-3">
-            <label class="form-label" for="editEventVisibility">Visibility</label>
-            <select class="form-select" id="editEventVisibility" name="visibility_id">
-              <?php foreach ($visibilities as $v): ?>
-                <option value="<?= (int)$v['id']; ?>"><?= h($v['label']); ?></option>
-              <?php endforeach; ?>
-            </select>
+          <div class="form-check mb-3">
+            <input class="form-check-input" type="checkbox" id="editEventPrivate" name="is_private" value="1">
+            <label class="form-check-label" for="editEventPrivate">Private</label>
           </div>
         </div>
         <div class="modal-footer d-flex justify-content-end align-items-center border-0">
@@ -191,7 +182,7 @@ document.addEventListener('DOMContentLoaded', function() {
       form.allDay.checked = info.event.allDay;
       form.description.value = info.event.extendedProps.description || '';
       form.event_type_id.value = info.event.extendedProps.event_type_id || '';
-      form.visibility_id.value = info.event.extendedProps.visibility_id || '';
+      form.is_private.checked = info.event.extendedProps.is_private == 1;
       editModal.show();
 
     events: {
@@ -256,7 +247,7 @@ document.addEventListener('DOMContentLoaded', function() {
           allDay: data.get('allDay') === 'on',
           description: data.get('description'),
           event_type_id: data.get('event_type_id'),
-          visibility_id: data.get('visibility_id')
+          is_private: data.get('is_private') ? 1 : 0
         });
         e.target.reset();
         bootstrap.Modal.getInstance(document.getElementById('addEventModal')).hide();
@@ -281,7 +272,7 @@ document.addEventListener('DOMContentLoaded', function() {
           event.setAllDay(form.allDay.checked);
           event.setExtendedProp('description', form.description.value);
           event.setExtendedProp('event_type_id', form.event_type_id.value);
-          event.setExtendedProp('visibility_id', form.visibility_id.value);
+          event.setExtendedProp('is_private', form.is_private.checked ? 1 : 0);
         }
         bootstrap.Modal.getInstance(document.getElementById('editEventModal')).hide();
       }

--- a/module/calendar/functions/create.php
+++ b/module/calendar/functions/create.php
@@ -12,11 +12,11 @@ $link_module = $_POST['link_module'] ?? null;
 $link_record_id = $_POST['link_record_id'] ?? null;
 $calendar_id = (int)($_POST['calendar_id'] ?? 0);
 $event_type_id = $_POST['event_type_id'] ?? null;
-$visibility_id = (int)($_POST['visibility_id'] ?? 0);
+$is_private = !empty($_POST['is_private']) ? 1 : 0;
 $attendees = $_POST['attendees'] ?? [];
 
 if ($title && $start_time && $calendar_id) {
-  $stmt = $pdo->prepare('INSERT INTO module_calendar_events (user_id, calendar_id, title, start_time, end_time, event_type_id, link_module, link_record_id, visibility_id) VALUES (:uid, :calendar_id, :title, :start_time, :end_time, :event_type_id, :link_module, :link_record_id, :visibility_id)');
+  $stmt = $pdo->prepare('INSERT INTO module_calendar_events (user_id, calendar_id, title, start_time, end_time, event_type_id, link_module, link_record_id, is_private) VALUES (:uid, :calendar_id, :title, :start_time, :end_time, :event_type_id, :link_module, :link_record_id, :is_private)');
 
   $stmt->execute([
     ':uid' => $this_user_id,
@@ -27,7 +27,7 @@ if ($title && $start_time && $calendar_id) {
     ':event_type_id' => $event_type_id,
     ':link_module' => $link_module,
     ':link_record_id' => $link_record_id,
-    ':visibility_id' => $visibility_id
+    ':is_private' => $is_private
 
   ]);
   $eventId = $pdo->lastInsertId();
@@ -45,7 +45,7 @@ if ($title && $start_time && $calendar_id) {
     'title' => $title,
     'start' => $start_time,
     'end' => $end_time,
-    'visibility_id' => $visibility_id
+    'is_private' => $is_private
   ]);
   exit;
 }

--- a/module/calendar/functions/delete.php
+++ b/module/calendar/functions/delete.php
@@ -6,18 +6,14 @@ header('Content-Type: application/json');
 
 $id = (int)($_POST['id'] ?? 0);
 if ($id) {
-  $privStmt = $pdo->prepare('SELECT id FROM lookup_list_items WHERE list_id=38 AND code="PRIVATE"');
-  $privStmt->execute();
-  $privateId = (int)$privStmt->fetchColumn();
-
-  $chk = $pdo->prepare('SELECT user_id, visibility_id FROM module_calendar_events WHERE id = ?');
+  $chk = $pdo->prepare('SELECT user_id, is_private FROM module_calendar_events WHERE id = ?');
   $chk->execute([$id]);
   $existing = $chk->fetch(PDO::FETCH_ASSOC);
   if (!$existing) {
     http_response_code(404);
     exit;
   }
-  if ($existing['visibility_id'] === $privateId && $existing['user_id'] != $this_user_id && !user_has_role('Admin')) {
+  if ($existing['is_private'] && $existing['user_id'] != $this_user_id && !user_has_role('Admin')) {
     http_response_code(403);
     exit;
   }

--- a/module/calendar/functions/google_events.php
+++ b/module/calendar/functions/google_events.php
@@ -34,7 +34,7 @@ function fetch_google_events(PDO $pdo, int $userId): array {
                 'related_module' => null,
                 'related_id' => null,
                 'event_type_id' => 0,
-                'visibility_id' => 0,
+                'is_private' => 0,
                 'source' => 'google'
             ];
         }

--- a/module/calendar/functions/list.php
+++ b/module/calendar/functions/list.php
@@ -8,24 +8,21 @@ require_once 'google_events.php';
 require_once 'microsoft_events.php';
 
 $calendar_id = isset($_GET['calendar_id']) ? (int)$_GET['calendar_id'] : 0;
-$privStmt = $pdo->prepare('SELECT id FROM lookup_list_items WHERE list_id=38 AND code="PRIVATE"');
-$privStmt->execute();
-$privateId = (int)$privStmt->fetchColumn();
 $events = [];
 if (user_has_role('Admin')) {
   if ($calendar_id) {
-    $stmt = $pdo->prepare('SELECT id, calendar_id, title, start_time, end_time, link_module, link_record_id, user_id, event_type_id, visibility_id FROM module_calendar_events WHERE calendar_id = :calid');
+    $stmt = $pdo->prepare('SELECT id, calendar_id, title, start_time, end_time, link_module, link_record_id, user_id, event_type_id, is_private FROM module_calendar_events WHERE calendar_id = :calid');
     $stmt->execute([':calid' => $calendar_id]);
   } else {
-    $stmt = $pdo->query('SELECT id, calendar_id, title, start_time, end_time, link_module, link_record_id, user_id, event_type_id, visibility_id FROM module_calendar_events');
+    $stmt = $pdo->query('SELECT id, calendar_id, title, start_time, end_time, link_module, link_record_id, user_id, event_type_id, is_private FROM module_calendar_events');
   }
 } else {
   if ($calendar_id) {
-    $stmt = $pdo->prepare('SELECT id, calendar_id, title, start_time, end_time, link_module, link_record_id, user_id, event_type_id, visibility_id FROM module_calendar_events WHERE (visibility_id <> :priv OR visibility_id IS NULL OR user_id = :uid) AND calendar_id = :calid');
-    $stmt->execute([':priv' => $privateId, ':uid' => $this_user_id, ':calid' => $calendar_id]);
+    $stmt = $pdo->prepare('SELECT id, calendar_id, title, start_time, end_time, link_module, link_record_id, user_id, event_type_id, is_private FROM module_calendar_events WHERE (is_private = 0 OR user_id = :uid) AND calendar_id = :calid');
+    $stmt->execute([':uid' => $this_user_id, ':calid' => $calendar_id]);
   } else {
-    $stmt = $pdo->prepare('SELECT id, calendar_id, title, start_time, end_time, link_module, link_record_id, user_id, event_type_id, visibility_id FROM module_calendar_events WHERE visibility_id <> :priv OR visibility_id IS NULL OR user_id = :uid');
-    $stmt->execute([':priv' => $privateId, ':uid' => $this_user_id]);
+    $stmt = $pdo->prepare('SELECT id, calendar_id, title, start_time, end_time, link_module, link_record_id, user_id, event_type_id, is_private FROM module_calendar_events WHERE is_private = 0 OR user_id = :uid');
+    $stmt->execute([':uid' => $this_user_id]);
   }
 
 }
@@ -40,7 +37,7 @@ while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
     'related_module' => $row['link_module'],
     'related_id' => $row['link_record_id'],
     'event_type_id' => $row['event_type_id'],
-    'visibility_id' => (int)$row['visibility_id']
+    'is_private' => (int)$row['is_private']
   ];
 }
 

--- a/module/calendar/functions/microsoft_events.php
+++ b/module/calendar/functions/microsoft_events.php
@@ -34,7 +34,7 @@ function fetch_microsoft_events(PDO $pdo, int $userId): array {
                 'related_module' => null,
                 'related_id' => null,
                 'event_type_id' => 0,
-                'visibility_id' => 0,
+                'is_private' => 0,
                 'source' => 'microsoft'
             ];
         }

--- a/module/calendar/include/calendar_view.php
+++ b/module/calendar/include/calendar_view.php
@@ -4,10 +4,8 @@ $calendars = [];
 $stmt = $pdo->query('SELECT id, name FROM module_calendar ORDER BY name');
 $calendars = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
-$visibilities = $pdo->query("SELECT id,label FROM lookup_list_items WHERE list_id=38 ORDER BY sort_order,label")->fetchAll(PDO::FETCH_ASSOC);
 $event_types = $pdo->query("SELECT id,label FROM lookup_list_items WHERE list_id=37 ORDER BY sort_order,label")->fetchAll(PDO::FETCH_ASSOC);
 $selected_calendar_id = $_SESSION['selected_calendar_id'] ?? 0;
-$default_visibility_id = $visibilities[0]['id'] ?? 0;
 $default_event_type_id = $event_types[0]['id'] ?? 0;
 
 ?>
@@ -70,13 +68,9 @@ $default_event_type_id = $event_types[0]['id'] ?? 0;
               <?php endforeach; ?>
             </select>
           </div>
-          <div class="mb-3">
-            <label class="form-label" for="addEventVisibility">Visibility</label>
-            <select class="form-select" id="addEventVisibility" name="visibility_id">
-              <?php foreach ($visibilities as $v): ?>
-                <option value="<?= (int)$v['id']; ?>"><?= h($v['label']); ?></option>
-              <?php endforeach; ?>
-            </select>
+          <div class="form-check mb-3">
+            <input class="form-check-input" type="checkbox" id="addEventPrivate" name="is_private" value="1">
+            <label class="form-check-label" for="addEventPrivate">Private</label>
           </div>
         </div>
         <div class="modal-footer d-flex justify-content-end align-items-center border-0">
@@ -122,13 +116,9 @@ $default_event_type_id = $event_types[0]['id'] ?? 0;
               <?php endforeach; ?>
             </select>
           </div>
-          <div class="mb-3">
-            <label class="form-label" for="editEventVisibility">Visibility</label>
-            <select class="form-select" id="editEventVisibility" name="visibility_id">
-              <?php foreach ($visibilities as $v): ?>
-                <option value="<?= (int)$v['id']; ?>"><?= h($v['label']); ?></option>
-              <?php endforeach; ?>
-            </select>
+          <div class="form-check mb-3">
+            <input class="form-check-input" type="checkbox" id="editEventPrivate" name="is_private" value="1">
+            <label class="form-check-label" for="editEventPrivate">Private</label>
           </div>
         </div>
         <div class="modal-footer d-flex justify-content-end align-items-center border-0">
@@ -148,7 +138,6 @@ document.addEventListener('DOMContentLoaded', function() {
   document.querySelector('.calendar-date').textContent = now.toLocaleDateString('en-US', {year:'numeric', month:'short', day:'numeric'});
 
   const defaultCalendarId = <?php echo (int)$selected_calendar_id; ?>;
-  const defaultVisibilityId = <?php echo (int)$default_visibility_id; ?>;
   const defaultEventTypeId = <?php echo (int)$default_event_type_id; ?>;
   const calendarEl = document.getElementById('calendar');
 
@@ -181,9 +170,8 @@ document.addEventListener('DOMContentLoaded', function() {
       form.title.value = info.event.title;
       form.start_time.value = dayjs(info.event.start).format('YYYY-MM-DD HH:mm');
       form.end_time.value = info.event.end ? dayjs(info.event.end).format('YYYY-MM-DD HH:mm') : '';
-      // Visibility uses visibility_id rather than legacy is_private flag
       form.event_type_id.value = info.event.extendedProps.event_type_id || defaultEventTypeId;
-      form.visibility_id.value = info.event.extendedProps.visibility_id;
+      form.is_private.checked = info.event.extendedProps.is_private == 1;
       bootstrap.Modal.getOrCreateInstance(document.getElementById('editEventModal')).show();
     },
     dateClick: function(info) {
@@ -191,7 +179,7 @@ document.addEventListener('DOMContentLoaded', function() {
       form.start_time.value = dayjs(info.date).format('YYYY-MM-DD HH:mm');
       form.end_time.value = '';
       form.event_type_id.value = defaultEventTypeId;
-      form.visibility_id.value = defaultVisibilityId;
+      form.is_private.checked = false;
       form.calendar_id.value = getCalendarId();
       bootstrap.Modal.getOrCreateInstance(document.getElementById('addEventModal')).show();
     }


### PR DESCRIPTION
## Summary
- Replace `visibility_id` lookup with boolean `is_private` in `module_calendar_events` schema and seed data
- Update calendar event CRUD endpoints and frontend forms to handle the `is_private` flag
- Add migration script converting existing visibility references to the new boolean field

## Testing
- `php -l includes/calendar.php`
- `php -l module/calendar/functions/list.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac19eafbd88333be1d307abb58b88b