### PR TITLE
Add admin tasks tables and permissions

### DIFF
--- a/_SQL/20240928_admin_tasks.sql
+++ b/_SQL/20240928_admin_tasks.sql
@@ -1,0 +1,152 @@
+-- Admin task management tables and permissions
+
+CREATE TABLE `admin_task` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT CURRENT_TIMESTAMP,
+  `date_updated` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `memo` text DEFAULT NULL,
+  `name` varchar(255) NOT NULL,
+  `description` text DEFAULT NULL,
+  `type_id` int(11) DEFAULT NULL,
+  `category_id` int(11) DEFAULT NULL,
+  `sub_category_id` int(11) DEFAULT NULL,
+  `status_id` int(11) DEFAULT NULL,
+  `priority_id` int(11) DEFAULT NULL,
+  `start_date` datetime DEFAULT NULL,
+  `due_date` datetime DEFAULT NULL,
+  `is_completed` tinyint(1) DEFAULT 0,
+  `completed_date` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `fk_admin_task_user_id` (`user_id`),
+  KEY `fk_admin_task_user_updated` (`user_updated`),
+  KEY `fk_admin_task_type_id` (`type_id`),
+  KEY `fk_admin_task_category_id` (`category_id`),
+  KEY `fk_admin_task_sub_category_id` (`sub_category_id`),
+  KEY `fk_admin_task_status_id` (`status_id`),
+  KEY `fk_admin_task_priority_id` (`priority_id`),
+  CONSTRAINT `fk_admin_task_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `fk_admin_task_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `fk_admin_task_type_id` FOREIGN KEY (`type_id`) REFERENCES `lookup_list_items` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `fk_admin_task_category_id` FOREIGN KEY (`category_id`) REFERENCES `lookup_list_items` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `fk_admin_task_sub_category_id` FOREIGN KEY (`sub_category_id`) REFERENCES `lookup_list_items` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `fk_admin_task_status_id` FOREIGN KEY (`status_id`) REFERENCES `lookup_list_items` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `fk_admin_task_priority_id` FOREIGN KEY (`priority_id`) REFERENCES `lookup_list_items` (`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `admin_task_assignments` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT CURRENT_TIMESTAMP,
+  `date_updated` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `memo` text DEFAULT NULL,
+  `task_id` int(11) NOT NULL,
+  `assigned_user_id` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `fk_admin_task_assignments_user_id` (`user_id`),
+  KEY `fk_admin_task_assignments_user_updated` (`user_updated`),
+  KEY `fk_admin_task_assignments_task_id` (`task_id`),
+  KEY `fk_admin_task_assignments_assigned_user_id` (`assigned_user_id`),
+  CONSTRAINT `fk_admin_task_assignments_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `fk_admin_task_assignments_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `fk_admin_task_assignments_task_id` FOREIGN KEY (`task_id`) REFERENCES `admin_task` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_admin_task_assignments_assigned_user_id` FOREIGN KEY (`assigned_user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `admin_task_files` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT CURRENT_TIMESTAMP,
+  `date_updated` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `memo` text DEFAULT NULL,
+  `task_id` int(11) NOT NULL,
+  `file_name` varchar(255) NOT NULL,
+  `file_path` varchar(255) DEFAULT NULL,
+  `file_size` int(11) DEFAULT NULL,
+  `mime_type` varchar(100) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `fk_admin_task_files_user_id` (`user_id`),
+  KEY `fk_admin_task_files_user_updated` (`user_updated`),
+  KEY `fk_admin_task_files_task_id` (`task_id`),
+  CONSTRAINT `fk_admin_task_files_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `fk_admin_task_files_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `fk_admin_task_files_task_id` FOREIGN KEY (`task_id`) REFERENCES `admin_task` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `admin_task_comments` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT CURRENT_TIMESTAMP,
+  `date_updated` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `memo` text DEFAULT NULL,
+  `task_id` int(11) NOT NULL,
+  `comment_text` text NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `fk_admin_task_comments_user_id` (`user_id`),
+  KEY `fk_admin_task_comments_user_updated` (`user_updated`),
+  KEY `fk_admin_task_comments_task_id` (`task_id`),
+  CONSTRAINT `fk_admin_task_comments_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `fk_admin_task_comments_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `fk_admin_task_comments_task_id` FOREIGN KEY (`task_id`) REFERENCES `admin_task` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `admin_task_relations` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT CURRENT_TIMESTAMP,
+  `date_updated` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `memo` text DEFAULT NULL,
+  `task_id` int(11) NOT NULL,
+  `related_module` varchar(255) NOT NULL,
+  `related_id` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `fk_admin_task_relations_user_id` (`user_id`),
+  KEY `fk_admin_task_relations_user_updated` (`user_updated`),
+  KEY `fk_admin_task_relations_task_id` (`task_id`),
+  CONSTRAINT `fk_admin_task_relations_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `fk_admin_task_relations_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `fk_admin_task_relations_task_id` FOREIGN KEY (`task_id`) REFERENCES `admin_task` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- Seed navigation link
+INSERT INTO admin_navigation_links (title, path, icon, sort_order, user_id, user_updated)
+VALUES ('Tasks', 'tasks/index.php', 'check-square', 13, 1, 1);
+
+-- RBAC seed
+INSERT INTO admin_permission_groups (user_id, user_updated, name, description)
+VALUES (1,1,'Admin Tasks','Permissions for managing administrative tasks');
+
+INSERT INTO admin_permissions (user_id, user_updated, module, action) VALUES
+  (1,1,'admin_task','create'),
+  (1,1,'admin_task','read'),
+  (1,1,'admin_task','update'),
+  (1,1,'admin_task','delete'),
+  (1,1,'admin_task_assignment','create'),
+  (1,1,'admin_task_assignment','read'),
+  (1,1,'admin_task_assignment','update'),
+  (1,1,'admin_task_assignment','delete'),
+  (1,1,'admin_task_file','create'),
+  (1,1,'admin_task_file','read'),
+  (1,1,'admin_task_file','update'),
+  (1,1,'admin_task_file','delete'),
+  (1,1,'admin_task_comment','create'),
+  (1,1,'admin_task_comment','read'),
+  (1,1,'admin_task_comment','update'),
+  (1,1,'admin_task_comment','delete');
+
+INSERT INTO admin_permission_group_permissions (user_id, user_updated, permission_group_id, permission_id)
+SELECT 1,1,pg.id,p.id
+FROM admin_permission_groups pg
+JOIN admin_permissions p ON p.module IN ('admin_task','admin_task_assignment','admin_task_file','admin_task_comment')
+WHERE pg.name='Admin Tasks';
+
+INSERT INTO admin_role_permissions (user_id, user_updated, role_id, permission_group_id)
+SELECT 1,1,1,pg.id FROM admin_permission_groups pg WHERE pg.name='Admin Tasks';
+
+INSERT INTO admin_role_permission_groups (user_id, user_updated, role_id, permission_group_id)
+SELECT 1,1,1,pg.id FROM admin_permission_groups pg WHERE pg.name='Admin Tasks';

--- a/_SQL/atlis.sql
+++ b/_SQL/atlis.sql
@@ -290,6 +290,9 @@ INSERT INTO `admin_navigation_links` (`id`, `title`, `path`, `icon`, `sort_order
 (13, 'Products & Services', 'products-services/index.php', 'box', 9, 1, 1, '2025-08-27 00:00:00', '2025-08-25 00:43:46', NULL),
 (15, 'Finances', 'finances/index.php', 'dollar-sign', 12, 1, 1, '2025-08-25 00:40:13', '2025-08-25 00:43:46', NULL);
 
+INSERT INTO admin_navigation_links (title, path, icon, sort_order, user_id, user_updated, date_created, date_updated, memo)
+VALUES ('Tasks', 'tasks/index.php', 'check-square', 13, 1, 1, '2025-09-01 00:00:00', '2025-09-01 00:00:00', NULL);
+
 -- --------------------------------------------------------
 
 --
@@ -402,6 +405,24 @@ INSERT INTO `admin_permissions` (`id`, `user_id`, `user_updated`, `date_created`
 (92, 1, 1, '2025-08-24 23:53:15', '2025-08-24 23:53:15', NULL, 'sow', 'delete'),
 (93, 1, 1, '2025-08-25 00:19:00', '2025-08-25 00:19:00', NULL, 'calendar', 'sync');
 
+INSERT INTO admin_permissions (user_id, user_updated, date_created, date_updated, memo, module, action) VALUES
+  (1,1,'2025-09-01 00:00:00','2025-09-01 00:00:00',NULL,'admin_task','create'),
+  (1,1,'2025-09-01 00:00:00','2025-09-01 00:00:00',NULL,'admin_task','read'),
+  (1,1,'2025-09-01 00:00:00','2025-09-01 00:00:00',NULL,'admin_task','update'),
+  (1,1,'2025-09-01 00:00:00','2025-09-01 00:00:00',NULL,'admin_task','delete'),
+  (1,1,'2025-09-01 00:00:00','2025-09-01 00:00:00',NULL,'admin_task_assignment','create'),
+  (1,1,'2025-09-01 00:00:00','2025-09-01 00:00:00',NULL,'admin_task_assignment','read'),
+  (1,1,'2025-09-01 00:00:00','2025-09-01 00:00:00',NULL,'admin_task_assignment','update'),
+  (1,1,'2025-09-01 00:00:00','2025-09-01 00:00:00',NULL,'admin_task_assignment','delete'),
+  (1,1,'2025-09-01 00:00:00','2025-09-01 00:00:00',NULL,'admin_task_file','create'),
+  (1,1,'2025-09-01 00:00:00','2025-09-01 00:00:00',NULL,'admin_task_file','read'),
+  (1,1,'2025-09-01 00:00:00','2025-09-01 00:00:00',NULL,'admin_task_file','update'),
+  (1,1,'2025-09-01 00:00:00','2025-09-01 00:00:00',NULL,'admin_task_file','delete'),
+  (1,1,'2025-09-01 00:00:00','2025-09-01 00:00:00',NULL,'admin_task_comment','create'),
+  (1,1,'2025-09-01 00:00:00','2025-09-01 00:00:00',NULL,'admin_task_comment','read'),
+  (1,1,'2025-09-01 00:00:00','2025-09-01 00:00:00',NULL,'admin_task_comment','update'),
+  (1,1,'2025-09-01 00:00:00','2025-09-01 00:00:00',NULL,'admin_task_comment','delete');
+
 -- --------------------------------------------------------
 
 --
@@ -440,6 +461,9 @@ INSERT INTO `admin_permission_groups` (`id`, `user_id`, `user_updated`, `date_cr
 (15, 1, 1, '2025-08-26 00:00:00', '2025-08-26 00:00:00', NULL, 'Meetings', 'Permissions for managing meetings'),
 (16, 1, 1, '2025-08-27 00:00:00', '2025-08-27 00:00:00', NULL, 'Products & Services', 'Permissions for managing products and services'),
 (17, 1, 1, '2025-08-24 23:53:15', '2025-08-24 23:53:15', NULL, 'Finances', 'Permissions for finance module');
+
+INSERT INTO admin_permission_groups (user_id, user_updated, date_created, date_updated, memo, name, description)
+VALUES (1,1,'2025-09-01 00:00:00','2025-09-01 00:00:00',NULL,'Admin Tasks','Permissions for managing administrative tasks');
 
 -- --------------------------------------------------------
 
@@ -553,6 +577,12 @@ INSERT INTO `admin_permission_group_permissions` (`id`, `user_id`, `user_updated
 (92, 1, 1, '2025-08-24 23:53:15', '2025-08-24 23:53:15', NULL, 17, 91),
 (100, 1, 1, '2025-08-25 00:19:00', '2025-08-25 00:19:00', NULL, 13, 93);
 
+INSERT INTO admin_permission_group_permissions (user_id, user_updated, permission_group_id, permission_id)
+SELECT 1,1,pg.id,p.id
+FROM admin_permission_groups pg
+JOIN admin_permissions p ON p.module IN ('admin_task','admin_task_assignment','admin_task_file','admin_task_comment')
+WHERE pg.name='Admin Tasks';
+
 -- --------------------------------------------------------
 
 --
@@ -651,6 +681,9 @@ INSERT INTO `admin_role_permissions` (`id`, `user_id`, `user_updated`, `date_cre
 (44, 1, 1, '2025-08-27 00:00:00', '2025-08-27 00:00:00', NULL, 1, 16),
 (45, 1, 1, '2025-08-27 00:00:00', '2025-08-27 00:00:00', NULL, 15, 16);
 
+INSERT INTO admin_role_permissions (user_id, user_updated, date_created, date_updated, memo, role_id, permission_group_id)
+SELECT 1,1,'2025-09-01 00:00:00','2025-09-01 00:00:00',NULL,1,pg.id FROM admin_permission_groups pg WHERE pg.name='Admin Tasks';
+
 -- --------------------------------------------------------
 
 --
@@ -707,6 +740,9 @@ INSERT INTO `admin_role_permission_groups` (`id`, `user_id`, `user_updated`, `da
 (41, 1, 1, '2025-08-24 00:00:00', '2025-08-24 00:00:00', NULL, 12, 13),
 (42, 1, 1, '2025-08-27 00:00:00', '2025-08-27 00:00:00', NULL, 1, 16),
 (43, 1, 1, '2025-08-27 00:00:00', '2025-08-27 00:00:00', NULL, 15, 16);
+
+INSERT INTO admin_role_permission_groups (user_id, user_updated, date_created, date_updated, memo, role_id, permission_group_id)
+SELECT 1,1,'2025-09-01 00:00:00','2025-09-01 00:00:00',NULL,1,pg.id FROM admin_permission_groups pg WHERE pg.name='Admin Tasks';
 
 -- --------------------------------------------------------
 
@@ -3380,6 +3416,123 @@ INSERT INTO `users_profile_pics` (`id`, `user_id`, `user_updated`, `date_created
 (4, 1, 1, '2025-08-21 22:14:15', '2025-08-22 08:26:16', NULL, '1_1755836055.JPEG', 'module/users/uploads/1_1755836055.JPEG', 143231, 'image/jpeg', 'f692123980cc18e618350c55f549f246d2cf73cf6e0632142019eb27bb34df3e', 513, 458, 1, 82),
 (5, 1, 1, '2025-08-22 08:26:01', '2025-08-22 08:26:16', NULL, '535471462_1222365166585268_6061415345364469578_n_1755872761.JPEG', 'module/users/uploads/535471462_1222365166585268_6061415345364469578_n_1755872761.JPEG', 72399, 'image/jpeg', 'db5dc9b5e63e2d99f123f9e42ab5f902239c4f8f9ba2674c54e2084159fc5a51', 600, 596, 1, 83);
 
+-- Table structure for table `admin_task`
+--
+
+CREATE TABLE `admin_task` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT current_timestamp(),
+  `date_updated` datetime DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  `memo` text DEFAULT NULL,
+  `name` varchar(255) NOT NULL,
+  `description` text DEFAULT NULL,
+  `type_id` int(11) DEFAULT NULL,
+  `category_id` int(11) DEFAULT NULL,
+  `sub_category_id` int(11) DEFAULT NULL,
+  `status_id` int(11) DEFAULT NULL,
+  `priority_id` int(11) DEFAULT NULL,
+  `start_date` datetime DEFAULT NULL,
+  `due_date` datetime DEFAULT NULL,
+  `is_completed` tinyint(1) DEFAULT 0,
+  `completed_date` datetime DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+--
+-- Dumping data for table `admin_task`
+--
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `admin_task_assignments`
+--
+
+CREATE TABLE `admin_task_assignments` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT current_timestamp(),
+  `date_updated` datetime DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  `memo` text DEFAULT NULL,
+  `task_id` int(11) NOT NULL,
+  `assigned_user_id` int(11) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+--
+-- Dumping data for table `admin_task_assignments`
+--
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `admin_task_files`
+--
+
+CREATE TABLE `admin_task_files` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT current_timestamp(),
+  `date_updated` datetime DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  `memo` text DEFAULT NULL,
+  `task_id` int(11) NOT NULL,
+  `file_name` varchar(255) NOT NULL,
+  `file_path` varchar(255) DEFAULT NULL,
+  `file_size` int(11) DEFAULT NULL,
+  `mime_type` varchar(100) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+--
+-- Dumping data for table `admin_task_files`
+--
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `admin_task_comments`
+--
+
+CREATE TABLE `admin_task_comments` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT current_timestamp(),
+  `date_updated` datetime DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  `memo` text DEFAULT NULL,
+  `task_id` int(11) NOT NULL,
+  `comment_text` text NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+--
+-- Dumping data for table `admin_task_comments`
+--
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `admin_task_relations`
+--
+
+CREATE TABLE `admin_task_relations` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT current_timestamp(),
+  `date_updated` datetime DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  `memo` text DEFAULT NULL,
+  `task_id` int(11) NOT NULL,
+  `related_module` varchar(255) NOT NULL,
+  `related_id` int(11) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+--
+-- Dumping data for table `admin_task_relations`
+--
+
+-- --------------------------------------------------------
+
 --
 -- Indexes for dumped tables
 --
@@ -4073,6 +4226,51 @@ ALTER TABLE `users_profile_pics`
   ADD KEY `fk_users_profile_pics_uploaded_by` (`uploaded_by`),
   ADD KEY `fk_users_profile_pics_status_id` (`status_id`);
 
+-- Indexes for table `admin_task`
+--
+ALTER TABLE `admin_task`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `fk_admin_task_user_id` (`user_id`),
+  ADD KEY `fk_admin_task_user_updated` (`user_updated`),
+  ADD KEY `fk_admin_task_type_id` (`type_id`),
+  ADD KEY `fk_admin_task_category_id` (`category_id`),
+  ADD KEY `fk_admin_task_sub_category_id` (`sub_category_id`),
+  ADD KEY `fk_admin_task_status_id` (`status_id`),
+  ADD KEY `fk_admin_task_priority_id` (`priority_id`);
+
+-- Indexes for table `admin_task_assignments`
+--
+ALTER TABLE `admin_task_assignments`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `fk_admin_task_assignments_user_id` (`user_id`),
+  ADD KEY `fk_admin_task_assignments_user_updated` (`user_updated`),
+  ADD KEY `fk_admin_task_assignments_task_id` (`task_id`),
+  ADD KEY `fk_admin_task_assignments_assigned_user_id` (`assigned_user_id`);
+
+-- Indexes for table `admin_task_files`
+--
+ALTER TABLE `admin_task_files`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `fk_admin_task_files_user_id` (`user_id`),
+  ADD KEY `fk_admin_task_files_user_updated` (`user_updated`),
+  ADD KEY `fk_admin_task_files_task_id` (`task_id`);
+
+-- Indexes for table `admin_task_comments`
+--
+ALTER TABLE `admin_task_comments`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `fk_admin_task_comments_user_id` (`user_id`),
+  ADD KEY `fk_admin_task_comments_user_updated` (`user_updated`),
+  ADD KEY `fk_admin_task_comments_task_id` (`task_id`);
+
+-- Indexes for table `admin_task_relations`
+--
+ALTER TABLE `admin_task_relations`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `fk_admin_task_relations_user_id` (`user_id`),
+  ADD KEY `fk_admin_task_relations_user_updated` (`user_updated`),
+  ADD KEY `fk_admin_task_relations_task_id` (`task_id`);
+
 --
 -- AUTO_INCREMENT for dumped tables
 --
@@ -4490,6 +4688,7 @@ ALTER TABLE `users_2fa`
 --
 ALTER TABLE `users_profile_pics`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=6;
+
 
 --
 -- Constraints for dumped tables
@@ -4962,6 +5161,51 @@ ALTER TABLE `person_skills`
   ADD CONSTRAINT `fk_person_skills_skill_id` FOREIGN KEY (`skill_id`) REFERENCES `lookup_list_items` (`id`),
   ADD CONSTRAINT `fk_person_skills_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
   ADD CONSTRAINT `fk_person_skills_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`) ON DELETE SET NULL;
+
+--
+-- Constraints for table `admin_task`
+--
+ALTER TABLE `admin_task`
+  ADD CONSTRAINT `fk_admin_task_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  ADD CONSTRAINT `fk_admin_task_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  ADD CONSTRAINT `fk_admin_task_type_id` FOREIGN KEY (`type_id`) REFERENCES `lookup_list_items` (`id`) ON DELETE SET NULL,
+  ADD CONSTRAINT `fk_admin_task_category_id` FOREIGN KEY (`category_id`) REFERENCES `lookup_list_items` (`id`) ON DELETE SET NULL,
+  ADD CONSTRAINT `fk_admin_task_sub_category_id` FOREIGN KEY (`sub_category_id`) REFERENCES `lookup_list_items` (`id`) ON DELETE SET NULL,
+  ADD CONSTRAINT `fk_admin_task_status_id` FOREIGN KEY (`status_id`) REFERENCES `lookup_list_items` (`id`) ON DELETE SET NULL,
+  ADD CONSTRAINT `fk_admin_task_priority_id` FOREIGN KEY (`priority_id`) REFERENCES `lookup_list_items` (`id`) ON DELETE SET NULL;
+
+--
+-- Constraints for table `admin_task_assignments`
+--
+ALTER TABLE `admin_task_assignments`
+  ADD CONSTRAINT `fk_admin_task_assignments_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  ADD CONSTRAINT `fk_admin_task_assignments_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  ADD CONSTRAINT `fk_admin_task_assignments_task_id` FOREIGN KEY (`task_id`) REFERENCES `admin_task` (`id`) ON DELETE CASCADE,
+  ADD CONSTRAINT `fk_admin_task_assignments_assigned_user_id` FOREIGN KEY (`assigned_user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE;
+
+--
+-- Constraints for table `admin_task_files`
+--
+ALTER TABLE `admin_task_files`
+  ADD CONSTRAINT `fk_admin_task_files_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  ADD CONSTRAINT `fk_admin_task_files_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  ADD CONSTRAINT `fk_admin_task_files_task_id` FOREIGN KEY (`task_id`) REFERENCES `admin_task` (`id`) ON DELETE CASCADE;
+
+--
+-- Constraints for table `admin_task_comments`
+--
+ALTER TABLE `admin_task_comments`
+  ADD CONSTRAINT `fk_admin_task_comments_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  ADD CONSTRAINT `fk_admin_task_comments_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  ADD CONSTRAINT `fk_admin_task_comments_task_id` FOREIGN KEY (`task_id`) REFERENCES `admin_task` (`id`) ON DELETE CASCADE;
+
+--
+-- Constraints for table `admin_task_relations`
+--
+ALTER TABLE `admin_task_relations`
+  ADD CONSTRAINT `fk_admin_task_relations_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  ADD CONSTRAINT `fk_admin_task_relations_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  ADD CONSTRAINT `fk_admin_task_relations_task_id` FOREIGN KEY (`task_id`) REFERENCES `admin_task` (`id`) ON DELETE CASCADE;
 
 --
 -- Constraints for table `users`


### PR DESCRIPTION
## Summary
- define admin task tables with assignments, files, comments, and relations
- seed tasks navigation link and RBAC entries without hard-coded primary keys
- ensure master schema uses auto-increment primary keys for admin task tables

## Testing
- ❌ `mysql -uroot --socket=/tmp/mysql.sock atlis < _SQL/20240928_admin_tasks.sql` (Can't connect to local server through socket '/tmp/mysql.sock')
- ❌ `mysql -uroot --socket=/tmp/mysql.sock atlis -e "SHOW TABLES;"` (Can't connect to local server through socket '/tmp/mysql.sock')
- ❌ `mysql -uroot --socket=/tmp/mysql.sock atlis -e "SHOW CREATE TABLE admin_task\G"` (Can't connect to local server through socket '/tmp/mysql.sock')

------
https://chatgpt.com/codex/tasks/task_e_68ad19d4a66c8333bc512b2723747b99