### PR TITLE
Centralize calendar event loading and simplify permissions

### DIFF
--- a/module/calendar/functions/delete.php
+++ b/module/calendar/functions/delete.php
@@ -1,7 +1,5 @@
 <?php
 require '../../../includes/php_header.php';
-require_permission('calendar','delete');
-
 header('Content-Type: application/json');
 
 $id = (int)($_POST['id'] ?? 0);

--- a/module/calendar/functions/delete_calendar.php
+++ b/module/calendar/functions/delete_calendar.php
@@ -1,7 +1,5 @@
 <?php
 require '../../../includes/php_header.php';
-require_permission('calendar','delete');
-
 header('Content-Type: application/json');
 
 $id = (int)($_POST['id'] ?? 0);

--- a/module/calendar/functions/google_events.php
+++ b/module/calendar/functions/google_events.php
@@ -46,7 +46,6 @@ function fetch_google_events(PDO $pdo, int $userId): array {
 
 if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
     require '../../../includes/php_header.php';
-    require_permission('calendar','read');
     header('Content-Type: application/json');
     echo json_encode(fetch_google_events($pdo, $this_user_id));
 }

--- a/module/calendar/functions/list.php
+++ b/module/calendar/functions/list.php
@@ -1,7 +1,5 @@
 <?php
 require '../../../includes/php_header.php';
-require_permission('calendar','read');
-
 header('Content-Type: application/json');
 
 require_once 'google_events.php';

--- a/module/calendar/functions/microsoft_events.php
+++ b/module/calendar/functions/microsoft_events.php
@@ -46,7 +46,6 @@ function fetch_microsoft_events(PDO $pdo, int $userId): array {
 
 if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
     require '../../../includes/php_header.php';
-    require_permission('calendar','read');
     header('Content-Type: application/json');
     echo json_encode(fetch_microsoft_events($pdo, $this_user_id));
 }

--- a/module/calendar/functions/update.php
+++ b/module/calendar/functions/update.php
@@ -1,7 +1,5 @@
 <?php
 require '../../../includes/php_header.php';
-require_permission('calendar','update');
-
 header('Content-Type: application/json');
 
 $id = (int)($_POST['id'] ?? 0);

--- a/module/calendar/functions/update_calendar.php
+++ b/module/calendar/functions/update_calendar.php
@@ -1,7 +1,5 @@
 <?php
 require '../../../includes/php_header.php';
-require_permission('calendar','update');
-
 header('Content-Type: application/json');
 
 $id = (int)($_POST['id'] ?? 0);


### PR DESCRIPTION
## Summary
- Delegate calendar event retrieval to `calendar_view.php` via `functions/list.php`
- Remove read, update, and delete permission checks across calendar endpoints, keeping only create checks

## Testing
- `php -l module/calendar/index.php`
- `php -l module/calendar/functions/list.php`
- `php -l module/calendar/functions/google_events.php`
- `php -l module/calendar/functions/microsoft_events.php`
- `php -l module/calendar/functions/update_calendar.php`
- `php -l module/calendar/functions/delete.php`
- `php -l module/calendar/functions/update.php`
- `php -l module/calendar/functions/delete_calendar.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac19e9f5b88333bde95d78835e6c29