### PR TITLE
Fix task assignment handling

### DIFF
--- a/admin/tasks/functions/add_assignment.php
+++ b/admin/tasks/functions/add_assignment.php
@@ -15,14 +15,18 @@ if (!hash_equals($_SESSION['csrf_token'] ?? '', $_POST['csrf_token'] ?? '')) {
 }
 
 $task_id = isset($_POST['task_id']) ? (int)$_POST['task_id'] : 0;
-$user_id = isset($_POST['user_id']) ? (int)$_POST['user_id'] : 0;
-if (!$task_id || !$user_id) {
+$assigned_user_id = isset($_POST['user_id']) ? (int)$_POST['user_id'] : 0;
+if (!$task_id || !$assigned_user_id) {
   die('Missing data');
 }
 
-$pdo->prepare('INSERT INTO admin_task_assignments (task_id, user_id, user_updated) VALUES (:task,:user,:uid)')
-    ->execute([':task' => $task_id, ':user' => $user_id, ':uid' => $this_user_id]);
+$pdo->prepare('INSERT INTO admin_task_assignments (task_id, assigned_user_id, user_id, user_updated) VALUES (:task_id, :assigned_user_id, :uid, :uid)')
+    ->execute([
+      ':task_id' => $task_id,
+      ':assigned_user_id' => $assigned_user_id,
+      ':uid' => $this_user_id
+    ]);
 
-admin_audit_log($pdo, $this_user_id, 'admin_task_assignments', $task_id, 'CREATE', null, json_encode(['user_id'=>$user_id]), 'Added assignment');
+admin_audit_log($pdo, $this_user_id, 'admin_task_assignments', $task_id, 'CREATE', null, json_encode(['assigned_user_id'=>$assigned_user_id]), 'Added assignment');
 
 header('Location: ../task.php?id=' . $task_id);

--- a/admin/tasks/functions/create.php
+++ b/admin/tasks/functions/create.php
@@ -29,7 +29,7 @@ $priority_id = $_POST['priority_id'] !== '' ? (int)$_POST['priority_id'] : null;
 $start_date = $_POST['start_date'] ?? null;
 $due_date = $_POST['due_date'] ?? null;
 $memo = $_POST['memo'] ?? null;
-$assignments = isset($_POST['assignments']) ? array_map('intval', (array)$_POST['assignments']) : [];
+$assigned_user_ids = isset($_POST['assignments']) ? array_map('intval', (array)$_POST['assignments']) : [];
 
 $stmt = $pdo->prepare('INSERT INTO admin_task (name, description, type_id, category_id, sub_category_id, status_id, priority_id, start_date, due_date, memo, user_id, user_updated) VALUES (:name,:description,:type_id,:category_id,:sub_category_id,:status_id,:priority_id,:start_date,:due_date,:memo,:uid,:uid)');
 $stmt->execute([
@@ -47,9 +47,13 @@ $stmt->execute([
 ]);
 $taskId = (int)$pdo->lastInsertId();
 
-foreach ($assignments as $uid) {
-  $pdo->prepare('INSERT INTO admin_task_assignments (task_id, user_id, user_updated) VALUES (:task_id, :user_id, :uid)')
-      ->execute([':task_id' => $taskId, ':user_id' => $uid, ':uid' => $this_user_id]);
+foreach ($assigned_user_ids as $assigned_user_id) {
+  $pdo->prepare('INSERT INTO admin_task_assignments (task_id, assigned_user_id, user_id, user_updated) VALUES (:task_id, :assigned_user_id, :uid, :uid)')
+      ->execute([
+        ':task_id' => $taskId,
+        ':assigned_user_id' => $assigned_user_id,
+        ':uid' => $this_user_id
+      ]);
 }
 
 admin_audit_log($pdo, $this_user_id, 'admin_task', $taskId, 'CREATE', null, json_encode(['name'=>$name]), 'Created task');

--- a/admin/tasks/functions/quick_add.php
+++ b/admin/tasks/functions/quick_add.php
@@ -30,8 +30,12 @@ $stmt = $pdo->prepare('INSERT INTO admin_task (name, status_id, user_id, user_up
 $stmt->execute([':name' => $name, ':status_id' => $statusId, ':uid' => $this_user_id]);
 $taskId = (int)$pdo->lastInsertId();
 
-$pdo->prepare('INSERT INTO admin_task_assignments (task_id, user_id, user_updated) VALUES (:task,:user,:uid)')
-    ->execute([':task' => $taskId, ':user' => $this_user_id, ':uid' => $this_user_id]);
+$pdo->prepare('INSERT INTO admin_task_assignments (task_id, assigned_user_id, user_id, user_updated) VALUES (:task_id, :assigned_user_id, :uid, :uid)')
+    ->execute([
+      ':task_id' => $taskId,
+      ':assigned_user_id' => $this_user_id,
+      ':uid' => $this_user_id
+    ]);
 
 admin_audit_log($pdo, $this_user_id, 'admin_task', $taskId, 'CREATE', null, json_encode(['name'=>$name]), 'Quick add');
 

--- a/admin/tasks/functions/remove_assignment.php
+++ b/admin/tasks/functions/remove_assignment.php
@@ -15,14 +15,17 @@ if (!hash_equals($_SESSION['csrf_token'] ?? '', $_POST['csrf_token'] ?? '')) {
 }
 
 $task_id = isset($_POST['task_id']) ? (int)$_POST['task_id'] : 0;
-$user_id = isset($_POST['user_id']) ? (int)$_POST['user_id'] : 0;
-if (!$task_id || !$user_id) {
+$assigned_user_id = isset($_POST['user_id']) ? (int)$_POST['user_id'] : 0;
+if (!$task_id || !$assigned_user_id) {
   die('Missing data');
 }
 
-$pdo->prepare('DELETE FROM admin_task_assignments WHERE task_id = :task AND user_id = :user')
-    ->execute([':task' => $task_id, ':user' => $user_id]);
+$pdo->prepare('DELETE FROM admin_task_assignments WHERE task_id = :task_id AND assigned_user_id = :assigned_user_id')
+    ->execute([
+      ':task_id' => $task_id,
+      ':assigned_user_id' => $assigned_user_id
+    ]);
 
-admin_audit_log($pdo, $this_user_id, 'admin_task_assignments', $task_id, 'DELETE', json_encode(['user_id'=>$user_id]), null, 'Removed assignment');
+admin_audit_log($pdo, $this_user_id, 'admin_task_assignments', $task_id, 'DELETE', json_encode(['assigned_user_id'=>$assigned_user_id]), null, 'Removed assignment');
 
 header('Location: ../task.php?id=' . $task_id);

--- a/admin/tasks/functions/update.php
+++ b/admin/tasks/functions/update.php
@@ -33,7 +33,7 @@ $priority_id = $_POST['priority_id'] !== '' ? (int)$_POST['priority_id'] : null;
 $start_date = $_POST['start_date'] ?? null;
 $due_date = $_POST['due_date'] ?? null;
 $memo = $_POST['memo'] ?? null;
-$assignments = isset($_POST['assignments']) ? array_map('intval', (array)$_POST['assignments']) : [];
+$assigned_user_ids = isset($_POST['assignments']) ? array_map('intval', (array)$_POST['assignments']) : [];
 
 $pdo->prepare('UPDATE admin_task SET name=:name, description=:description, type_id=:type_id, category_id=:category_id, sub_category_id=:sub_category_id, status_id=:status_id, priority_id=:priority_id, start_date=:start_date, due_date=:due_date, memo=:memo, user_updated=:uid WHERE id=:id')
     ->execute([
@@ -52,9 +52,13 @@ $pdo->prepare('UPDATE admin_task SET name=:name, description=:description, type_
     ]);
 
 $pdo->prepare('DELETE FROM admin_task_assignments WHERE task_id = :id')->execute([':id' => $id]);
-foreach ($assignments as $uid) {
-  $pdo->prepare('INSERT INTO admin_task_assignments (task_id, user_id, user_updated) VALUES (:task_id,:user_id,:uid)')
-      ->execute([':task_id' => $id, ':user_id' => $uid, ':uid' => $this_user_id]);
+foreach ($assigned_user_ids as $assigned_user_id) {
+  $pdo->prepare('INSERT INTO admin_task_assignments (task_id, assigned_user_id, user_id, user_updated) VALUES (:task_id, :assigned_user_id, :uid, :uid)')
+      ->execute([
+        ':task_id' => $id,
+        ':assigned_user_id' => $assigned_user_id,
+        ':uid' => $this_user_id
+      ]);
 }
 
 admin_audit_log($pdo, $this_user_id, 'admin_task', $id, 'UPDATE', json_encode($old), json_encode(['name'=>$name]), 'Updated task');

--- a/admin/tasks/task.php
+++ b/admin/tasks/task.php
@@ -39,11 +39,11 @@ $priorities = get_lookup_items($pdo, 'ADMIN_TASK_PRIORITY');
 $userStmt = $pdo->query('SELECT id, email FROM users ORDER BY email');
 $users = $userStmt->fetchAll(PDO::FETCH_ASSOC);
 
-$assignedIds = [];
+$assignedUserIds = [];
 if ($editing) {
-  $assStmt = $pdo->prepare('SELECT user_id FROM admin_task_assignments WHERE task_id = :id');
+  $assStmt = $pdo->prepare('SELECT assigned_user_id FROM admin_task_assignments WHERE task_id = :id');
   $assStmt->execute([':id' => $id]);
-  $assignedIds = $assStmt->fetchAll(PDO::FETCH_COLUMN);
+  $assignedUserIds = $assStmt->fetchAll(PDO::FETCH_COLUMN);
 }
 
 $comments = [];
@@ -140,7 +140,7 @@ $_SESSION['csrf_token'] = $token;
     <label class="form-label">Assign Users</label>
     <select name="assignments[]" class="form-select" multiple>
       <?php foreach ($users as $u): ?>
-      <option value="<?= $u['id']; ?>" <?= in_array($u['id'], $assignedIds) ? 'selected' : ''; ?>><?= htmlspecialchars($u['email']); ?></option>
+      <option value="<?= $u['id']; ?>" <?= in_array($u['id'], $assignedUserIds) ? 'selected' : ''; ?>><?= htmlspecialchars($u['email']); ?></option>
       <?php endforeach; ?>
     </select>
   </div>


### PR DESCRIPTION
## Summary
- track assigned users separately from row creators in all task assignment inserts
- target `assigned_user_id` in assignment deletes and assignment lookups
- log assignment changes with `assigned_user_id` and clarify variable names

## Testing
- `php -l admin/tasks/functions/create.php`
- `php -l admin/tasks/functions/update.php`
- `php -l admin/tasks/functions/quick_add.php`
- `php -l admin/tasks/functions/add_assignment.php`
- `php -l admin/tasks/functions/remove_assignment.php`
- `php -l admin/tasks/task.php`
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_68ad3a2cf37c83339dd76dfc389c8ed1