### PR TITLE
Add project file folder management

### DIFF
--- a/_SQL/20250312_project_file_folders.sql
+++ b/_SQL/20250312_project_file_folders.sql
@@ -1,0 +1,30 @@
+-- Project file folders and folder_id column
+
+CREATE TABLE `module_projects_folders` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT current_timestamp(),
+  `date_updated` datetime DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  `memo` text DEFAULT NULL,
+  `project_id` int(11) NOT NULL,
+  `parent_id` int(11) DEFAULT NULL,
+  `name` varchar(255) NOT NULL,
+  `path` varchar(255) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uniq_project_path` (`project_id`,`path`),
+  KEY `fk_module_projects_folders_user_id` (`user_id`),
+  KEY `fk_module_projects_folders_user_updated` (`user_updated`),
+  KEY `fk_module_projects_folders_project_id` (`project_id`),
+  KEY `fk_module_projects_folders_parent_id` (`parent_id`),
+  CONSTRAINT `fk_module_projects_folders_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+  CONSTRAINT `fk_module_projects_folders_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`),
+  CONSTRAINT `fk_module_projects_folders_project_id` FOREIGN KEY (`project_id`) REFERENCES `module_projects` (`id`),
+  CONSTRAINT `fk_module_projects_folders_parent_id` FOREIGN KEY (`parent_id`) REFERENCES `module_projects_folders` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+ALTER TABLE `module_projects_files`
+  ADD COLUMN `folder_id` int(11) DEFAULT NULL AFTER `project_id`,
+  ADD KEY `fk_module_projects_files_folder_id` (`folder_id`),
+  ADD CONSTRAINT `fk_module_projects_files_folder_id` FOREIGN KEY (`folder_id`) REFERENCES `module_projects_folders` (`id`);
+

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -225,4 +225,19 @@ function import_system_properties(PDO $pdo, string $data, string $format='json')
   return true;
 }
 
+function get_project_folder_path(PDO $pdo, int $folder_id): string {
+  if(!$folder_id) return '';
+  $stmt = $pdo->prepare('SELECT path FROM module_projects_folders WHERE id = :id');
+  $stmt->execute([':id' => $folder_id]);
+  $path = $stmt->fetchColumn();
+  return $path ?: '';
+}
+
+function get_project_root_folder(PDO $pdo, int $project_id): ?int {
+  $stmt = $pdo->prepare('SELECT id FROM module_projects_folders WHERE project_id = :pid AND parent_id IS NULL');
+  $stmt->execute([':pid' => $project_id]);
+  $id = $stmt->fetchColumn();
+  return $id ? (int)$id : null;
+}
+
 ?>

--- a/module/project/functions/create_folder.php
+++ b/module/project/functions/create_folder.php
@@ -1,0 +1,80 @@
+<?php
+require '../../../includes/php_header.php';
+require_permission('project','update');
+
+$project_id = (int)($_POST['project_id'] ?? 0);
+$name = trim($_POST['name'] ?? '');
+$parent_id = isset($_POST['parent_id']) && $_POST['parent_id'] !== '' ? (int)$_POST['parent_id'] : null;
+
+header('Content-Type: application/json');
+
+if(!$project_id || $name === ''){
+  http_response_code(400);
+  echo json_encode(['error' => 'Missing project_id or name']);
+  exit;
+}
+
+$maxFolders = (int)get_system_property($pdo,'PROJECT_FILE_MAX_FOLDER_COUNT');
+if($maxFolders){
+  $stmt = $pdo->prepare('SELECT COUNT(*) FROM module_projects_folders WHERE project_id=:pid');
+  $stmt->execute([':pid'=>$project_id]);
+  if($stmt->fetchColumn() >= $maxFolders){
+    http_response_code(400);
+    echo json_encode(['error'=>'Folder limit reached']);
+    exit;
+  }
+}
+
+$parentPath = '';
+if($parent_id){
+  $stmt = $pdo->prepare('SELECT path FROM module_projects_folders WHERE id=:id AND project_id=:pid');
+  $stmt->execute([':id'=>$parent_id, ':pid'=>$project_id]);
+  $parentPath = $stmt->fetchColumn();
+  if($parentPath === false){
+    http_response_code(404);
+    echo json_encode(['error'=>'Parent folder not found']);
+    exit;
+  }
+}
+
+$maxDepth = (int)get_system_property($pdo,'PROJECT_FILE_MAX_FOLDER_DEPTH');
+if($maxDepth){
+  $parentDepth = $parentPath === '' ? 0 : substr_count($parentPath,'/') + 1;
+  if($parentDepth + 1 > $maxDepth){
+    http_response_code(400);
+    echo json_encode(['error'=>'Folder depth exceeded']);
+    exit;
+  }
+}
+
+$safeName = preg_replace('/[^A-Za-z0-9._-]/','_', $name);
+$newPath = ($parentPath !== '' ? $parentPath . '/' : '') . $safeName;
+
+$stmt = $pdo->prepare('SELECT id FROM module_projects_folders WHERE project_id=:pid AND path=:path');
+$stmt->execute([':pid'=>$project_id, ':path'=>$newPath]);
+if($stmt->fetchColumn()){
+  http_response_code(400);
+  echo json_encode(['error'=>'Folder already exists']);
+  exit;
+}
+
+$baseDir = dirname(__DIR__) . '/uploads/' . $project_id . '/' . ($parentPath !== '' ? $parentPath . '/' : '');
+if(!is_dir($baseDir.$safeName)){
+  mkdir($baseDir.$safeName,0777,true);
+}
+
+$stmt = $pdo->prepare('INSERT INTO module_projects_folders (user_id,user_updated,project_id,parent_id,name,path) VALUES (:uid,:uid,:pid,:parent,:name,:path)');
+$stmt->execute([
+  ':uid'=>$this_user_id,
+  ':pid'=>$project_id,
+  ':parent'=>$parent_id,
+  ':name'=>$safeName,
+  ':path'=>$newPath
+]);
+$fid = $pdo->lastInsertId();
+
+admin_audit_log($pdo,$this_user_id,'module_projects_folders',$fid,'CREATE','',json_encode(['name'=>$safeName,'parent_id'=>$parent_id]));
+
+echo json_encode(['id'=>$fid,'name'=>$safeName,'path'=>$newPath]);
+exit;
+

--- a/module/project/functions/delete_file.php
+++ b/module/project/functions/delete_file.php
@@ -1,11 +1,12 @@
 <?php
 require '../../../includes/php_header.php';
+require_permission('project','update');
 $id          = (int)($_POST['id'] ?? 0);
 $project_id  = (int)($_POST['project_id'] ?? 0);
 $question_id = (int)($_POST['question_id'] ?? 0);
 
 if ($id && $project_id) {
-  $sql = 'SELECT user_id, file_path, file_name FROM module_projects_files WHERE id = :id AND project_id = :pid';
+  $sql = 'SELECT user_id, file_path, file_name, folder_id FROM module_projects_files WHERE id = :id AND project_id = :pid';
   $params = [':id' => $id, ':pid' => $project_id];
   if ($question_id) {
     $sql .= ' AND question_id = :qid';

--- a/module/project/functions/delete_folder.php
+++ b/module/project/functions/delete_folder.php
@@ -1,0 +1,51 @@
+<?php
+require '../../../includes/php_header.php';
+require_permission('project','update');
+
+$folder_id = (int)($_POST['id'] ?? 0);
+$project_id = (int)($_POST['project_id'] ?? 0);
+
+header('Content-Type: application/json');
+
+if(!$folder_id || !$project_id){
+  http_response_code(400);
+  echo json_encode(['error'=>'Missing folder or project']);
+  exit;
+}
+
+$stmt = $pdo->prepare('SELECT id, parent_id, path FROM module_projects_folders WHERE id=:id AND project_id=:pid');
+$stmt->execute([':id'=>$folder_id, ':pid'=>$project_id]);
+$folder = $stmt->fetch(PDO::FETCH_ASSOC);
+if(!$folder || !$folder_id || $folder['parent_id'] === null && $folder['path'] === ''){
+  http_response_code(404);
+  echo json_encode(['error'=>'Folder not found']);
+  exit;
+}
+
+$stmt = $pdo->prepare('SELECT COUNT(*) FROM module_projects_folders WHERE parent_id=:id');
+$stmt->execute([':id'=>$folder_id]);
+if($stmt->fetchColumn() > 0){
+  http_response_code(400);
+  echo json_encode(['error'=>'Folder not empty']);
+  exit;
+}
+
+$stmt = $pdo->prepare('SELECT COUNT(*) FROM module_projects_files WHERE folder_id=:id');
+$stmt->execute([':id'=>$folder_id]);
+if($stmt->fetchColumn() > 0){
+  http_response_code(400);
+  echo json_encode(['error'=>'Folder not empty']);
+  exit;
+}
+
+$dir = dirname(__DIR__) . '/uploads/' . $project_id . '/' . $folder['path'];
+if(is_dir($dir)){
+  rmdir($dir);
+}
+
+$pdo->prepare('DELETE FROM module_projects_folders WHERE id=:id')->execute([':id'=>$folder_id]);
+admin_audit_log($pdo,$this_user_id,'module_projects_folders',$folder_id,'DELETE','',json_encode(['path'=>$folder['path']]));
+
+echo json_encode(['success'=>true]);
+exit;
+

--- a/module/project/functions/edit_file.php
+++ b/module/project/functions/edit_file.php
@@ -1,23 +1,43 @@
 <?php
 require '../../../includes/php_header.php';
+require_permission('project','update');
 $id         = (int)($_POST['id'] ?? 0);
 $project_id = (int)($_POST['project_id'] ?? 0);
 $description = trim($_POST['description'] ?? '');
 $file_type_id = (int)($_POST['file_type_id'] ?? 0);
 $status_id    = (int)($_POST['status_id'] ?? 0);
 $sort_order   = isset($_POST['sort_order']) ? (int)$_POST['sort_order'] : 0;
+$folder_id    = isset($_POST['folder_id']) && $_POST['folder_id'] !== '' ? (int)$_POST['folder_id'] : null;
 
 if ($id && $project_id) {
-    $stmt = $pdo->prepare('SELECT user_id, description, file_type_id, status_id, sort_order FROM module_projects_files WHERE id = :id');
+    $stmt = $pdo->prepare('SELECT user_id, description, file_type_id, status_id, sort_order, folder_id, file_path, file_name FROM module_projects_files WHERE id = :id');
     $stmt->execute([':id' => $id]);
     $current = $stmt->fetch(PDO::FETCH_ASSOC);
     if ($current && (user_has_permission('project','update') || $is_admin || $current['user_id'] == $this_user_id)) {
-        $pdo->prepare('UPDATE module_projects_files SET description = :description, file_type_id = :file_type_id, status_id = :status_id, sort_order = :sort_order, user_updated = :uid WHERE id = :id')
+        $newPath = $current['file_path'];
+        if($folder_id !== null && $folder_id != $current['folder_id']){
+            $folderPath = get_project_folder_path($pdo,$folder_id);
+            $baseDir = dirname(__DIR__,3);
+            $oldFull = $baseDir . $current['file_path'];
+            $newRel = '/module/project/uploads/' . $project_id . '/' . ($folderPath !== '' ? $folderPath . '/' : '') . basename($current['file_path']);
+            $newFull = $baseDir . $newRel;
+            if(!is_dir(dirname($newFull))){ mkdir(dirname($newFull),0777,true); }
+            if(@rename($oldFull,$newFull)){
+                $newPath = $newRel;
+            } else {
+                $folder_id = $current['folder_id'];
+            }
+        } else {
+            $folder_id = $current['folder_id'];
+        }
+        $pdo->prepare('UPDATE module_projects_files SET description = :description, file_type_id = :file_type_id, status_id = :status_id, sort_order = :sort_order, folder_id = :folder_id, file_path = :path, user_updated = :uid WHERE id = :id')
             ->execute([
                 ':description' => $description !== '' ? $description : null,
                 ':file_type_id' => $file_type_id ?: null,
                 ':status_id' => $status_id ?: null,
                 ':sort_order' => $sort_order,
+                ':folder_id' => $folder_id,
+                ':path' => $newPath,
                 ':uid' => $this_user_id,
                 ':id' => $id
             ]);
@@ -25,7 +45,9 @@ if ($id && $project_id) {
             'description' => $description !== '' ? $description : null,
             'file_type_id' => $file_type_id ?: null,
             'status_id' => $status_id ?: null,
-            'sort_order' => $sort_order
+            'sort_order' => $sort_order,
+            'folder_id' => $folder_id,
+            'file_path' => $newPath
         ]));
     } else {
         header('HTTP/1.1 403 Forbidden');

--- a/module/project/functions/list_folder.php
+++ b/module/project/functions/list_folder.php
@@ -1,0 +1,37 @@
+<?php
+require '../../../includes/php_header.php';
+require_permission('project','view');
+
+$project_id = (int)($_GET['project_id'] ?? 0);
+$folder_id = isset($_GET['folder_id']) && $_GET['folder_id'] !== '' ? (int)$_GET['folder_id'] : null;
+
+header('Content-Type: application/json');
+
+if(!$project_id){
+  http_response_code(400);
+  echo json_encode(['error'=>'Missing project_id']);
+  exit;
+}
+
+if(!$folder_id){
+  $folder_id = get_project_root_folder($pdo,$project_id);
+}
+
+$current = null;
+if($folder_id){
+  $stmt = $pdo->prepare('SELECT id,name,path FROM module_projects_folders WHERE id=:id AND project_id=:pid');
+  $stmt->execute([':id'=>$folder_id, ':pid'=>$project_id]);
+  $current = $stmt->fetch(PDO::FETCH_ASSOC);
+}
+
+$stmt = $pdo->prepare('SELECT id,name,path FROM module_projects_folders WHERE project_id=:pid AND parent_id'.($folder_id?'=:fid':' IS NULL').' ORDER BY name');
+$stmt->execute([':pid'=>$project_id, ':fid'=>$folder_id]);
+$folders = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+$stmt = $pdo->prepare('SELECT id,file_name,file_path,file_size,file_type FROM module_projects_files WHERE project_id=:pid AND folder_id'.($folder_id?'=:fid':' IS NULL').' AND note_id IS NULL AND question_id IS NULL ORDER BY sort_order, date_created DESC');
+$stmt->execute([':pid'=>$project_id, ':fid'=>$folder_id]);
+$files = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+echo json_encode(['current'=>$current,'folders'=>$folders,'files'=>$files]);
+exit;
+

--- a/module/project/functions/move_file.php
+++ b/module/project/functions/move_file.php
@@ -1,0 +1,51 @@
+<?php
+require '../../../includes/php_header.php';
+require_permission('project','update');
+
+$file_id = (int)($_POST['id'] ?? 0);
+$target_folder_id = isset($_POST['target_folder_id']) && $_POST['target_folder_id'] !== '' ? (int)$_POST['target_folder_id'] : null;
+
+header('Content-Type: application/json');
+
+if(!$file_id){
+  http_response_code(400);
+  echo json_encode(['error'=>'Missing file id']);
+  exit;
+}
+
+$stmt = $pdo->prepare('SELECT id,project_id,file_path,file_name,folder_id FROM module_projects_files WHERE id=:id');
+$stmt->execute([':id'=>$file_id]);
+$file = $stmt->fetch(PDO::FETCH_ASSOC);
+if(!$file){
+  http_response_code(404);
+  echo json_encode(['error'=>'File not found']);
+  exit;
+}
+
+$newPathPart = get_project_folder_path($pdo,$target_folder_id);
+$oldFullPath = dirname(__DIR__,3) . $file['file_path'];
+$newRelPath = '/module/project/uploads/' . $file['project_id'] . '/' . ($newPathPart !== '' ? $newPathPart . '/' : '') . basename($file['file_path']);
+$newFullPath = dirname(__DIR__,3) . $newRelPath;
+
+if(!is_dir(dirname($newFullPath))){
+  mkdir(dirname($newFullPath),0777,true);
+}
+
+if(!@rename($oldFullPath,$newFullPath)){
+  http_response_code(500);
+  echo json_encode(['error'=>'Move failed']);
+  exit;
+}
+
+$pdo->prepare('UPDATE module_projects_files SET folder_id=:fid,file_path=:path,user_updated=:uid WHERE id=:id')->execute([
+  ':fid'=>$target_folder_id,
+  ':path'=>$newRelPath,
+  ':uid'=>$this_user_id,
+  ':id'=>$file_id
+]);
+
+admin_audit_log($pdo,$this_user_id,'module_projects_files',$file_id,'MOVE',$file['file_path'],$newRelPath);
+
+echo json_encode(['success'=>true,'path'=>$newRelPath]);
+exit;
+

--- a/module/project/functions/move_folder.php
+++ b/module/project/functions/move_folder.php
@@ -1,0 +1,108 @@
+<?php
+require '../../../includes/php_header.php';
+require_permission('project','update');
+
+$folder_id = (int)($_POST['id'] ?? 0);
+$target_parent_id = isset($_POST['target_parent_id']) && $_POST['target_parent_id'] !== '' ? (int)$_POST['target_parent_id'] : null;
+
+header('Content-Type: application/json');
+
+if(!$folder_id){
+  http_response_code(400);
+  echo json_encode(['error'=>'Missing folder id']);
+  exit;
+}
+
+$stmt = $pdo->prepare('SELECT id,project_id,name,path,parent_id FROM module_projects_folders WHERE id=:id');
+$stmt->execute([':id'=>$folder_id]);
+$folder = $stmt->fetch(PDO::FETCH_ASSOC);
+if(!$folder){
+  http_response_code(404);
+  echo json_encode(['error'=>'Folder not found']);
+  exit;
+}
+if($folder['parent_id'] === null && $folder['path'] === ''){
+  http_response_code(400);
+  echo json_encode(['error'=>'Cannot move root']);
+  exit;
+}
+
+$targetPath = '';
+if($target_parent_id){
+  if($target_parent_id == $folder_id){
+    http_response_code(400);
+    echo json_encode(['error'=>'Invalid target']);
+    exit;
+  }
+  $stmt = $pdo->prepare('SELECT id,path FROM module_projects_folders WHERE id=:id AND project_id=:pid');
+  $stmt->execute([':id'=>$target_parent_id, ':pid'=>$folder['project_id']]);
+  $target = $stmt->fetch(PDO::FETCH_ASSOC);
+  if(!$target){
+    http_response_code(404);
+    echo json_encode(['error'=>'Target folder not found']);
+    exit;
+  }
+  if(str_starts_with($target['path'],$folder['path'].'/')){
+    http_response_code(400);
+    echo json_encode(['error'=>'Cannot move into descendant']);
+    exit;
+  }
+  $targetPath = $target['path'];
+}
+
+$maxDepth = (int)get_system_property($pdo,'PROJECT_FILE_MAX_FOLDER_DEPTH');
+if($maxDepth){
+  $targetDepth = $targetPath === '' ? 0 : substr_count($targetPath,'/') + 1;
+  $folderDepth = $folder['path'] === '' ? 0 : substr_count($folder['path'],'/') + 1;
+  $newDepth = $targetDepth + 1; // depth of moved folder root
+  if($newDepth > $maxDepth){
+    http_response_code(400);
+    echo json_encode(['error'=>'Folder depth exceeded']);
+    exit;
+  }
+}
+
+$oldPath = $folder['path'];
+$newPath = ($targetPath !== '' ? $targetPath . '/' : '') . $folder['name'];
+
+$baseDir = dirname(__DIR__) . '/uploads/' . $folder['project_id'] . '/';
+$oldFull = $baseDir . $oldPath;
+$newFull = $baseDir . $newPath;
+if(!is_dir(dirname($newFull))){
+  mkdir(dirname($newFull),0777,true);
+}
+if(!@rename($oldFull,$newFull)){
+  http_response_code(500);
+  echo json_encode(['error'=>'Move failed']);
+  exit;
+}
+
+$pdo->prepare('UPDATE module_projects_folders SET parent_id=:pid,path=:path,user_updated=:uid WHERE id=:id')->execute([
+  ':pid'=>$target_parent_id,
+  ':path'=>$newPath,
+  ':uid'=>$this_user_id,
+  ':id'=>$folder_id
+]);
+
+$oldPrefix = '/module/project/uploads/' . $folder['project_id'] . '/' . $oldPath;
+$newPrefix = '/module/project/uploads/' . $folder['project_id'] . '/' . $newPath;
+$like = $oldPrefix . '%';
+$pdo->prepare('UPDATE module_projects_files SET file_path = REPLACE(file_path,:old,:new) WHERE project_id=:pid AND file_path LIKE :like')->execute([
+  ':old'=>$oldPrefix,
+  ':new'=>$newPrefix,
+  ':pid'=>$folder['project_id'],
+  ':like'=>$like
+]);
+
+$pdo->prepare('UPDATE module_projects_folders SET path = REPLACE(path,:old,:new) WHERE project_id=:pid AND path LIKE :oldlike')->execute([
+  ':old'=>$oldPath.'/',
+  ':new'=>$newPath.'/',
+  ':pid'=>$folder['project_id'],
+  ':oldlike'=>$oldPath.'/%'
+]);
+
+admin_audit_log($pdo,$this_user_id,'module_projects_folders',$folder_id,'MOVE',$oldPath,$newPath);
+
+echo json_encode(['success'=>true,'path'=>$newPath]);
+exit;
+

--- a/module/project/migrate_project_files.php
+++ b/module/project/migrate_project_files.php
@@ -1,0 +1,43 @@
+<?php
+// CLI script to migrate project files into folder structure
+require '../../includes/php_header.php';
+
+if(php_sapi_name() !== 'cli'){
+  echo "CLI only\n";
+  exit;
+}
+
+$projects = $pdo->query('SELECT id FROM module_projects')->fetchAll(PDO::FETCH_COLUMN);
+foreach($projects as $pid){
+  $stmt = $pdo->prepare('SELECT id FROM module_projects_folders WHERE project_id=:pid AND parent_id IS NULL');
+  $stmt->execute([':pid'=>$pid]);
+  $root = $stmt->fetchColumn();
+  if(!$root){
+    $pdo->prepare('INSERT INTO module_projects_folders (user_id,user_updated,project_id,parent_id,name,path) VALUES (0,0,:pid,NULL,"","")')->execute([':pid'=>$pid]);
+    $root = $pdo->lastInsertId();
+  }
+  $dir = __DIR__ . '/uploads/' . $pid . '/';
+  if(!is_dir($dir)){
+    mkdir($dir,0777,true);
+  }
+  $stmt = $pdo->prepare('SELECT id,file_path,file_name FROM module_projects_files WHERE project_id=:pid AND (folder_id IS NULL OR file_path NOT LIKE :p)');
+  $stmt->execute([':pid'=>$pid, ':p'=>'/module/project/uploads/'.$pid.'/%']);
+  $files = $stmt->fetchAll(PDO::FETCH_ASSOC);
+  foreach($files as $f){
+    $basename = basename($f['file_path']);
+    $oldFull = __DIR__ . '/uploads/' . $basename;
+    $newRel = '/module/project/uploads/' . $pid . '/' . $basename;
+    $newFull = __DIR__ . '/uploads/' . $pid . '/' . $basename;
+    if(is_file($oldFull)){
+      rename($oldFull,$newFull);
+    }
+    $pdo->prepare('UPDATE module_projects_files SET folder_id=:fid,file_path=:path WHERE id=:id')->execute([
+      ':fid'=>$root,
+      ':path'=>$newRel,
+      ':id'=>$f['id']
+    ]);
+  }
+}
+
+echo "Migration complete\n";
+


### PR DESCRIPTION
## Summary
- add helper functions to resolve project folder paths
- support creating, listing, deleting, and moving project folders/files
- migrate legacy project files into new folder structure

## Testing
- `php -l includes/functions.php`
- `php -l module/project/functions/create_folder.php`
- `php -l module/project/functions/delete_folder.php`
- `php -l module/project/functions/list_folder.php`
- `php -l module/project/functions/move_file.php`
- `php -l module/project/functions/move_folder.php`
- `php -l module/project/functions/upload_file.php`
- `php -l module/project/functions/delete_file.php`
- `php -l module/project/functions/edit_file.php`
- `php -l module/project/migrate_project_files.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad3a8c65f083339dc6b7dd70cf6a32