### PR TITLE
Add admin task management module

### DIFF
--- a/admin/tasks/functions/add_comment.php
+++ b/admin/tasks/functions/add_comment.php
@@ -1,0 +1,29 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) {
+  session_start();
+}
+require_once '../../../includes/php_header.php';
+require_permission('admin_task_comment','create');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+  http_response_code(405);
+  exit;
+}
+
+if (!hash_equals($_SESSION['csrf_token'] ?? '', $_POST['csrf_token'] ?? '')) {
+  die('Invalid CSRF token');
+}
+
+$task_id = isset($_POST['task_id']) ? (int)$_POST['task_id'] : 0;
+$comment = trim($_POST['comment'] ?? '');
+if (!$task_id || $comment === '') {
+  die('Missing data');
+}
+
+$pdo->prepare('INSERT INTO admin_task_comments (task_id, user_id, comment, user_updated) VALUES (:task,:uid,:comment,:uid)')
+    ->execute([':task' => $task_id, ':uid' => $this_user_id, ':comment' => $comment]);
+$cid = (int)$pdo->lastInsertId();
+
+admin_audit_log($pdo, $this_user_id, 'admin_task_comments', $cid, 'CREATE', null, json_encode(['comment'=>$comment]), 'Added comment');
+
+header('Location: ../task.php?id=' . $task_id);

--- a/admin/tasks/functions/create.php
+++ b/admin/tasks/functions/create.php
@@ -1,0 +1,57 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) {
+  session_start();
+}
+require_once '../../../includes/php_header.php';
+require_permission('admin_task','create');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+  http_response_code(405);
+  exit;
+}
+
+if (!hash_equals($_SESSION['csrf_token'] ?? '', $_POST['csrf_token'] ?? '')) {
+  die('Invalid CSRF token');
+}
+
+$name = trim($_POST['name'] ?? '');
+if ($name === '') {
+  $_SESSION['error_message'] = 'Name required';
+  header('Location: ../task.php');
+  exit;
+}
+$description = $_POST['description'] ?? null;
+$type_id = $_POST['type_id'] !== '' ? (int)$_POST['type_id'] : null;
+$category_id = $_POST['category_id'] !== '' ? (int)$_POST['category_id'] : null;
+$sub_category_id = $_POST['sub_category_id'] !== '' ? (int)$_POST['sub_category_id'] : null;
+$status_id = $_POST['status_id'] !== '' ? (int)$_POST['status_id'] : null;
+$priority_id = $_POST['priority_id'] !== '' ? (int)$_POST['priority_id'] : null;
+$start_date = $_POST['start_date'] ?? null;
+$due_date = $_POST['due_date'] ?? null;
+$memo = $_POST['memo'] ?? null;
+$assignments = isset($_POST['assignments']) ? array_map('intval', (array)$_POST['assignments']) : [];
+
+$stmt = $pdo->prepare('INSERT INTO admin_task (name, description, type_id, category_id, sub_category_id, status_id, priority_id, start_date, due_date, memo, user_id, user_updated) VALUES (:name,:description,:type_id,:category_id,:sub_category_id,:status_id,:priority_id,:start_date,:due_date,:memo,:uid,:uid)');
+$stmt->execute([
+  ':name' => $name,
+  ':description' => $description,
+  ':type_id' => $type_id,
+  ':category_id' => $category_id,
+  ':sub_category_id' => $sub_category_id,
+  ':status_id' => $status_id,
+  ':priority_id' => $priority_id,
+  ':start_date' => $start_date ?: null,
+  ':due_date' => $due_date ?: null,
+  ':memo' => $memo,
+  ':uid' => $this_user_id
+]);
+$taskId = (int)$pdo->lastInsertId();
+
+foreach ($assignments as $uid) {
+  $pdo->prepare('INSERT INTO admin_task_assignments (task_id, user_id, user_updated) VALUES (:task_id, :user_id, :uid)')
+      ->execute([':task_id' => $taskId, ':user_id' => $uid, ':uid' => $this_user_id]);
+}
+
+admin_audit_log($pdo, $this_user_id, 'admin_task', $taskId, 'CREATE', null, json_encode(['name'=>$name]), 'Created task');
+
+header('Location: ../task.php?id=' . $taskId);

--- a/admin/tasks/functions/delete.php
+++ b/admin/tasks/functions/delete.php
@@ -1,0 +1,34 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) {
+  session_start();
+}
+require_once '../../../includes/php_header.php';
+require_permission('admin_task','delete');
+
+$method = $_SERVER['REQUEST_METHOD'];
+if ($method !== 'POST' && $method !== 'GET') {
+  http_response_code(405);
+  exit;
+}
+
+$id = isset($_POST['id']) ? (int)$_POST['id'] : (int)($_GET['id'] ?? 0);
+$token = $_POST['csrf_token'] ?? ($_GET['csrf_token'] ?? '');
+if (!hash_equals($_SESSION['csrf_token'] ?? '', $token)) {
+  die('Invalid CSRF token');
+}
+if (!$id) {
+  die('Invalid ID');
+}
+
+$oldStmt = $pdo->prepare('SELECT * FROM admin_task WHERE id = :id');
+$oldStmt->execute([':id' => $id]);
+$old = $oldStmt->fetch(PDO::FETCH_ASSOC);
+
+$pdo->prepare('DELETE FROM admin_task WHERE id = :id')->execute([':id' => $id]);
+$pdo->prepare('DELETE FROM admin_task_assignments WHERE task_id = :id')->execute([':id' => $id]);
+$pdo->prepare('DELETE FROM admin_task_comments WHERE task_id = :id')->execute([':id' => $id]);
+$pdo->prepare('DELETE FROM admin_task_files WHERE task_id = :id')->execute([':id' => $id]);
+
+admin_audit_log($pdo, $this_user_id, 'admin_task', $id, 'DELETE', json_encode($old), null, 'Deleted task');
+
+header('Location: ../index.php');

--- a/admin/tasks/functions/delete_comment.php
+++ b/admin/tasks/functions/delete_comment.php
@@ -1,0 +1,29 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) {
+  session_start();
+}
+require_once '../../../includes/php_header.php';
+require_permission('admin_task_comment','delete');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+  http_response_code(405);
+  exit;
+}
+
+if (!hash_equals($_SESSION['csrf_token'] ?? '', $_POST['csrf_token'] ?? '')) {
+  die('Invalid CSRF token');
+}
+
+$id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+if (!$id) { die('Invalid ID'); }
+
+$stmt = $pdo->prepare('SELECT task_id, comment FROM admin_task_comments WHERE id = :id');
+$stmt->execute([':id' => $id]);
+$comment = $stmt->fetch(PDO::FETCH_ASSOC);
+if ($comment) {
+  $pdo->prepare('DELETE FROM admin_task_comments WHERE id = :id')->execute([':id' => $id]);
+  admin_audit_log($pdo, $this_user_id, 'admin_task_comments', $id, 'DELETE', json_encode($comment), null, 'Deleted comment');
+  header('Location: ../task.php?id=' . $comment['task_id']);
+} else {
+  header('Location: ../index.php');
+}

--- a/admin/tasks/functions/delete_file.php
+++ b/admin/tasks/functions/delete_file.php
@@ -1,0 +1,34 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) {
+  session_start();
+}
+require_once '../../../includes/php_header.php';
+require_permission('admin_task_file','delete');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+  http_response_code(405);
+  exit;
+}
+
+if (!hash_equals($_SESSION['csrf_token'] ?? '', $_POST['csrf_token'] ?? '')) {
+  die('Invalid CSRF token');
+}
+
+$id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+if (!$id) { die('Invalid ID'); }
+
+$stmt = $pdo->prepare('SELECT task_id, file_path FROM admin_task_files WHERE id = :id');
+$stmt->execute([':id' => $id]);
+$file = $stmt->fetch(PDO::FETCH_ASSOC);
+if ($file) {
+  $pdo->prepare('DELETE FROM admin_task_files WHERE id = :id')->execute([':id' => $id]);
+  $path = '../../' . basename($file['file_path']);
+  $fullPath = realpath(__DIR__ . '/../uploads/' . basename($file['file_path']));
+  if ($fullPath && file_exists($fullPath)) {
+    unlink($fullPath);
+  }
+  admin_audit_log($pdo, $this_user_id, 'admin_task_files', $id, 'DELETE', json_encode($file), null, 'Deleted file');
+  header('Location: ../task.php?id=' . $file['task_id']);
+} else {
+  header('Location: ../index.php');
+}

--- a/admin/tasks/functions/quick_add.php
+++ b/admin/tasks/functions/quick_add.php
@@ -1,0 +1,38 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) {
+  session_start();
+}
+require_once '../../../includes/php_header.php';
+require_permission('admin_task','create');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+  http_response_code(405);
+  exit;
+}
+
+if (!hash_equals($_SESSION['csrf_token'] ?? '', $_POST['csrf_token'] ?? '')) {
+  die('Invalid CSRF token');
+}
+
+$name = trim($_POST['name'] ?? '');
+if ($name === '') {
+  $_SESSION['error_message'] = 'Name required';
+  header('Location: ../index.php');
+  exit;
+}
+
+$statusStmt = $pdo->prepare("SELECT li.id FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = 'ADMIN_TASK_STATUS' AND li.code = 'NEW' LIMIT 1");
+$statusStmt->execute();
+$statusId = (int)$statusStmt->fetchColumn();
+if (!$statusId) { $statusId = null; }
+
+$stmt = $pdo->prepare('INSERT INTO admin_task (name, status_id, user_id, user_updated) VALUES (:name, :status_id, :uid, :uid)');
+$stmt->execute([':name' => $name, ':status_id' => $statusId, ':uid' => $this_user_id]);
+$taskId = (int)$pdo->lastInsertId();
+
+$pdo->prepare('INSERT INTO admin_task_assignments (task_id, user_id, user_updated) VALUES (:task,:user,:uid)')
+    ->execute([':task' => $taskId, ':user' => $this_user_id, ':uid' => $this_user_id]);
+
+admin_audit_log($pdo, $this_user_id, 'admin_task', $taskId, 'CREATE', null, json_encode(['name'=>$name]), 'Quick add');
+
+header('Location: ../index.php');

--- a/admin/tasks/functions/remove_assignment.php
+++ b/admin/tasks/functions/remove_assignment.php
@@ -1,0 +1,28 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) {
+  session_start();
+}
+require_once '../../../includes/php_header.php';
+require_permission('admin_task_assignment','delete');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+  http_response_code(405);
+  exit;
+}
+
+if (!hash_equals($_SESSION['csrf_token'] ?? '', $_POST['csrf_token'] ?? '')) {
+  die('Invalid CSRF token');
+}
+
+$task_id = isset($_POST['task_id']) ? (int)$_POST['task_id'] : 0;
+$user_id = isset($_POST['user_id']) ? (int)$_POST['user_id'] : 0;
+if (!$task_id || !$user_id) {
+  die('Missing data');
+}
+
+$pdo->prepare('DELETE FROM admin_task_assignments WHERE task_id = :task AND user_id = :user')
+    ->execute([':task' => $task_id, ':user' => $user_id]);
+
+admin_audit_log($pdo, $this_user_id, 'admin_task_assignments', $task_id, 'DELETE', json_encode(['user_id'=>$user_id]), null, 'Removed assignment');
+
+header('Location: ../task.php?id=' . $task_id);

--- a/admin/tasks/functions/update.php
+++ b/admin/tasks/functions/update.php
@@ -1,0 +1,62 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) {
+  session_start();
+}
+require_once '../../../includes/php_header.php';
+require_permission('admin_task','update');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+  http_response_code(405);
+  exit;
+}
+
+if (!hash_equals($_SESSION['csrf_token'] ?? '', $_POST['csrf_token'] ?? '')) {
+  die('Invalid CSRF token');
+}
+
+$id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+if (!$id) {
+  die('Invalid ID');
+}
+
+$oldStmt = $pdo->prepare('SELECT * FROM admin_task WHERE id = :id');
+$oldStmt->execute([':id' => $id]);
+$old = $oldStmt->fetch(PDO::FETCH_ASSOC);
+
+$name = trim($_POST['name'] ?? '');
+$description = $_POST['description'] ?? null;
+$type_id = $_POST['type_id'] !== '' ? (int)$_POST['type_id'] : null;
+$category_id = $_POST['category_id'] !== '' ? (int)$_POST['category_id'] : null;
+$sub_category_id = $_POST['sub_category_id'] !== '' ? (int)$_POST['sub_category_id'] : null;
+$status_id = $_POST['status_id'] !== '' ? (int)$_POST['status_id'] : null;
+$priority_id = $_POST['priority_id'] !== '' ? (int)$_POST['priority_id'] : null;
+$start_date = $_POST['start_date'] ?? null;
+$due_date = $_POST['due_date'] ?? null;
+$memo = $_POST['memo'] ?? null;
+$assignments = isset($_POST['assignments']) ? array_map('intval', (array)$_POST['assignments']) : [];
+
+$pdo->prepare('UPDATE admin_task SET name=:name, description=:description, type_id=:type_id, category_id=:category_id, sub_category_id=:sub_category_id, status_id=:status_id, priority_id=:priority_id, start_date=:start_date, due_date=:due_date, memo=:memo, user_updated=:uid WHERE id=:id')
+    ->execute([
+      ':name' => $name,
+      ':description' => $description,
+      ':type_id' => $type_id,
+      ':category_id' => $category_id,
+      ':sub_category_id' => $sub_category_id,
+      ':status_id' => $status_id,
+      ':priority_id' => $priority_id,
+      ':start_date' => $start_date ?: null,
+      ':due_date' => $due_date ?: null,
+      ':memo' => $memo,
+      ':uid' => $this_user_id,
+      ':id' => $id
+    ]);
+
+$pdo->prepare('DELETE FROM admin_task_assignments WHERE task_id = :id')->execute([':id' => $id]);
+foreach ($assignments as $uid) {
+  $pdo->prepare('INSERT INTO admin_task_assignments (task_id, user_id, user_updated) VALUES (:task_id,:user_id,:uid)')
+      ->execute([':task_id' => $id, ':user_id' => $uid, ':uid' => $this_user_id]);
+}
+
+admin_audit_log($pdo, $this_user_id, 'admin_task', $id, 'UPDATE', json_encode($old), json_encode(['name'=>$name]), 'Updated task');
+
+header('Location: ../task.php?id=' . $id);

--- a/admin/tasks/functions/upload_file.php
+++ b/admin/tasks/functions/upload_file.php
@@ -1,0 +1,58 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) {
+  session_start();
+}
+require_once '../../../includes/php_header.php';
+require_permission('admin_task_file','create');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+  http_response_code(405);
+  exit;
+}
+
+if (!hash_equals($_SESSION['csrf_token'] ?? '', $_POST['csrf_token'] ?? '')) {
+  die('Invalid CSRF token');
+}
+
+$task_id = isset($_POST['task_id']) ? (int)$_POST['task_id'] : 0;
+if (!$task_id || empty($_FILES['file']['name'])) {
+  die('Missing data');
+}
+
+$file = $_FILES['file'];
+if ($file['error'] !== UPLOAD_ERR_OK) {
+  die('Upload error');
+}
+if ($file['size'] > 10 * 1024 * 1024) {
+  die('File too large');
+}
+
+$finfo = finfo_open(FILEINFO_MIME_TYPE);
+$mime = finfo_file($finfo, $file['tmp_name']);
+finfo_close($finfo);
+
+$safe = preg_replace('/[^a-zA-Z0-9_-]/', '_', pathinfo($file['name'], PATHINFO_FILENAME));
+$ext = pathinfo($file['name'], PATHINFO_EXTENSION);
+$filename = $safe . '_' . time() . '.' . $ext;
+$destDir = '../uploads/';
+if (!is_dir($destDir)) { mkdir($destDir, 0755, true); }
+$dest = $destDir . $filename;
+if (!move_uploaded_file($file['tmp_name'], $dest)) {
+  die('Failed to save file');
+}
+
+$relPath = 'admin/tasks/uploads/' . $filename;
+$pdo->prepare('INSERT INTO admin_task_files (task_id, file_name, file_path, file_size, file_type, user_id, user_updated) VALUES (:task,:name,:path,:size,:type,:uid,:uid)')
+    ->execute([
+      ':task' => $task_id,
+      ':name' => $file['name'],
+      ':path' => $relPath,
+      ':size' => $file['size'],
+      ':type' => $mime,
+      ':uid' => $this_user_id
+    ]);
+$fileId = (int)$pdo->lastInsertId();
+
+admin_audit_log($pdo, $this_user_id, 'admin_task_files', $fileId, 'CREATE', null, json_encode(['file'=>$file['name']]), 'Uploaded file');
+
+header('Location: ../task.php?id=' . $task_id);

--- a/admin/tasks/index.php
+++ b/admin/tasks/index.php
@@ -1,0 +1,96 @@
+<?php
+require '../admin_header.php';
+require_permission('admin_task','read');
+
+$token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
+$_SESSION['csrf_token'] = $token;
+
+$sql = "SELECT t.id, t.name, 
+               type.label AS type_label,
+               cat.label AS category_label,
+               sub.label AS sub_category_label,
+               st.label AS status_label,
+               pr.label AS priority_label
+        FROM admin_task t
+        LEFT JOIN lookup_list_items type ON t.type_id = type.id
+        LEFT JOIN lookup_list_items cat ON t.category_id = cat.id
+        LEFT JOIN lookup_list_items sub ON t.sub_category_id = sub.id
+        LEFT JOIN lookup_list_items st ON t.status_id = st.id
+        LEFT JOIN lookup_list_items pr ON t.priority_id = pr.id
+        ORDER BY t.date_created DESC";
+$tasks = $pdo->query($sql)->fetchAll(PDO::FETCH_ASSOC);
+?>
+<h2 class="mb-4">Tasks</h2>
+<div class="mb-3 d-flex gap-2">
+  <?php if (user_has_permission('admin_task','create')): ?>
+  <button class="btn btn-sm btn-success" data-bs-toggle="modal" data-bs-target="#taskModal">Add Task</button>
+  <?php endif; ?>
+  <?php if (user_has_permission('admin_task','create')): ?>
+  <form class="d-flex gap-2" method="post" action="functions/quick_add.php">
+    <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+    <input class="form-control form-control-sm" type="text" name="name" placeholder="Quick Add" required>
+    <button class="btn btn-sm btn-primary" type="submit">Add</button>
+  </form>
+  <?php endif; ?>
+</div>
+<div id="tasks" data-list='{"valueNames":["id","name","type","category","subcategory","status","priority"],"page":25,"pagination":true}'>
+  <div class="row justify-content-between g-2 mb-3">
+    <div class="col-auto">
+      <input class="form-control form-control-sm search" placeholder="Search" />
+    </div>
+  </div>
+  <div class="table-responsive">
+    <table class="table table-striped table-sm mb-0">
+      <thead>
+        <tr>
+          <th class="sort" data-sort="id">ID</th>
+          <th class="sort" data-sort="name">Name</th>
+          <th class="sort" data-sort="type">Type</th>
+          <th class="sort" data-sort="category">Category</th>
+          <th class="sort" data-sort="subcategory">Sub Category</th>
+          <th class="sort" data-sort="status">Status</th>
+          <th class="sort" data-sort="priority">Priority</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody class="list">
+        <?php foreach($tasks as $t): ?>
+        <tr>
+          <td class="id"><?= htmlspecialchars($t['id']); ?></td>
+          <td class="name"><?= htmlspecialchars($t['name']); ?></td>
+          <td class="type"><?= htmlspecialchars($t['type_label']); ?></td>
+          <td class="category"><?= htmlspecialchars($t['category_label']); ?></td>
+          <td class="subcategory"><?= htmlspecialchars($t['sub_category_label']); ?></td>
+          <td class="status"><?= htmlspecialchars($t['status_label']); ?></td>
+          <td class="priority"><?= htmlspecialchars($t['priority_label']); ?></td>
+          <td>
+            <a class="btn btn-sm btn-warning" href="task.php?id=<?= $t['id']; ?>">Edit</a>
+            <?php if (user_has_permission('admin_task','delete')): ?>
+            <form method="post" action="functions/delete.php" class="d-inline" onsubmit="return confirm('Delete this task?');">
+              <input type="hidden" name="id" value="<?= $t['id']; ?>">
+              <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+              <button class="btn btn-sm btn-danger">Delete</button>
+            </form>
+            <?php endif; ?>
+          </td>
+        </tr>
+        <?php endforeach; ?>
+      </tbody>
+    </table>
+  </div>
+  <div class="d-flex justify-content-between align-items-center mt-3">
+    <p class="mb-0" data-list-info></p>
+    <ul class="pagination mb-0"></ul>
+  </div>
+</div>
+
+<div class="modal fade" id="taskModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-body p-0">
+        <iframe src="task.php" class="w-100" style="height:600px;border:0"></iframe>
+      </div>
+    </div>
+  </div>
+</div>
+<?php require '../admin_footer.php'; ?>

--- a/admin/tasks/task.php
+++ b/admin/tasks/task.php
@@ -1,0 +1,218 @@
+<?php
+require '../admin_header.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$editing = $id > 0;
+
+if ($editing) {
+  require_permission('admin_task','update');
+  $stmt = $pdo->prepare('SELECT * FROM admin_task WHERE id = :id');
+  $stmt->execute([':id' => $id]);
+  $task = $stmt->fetch(PDO::FETCH_ASSOC);
+  if (!$task) {
+    echo '<div class="alert alert-danger">Task not found.</div>';
+    require '../admin_footer.php';
+    exit;
+  }
+} else {
+  require_permission('admin_task','create');
+  $task = [
+    'name' => '',
+    'description' => '',
+    'type_id' => null,
+    'category_id' => null,
+    'sub_category_id' => null,
+    'status_id' => null,
+    'priority_id' => null,
+    'start_date' => null,
+    'due_date' => null,
+    'memo' => null
+  ];
+}
+
+$types = get_lookup_items($pdo, 'ADMIN_TASK_TYPE');
+$categories = get_lookup_items($pdo, 'ADMIN_TASK_CATEGORY');
+$subcategories = get_lookup_items($pdo, 'ADMIN_TASK_SUB_CATEGORY');
+$statuses = get_lookup_items($pdo, 'ADMIN_TASK_STATUS');
+$priorities = get_lookup_items($pdo, 'ADMIN_TASK_PRIORITY');
+
+$userStmt = $pdo->query('SELECT id, email FROM users ORDER BY email');
+$users = $userStmt->fetchAll(PDO::FETCH_ASSOC);
+
+$assignedIds = [];
+if ($editing) {
+  $assStmt = $pdo->prepare('SELECT user_id FROM admin_task_assignments WHERE task_id = :id');
+  $assStmt->execute([':id' => $id]);
+  $assignedIds = $assStmt->fetchAll(PDO::FETCH_COLUMN);
+}
+
+$comments = [];
+if ($editing) {
+  $cstmt = $pdo->prepare('SELECT c.id, c.comment, u.email, c.date_created FROM admin_task_comments c JOIN users u ON c.user_id = u.id WHERE c.task_id = :id ORDER BY c.date_created');
+  $cstmt->execute([':id' => $id]);
+  $comments = $cstmt->fetchAll(PDO::FETCH_ASSOC);
+}
+
+$files = [];
+if ($editing) {
+  $fstmt = $pdo->prepare('SELECT id, file_name, file_path FROM admin_task_files WHERE task_id = :id ORDER BY date_created');
+  $fstmt->execute([':id' => $id]);
+  $files = $fstmt->fetchAll(PDO::FETCH_ASSOC);
+}
+
+$token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
+$_SESSION['csrf_token'] = $token;
+?>
+<h2 class="mb-4"><?= $editing ? 'Edit Task' : 'Add Task'; ?></h2>
+<form method="post" action="functions/<?= $editing ? 'update' : 'create'; ?>.php">
+  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+  <?php if ($editing): ?>
+  <input type="hidden" name="id" value="<?= $id; ?>">
+  <?php endif; ?>
+  <div class="mb-3">
+    <label class="form-label">Name</label>
+    <input type="text" name="name" class="form-control" value="<?= htmlspecialchars($task['name']); ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Description</label>
+    <textarea name="description" class="form-control" rows="3"><?= htmlspecialchars($task['description']); ?></textarea>
+  </div>
+  <div class="row mb-3">
+    <div class="col">
+      <label class="form-label">Type</label>
+      <select name="type_id" class="form-select">
+        <option value="">--</option>
+        <?php foreach ($types as $i): ?>
+        <option value="<?= $i['id']; ?>" <?= $task['type_id'] == $i['id'] ? 'selected' : ''; ?>><?= htmlspecialchars($i['label']); ?></option>
+        <?php endforeach; ?>
+      </select>
+    </div>
+    <div class="col">
+      <label class="form-label">Category</label>
+      <select name="category_id" class="form-select">
+        <option value="">--</option>
+        <?php foreach ($categories as $i): ?>
+        <option value="<?= $i['id']; ?>" <?= $task['category_id'] == $i['id'] ? 'selected' : ''; ?>><?= htmlspecialchars($i['label']); ?></option>
+        <?php endforeach; ?>
+      </select>
+    </div>
+    <div class="col">
+      <label class="form-label">Sub Category</label>
+      <select name="sub_category_id" class="form-select">
+        <option value="">--</option>
+        <?php foreach ($subcategories as $i): ?>
+        <option value="<?= $i['id']; ?>" <?= $task['sub_category_id'] == $i['id'] ? 'selected' : ''; ?>><?= htmlspecialchars($i['label']); ?></option>
+        <?php endforeach; ?>
+      </select>
+    </div>
+  </div>
+  <div class="row mb-3">
+    <div class="col">
+      <label class="form-label">Status</label>
+      <select name="status_id" class="form-select">
+        <option value="">--</option>
+        <?php foreach ($statuses as $i): ?>
+        <option value="<?= $i['id']; ?>" <?= $task['status_id'] == $i['id'] ? 'selected' : ''; ?>><?= htmlspecialchars($i['label']); ?></option>
+        <?php endforeach; ?>
+      </select>
+    </div>
+    <div class="col">
+      <label class="form-label">Priority</label>
+      <select name="priority_id" class="form-select">
+        <option value="">--</option>
+        <?php foreach ($priorities as $i): ?>
+        <option value="<?= $i['id']; ?>" <?= $task['priority_id'] == $i['id'] ? 'selected' : ''; ?>><?= htmlspecialchars($i['label']); ?></option>
+        <?php endforeach; ?>
+      </select>
+    </div>
+  </div>
+  <div class="row mb-3">
+    <div class="col">
+      <label class="form-label">Start Date</label>
+      <input type="date" name="start_date" class="form-control" value="<?= htmlspecialchars($task['start_date']); ?>">
+    </div>
+    <div class="col">
+      <label class="form-label">Due Date</label>
+      <input type="date" name="due_date" class="form-control" value="<?= htmlspecialchars($task['due_date']); ?>">
+    </div>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Assign Users</label>
+    <select name="assignments[]" class="form-select" multiple>
+      <?php foreach ($users as $u): ?>
+      <option value="<?= $u['id']; ?>" <?= in_array($u['id'], $assignedIds) ? 'selected' : ''; ?>><?= htmlspecialchars($u['email']); ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Memo</label>
+    <textarea name="memo" class="form-control" rows="2"><?= htmlspecialchars($task['memo']); ?></textarea>
+  </div>
+  <div class="mb-3">
+    <button class="btn btn-sm btn-primary" type="submit">Save</button>
+    <?php if ($editing && user_has_permission('admin_task','delete')): ?>
+    <a href="functions/delete.php?id=<?= $id; ?>&csrf_token=<?= $token; ?>" class="btn btn-sm btn-danger" onclick="return confirm('Delete this task?');">Delete</a>
+    <?php endif; ?>
+  </div>
+</form>
+
+<?php if ($editing): ?>
+<hr>
+<h5>Files</h5>
+<ul class="list-unstyled">
+  <?php foreach ($files as $f): ?>
+  <li>
+    <a href="../tasks/uploads/<?= htmlspecialchars(basename($f['file_path'])); ?>" target="_blank"><?= htmlspecialchars($f['file_name']); ?></a>
+    <?php if (user_has_permission('admin_task_file','delete')): ?>
+    <form method="post" action="functions/delete_file.php" class="d-inline">
+      <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+      <input type="hidden" name="id" value="<?= $f['id']; ?>">
+      <button class="btn btn-sm btn-link text-danger">Delete</button>
+    </form>
+    <?php endif; ?>
+  </li>
+  <?php endforeach; ?>
+</ul>
+<?php if (user_has_permission('admin_task_file','create')): ?>
+<form method="post" action="functions/upload_file.php" enctype="multipart/form-data" class="mb-3">
+  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+  <input type="hidden" name="task_id" value="<?= $id; ?>">
+  <input type="file" name="file" required>
+  <button class="btn btn-sm btn-secondary">Upload</button>
+</form>
+<?php endif; ?>
+<hr>
+<h5>Comments</h5>
+<ul class="list-unstyled">
+  <?php foreach ($comments as $c): ?>
+  <li class="mb-2">
+    <strong><?= htmlspecialchars($c['email']); ?>:</strong>
+    <?= nl2br(htmlspecialchars($c['comment'])); ?>
+    <?php if (user_has_permission('admin_task_comment','delete')): ?>
+    <form method="post" action="functions/delete_comment.php" class="d-inline">
+      <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+      <input type="hidden" name="id" value="<?= $c['id']; ?>">
+      <button class="btn btn-sm btn-link text-danger">Delete</button>
+    </form>
+    <?php endif; ?>
+  </li>
+  <?php endforeach; ?>
+</ul>
+<?php if (user_has_permission('admin_task_comment','create')): ?>
+<form method="post" action="functions/add_comment.php" class="mb-3">
+  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+  <input type="hidden" name="task_id" value="<?= $id; ?>">
+  <textarea name="comment" class="form-control" rows="2" required></textarea>
+  <button class="btn btn-sm btn-secondary mt-2">Add Comment</button>
+</form>
+<?php endif; ?>
+<hr>
+<h5>Related Records</h5>
+<div id="relations">
+  <div class="row g-2 align-items-center mb-2">
+    <div class="col"><input type="text" name="relation_module[]" class="form-control" placeholder="Module"></div>
+    <div class="col"><input type="text" name="relation_record_id[]" class="form-control" placeholder="Record ID"></div>
+  </div>
+</div>
+<?php endif; ?>
+<?php require '../admin_footer.php'; ?>


### PR DESCRIPTION
## Summary
- Add admin tasks index with Phoenix list, quick add, and modal create
- Implement task detail form with assignments, files, comments, and relation placeholders
- Provide backend handlers for CRUD, assignments, files, comments, and quick add

## Testing
- `find admin/tasks -name "*.php" -print0 | xargs -0 -I{} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_68ad19d108fc83339e1fdbdd01179716