### PR TITLE
Defer file manager script to footer

### DIFF
--- a/includes/js_footer.php
+++ b/includes/js_footer.php
@@ -18,6 +18,7 @@
     <!-- Phoenix Core & Config -->
     <script src="<?php echo getURLDir(); ?>assets/js/config.js"></script>
     <script src="<?php echo getURLDir(); ?>assets/js/phoenix.js"></script>
+    <script src="<?php echo getURLDir(); ?>assets/js/file-manager.js"></script>
 
     <!-- Project-specific JS (if any) -->
     <script src="<?php echo getURLDir(); ?>assets/js/projectmanagement-dashboard.js"></script>

--- a/module/project/include/details_view.php
+++ b/module/project/include/details_view.php
@@ -257,7 +257,6 @@ if (!empty($current_project)) {
                     </div>
                   <?php endif; ?>
                 </div>
-                <script src="<?php echo getURLDir(); ?>assets/js/file-manager.js"></script>
                 <script src="<?php echo getURLDir(); ?>module/project/assets/file_cabinet.js"></script>
 
               </div>


### PR DESCRIPTION
## Summary
- Remove early inclusion of file-manager.js from project details view
- Load file-manager.js after phoenix.js in shared JS footer

## Testing
- `php -l module/project/include/details_view.php`
- `php -l includes/js_footer.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad3f4c768c8333b5d08c6f33b6beb3