### PR TITLE
Add null-safe escaping helper and replace direct htmlspecialchars use

### DIFF
--- a/admin/branding/index.php
+++ b/admin/branding/index.php
@@ -33,8 +33,8 @@ $bootstrapColors = ['primary','secondary','success','danger','warning','info','l
 ?>
   <div class="col">
     <?= $html ?>
-    <button class="btn btn-sm btn-link p-0 ms-1 copy-snippet" data-snippet="<?= htmlspecialchars($html, ENT_QUOTES) ?>" title="Copy HTML"><span class="fa-regular fa-copy"></span></button>
-    <code class="d-block mt-1"><?= htmlspecialchars($html) ?></code>
+    <button class="btn btn-sm btn-link p-0 ms-1 copy-snippet" data-snippet="<?= e($html, ENT_QUOTES) ?>" title="Copy HTML"><span class="fa-regular fa-copy"></span></button>
+    <code class="d-block mt-1"><?= e($html) ?></code>
   </div>
 <?php endforeach; ?>
 </div>
@@ -47,8 +47,8 @@ $bootstrapColors = ['primary','secondary','success','danger','warning','info','l
 ?>
   <div class="col">
     <?= $html ?>
-    <button class="btn btn-sm btn-link p-0 ms-1 copy-snippet" data-snippet="<?= htmlspecialchars($html, ENT_QUOTES) ?>" title="Copy HTML"><span class="fa-regular fa-copy"></span></button>
-    <code class="d-block mt-1"><?= htmlspecialchars($html) ?></code>
+    <button class="btn btn-sm btn-link p-0 ms-1 copy-snippet" data-snippet="<?= e($html, ENT_QUOTES) ?>" title="Copy HTML"><span class="fa-regular fa-copy"></span></button>
+    <code class="d-block mt-1"><?= e($html) ?></code>
   </div>
 <?php endforeach; ?>
 </div>

--- a/admin/index.php
+++ b/admin/index.php
@@ -8,9 +8,9 @@ $modules = require __DIR__ . '/modules.php';
     <div class="col-md-4">
       <div class="card shadow-sm">
         <div class="card-body">
-          <h5 class="card-title"><span class="me-2" data-feather="<?= htmlspecialchars($module['icon']); ?>"></span><?= htmlspecialchars($module['title']); ?></h5>
-          <p class="card-text"><?php if(isset($module['memo'])){ htmlspecialchars($module['memo']); } ?></p>
-          <a href="<?= htmlspecialchars($module['path']); ?>" class="btn btn-primary btn-sm">Manage</a>
+          <h5 class="card-title"><span class="me-2" data-feather="<?= e($module['icon']); ?>"></span><?= e($module['title']); ?></h5>
+          <p class="card-text"><?php if(isset($module['memo'])){ e($module['memo']); } ?></p>
+          <a href="<?= e($module['path']); ?>" class="btn btn-primary btn-sm">Manage</a>
         </div>
       </div>
     </div>

--- a/admin/left_navigation.php
+++ b/admin/left_navigation.php
@@ -8,8 +8,8 @@ $navLinks = $stmt->fetchAll(PDO::FETCH_ASSOC);
       <ul class="navbar-nav flex-column" id="navbarVerticalNav">
         <?php foreach ($navLinks as $link): ?>
         <li class="nav-item">
-          <a class="nav-link" href="<?php echo getURLDir(); ?>admin/<?= htmlspecialchars($link['path']); ?>">
-            <div class="d-flex align-items-center"><span class="nav-link-icon"><span data-feather="<?= htmlspecialchars($link['icon']); ?>"></span></span><span class="nav-link-text"><?= htmlspecialchars($link['title']); ?></span></div>
+          <a class="nav-link" href="<?php echo getURLDir(); ?>admin/<?= e($link['path']); ?>">
+            <div class="d-flex align-items-center"><span class="nav-link-icon"><span data-feather="<?= e($link['icon']); ?>"></span></span><span class="nav-link-text"><?= e($link['title']); ?></span></div>
           </a>
         </li>
         <?php endforeach; ?>

--- a/admin/lookup-lists/attributes.php
+++ b/admin/lookup-lists/attributes.php
@@ -68,7 +68,7 @@ $selectedAttrCode = $_POST['attr_code'] ?? '';
 
 <div class="row">
   <div class="col-12">
-    <h2 class="mb-4">Attributes for <?= htmlspecialchars($item['label']); ?>
+    <h2 class="mb-4">Attributes for <?= e($item['label']); ?>
       <br />
       <a class="btn btn-secondary" href="index.php">Back</a>
     </h2>
@@ -79,7 +79,7 @@ $selectedAttrCode = $_POST['attr_code'] ?? '';
 <?= flash_message($message); ?>
 <form method="post" class="row g-2 mb-3">
   <input type="hidden" name="csrf_token" value="<?= $token; ?>">
-  <input type="hidden" name="id" value="<?= htmlspecialchars($_POST['id'] ?? ''); ?>">
+  <input type="hidden" name="id" value="<?= e($_POST['id'] ?? ''); ?>">
   <div class="col-md-4">
     <select class="form-select" name="attr_code" required>
       <?php foreach ($attrItems as $attrItem): ?>
@@ -89,7 +89,7 @@ $selectedAttrCode = $_POST['attr_code'] ?? '';
       <?php endforeach; ?>
     </select>
   </div>
-    <div class="col-md-4"><input class="form-control" name="attr_value" placeholder="Value" value="<?= htmlspecialchars($_POST['attr_value'] ?? ''); ?>"></div>
+    <div class="col-md-4"><input class="form-control" name="attr_value" placeholder="Value" value="<?= e($_POST['attr_value'] ?? ''); ?>"></div>
   <div class="col-md-2"><button class="btn btn-success" type="submit" id="saveBtn">Save</button></div>
 </form>
   <div id="attrs" data-list='{"valueNames":["attr_code","attr_value"],"page":25,"pagination":true}'>
@@ -104,10 +104,10 @@ $selectedAttrCode = $_POST['attr_code'] ?? '';
       <tbody class="list">
         <?php foreach($attrs as $a): ?>
           <tr>
-            <td class="attr_code"><?= htmlspecialchars($a['attr_code']); ?></td>
-            <td class="attr_value"><?= htmlspecialchars($a['attr_value']); ?></td>
+            <td class="attr_code"><?= e($a['attr_code']); ?></td>
+            <td class="attr_value"><?= e($a['attr_value']); ?></td>
             <td>
-              <button class="btn btn-sm btn-warning" onclick="fillAttr(<?= $a['id']; ?>,'<?= htmlspecialchars($a['attr_code'],ENT_QUOTES); ?>','<?= htmlspecialchars($a['attr_value'],ENT_QUOTES); ?>');return false;">Edit</button>
+              <button class="btn btn-sm btn-warning" onclick="fillAttr(<?= $a['id']; ?>,'<?= e($a['attr_code'],ENT_QUOTES); ?>','<?= e($a['attr_value'],ENT_QUOTES); ?>');return false;">Edit</button>
               <form method="post" class="d-inline">
                 <input type="hidden" name="delete_id" value="<?= $a['id']; ?>">
                 <input type="hidden" name="csrf_token" value="<?= $token; ?>">

--- a/admin/lookup-lists/edit.php
+++ b/admin/lookup-lists/edit.php
@@ -50,15 +50,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   <input type="hidden" name="csrf_token" value="<?= $token; ?>">
   <div class="mb-3">
     <label class="form-label">Name</label>
-    <input type="text" class="form-control" name="name" value="<?= htmlspecialchars($name); ?>" required>
+    <input type="text" class="form-control" name="name" value="<?= e($name); ?>" required>
   </div>
   <div class="mb-3">
     <label class="form-label">Description</label>
-    <textarea class="form-control" name="description"><?= htmlspecialchars($description); ?></textarea>
+    <textarea class="form-control" name="description"><?= e($description); ?></textarea>
   </div>
   <div class="mb-3">
     <label class="form-label">Memo</label>
-    <textarea class="form-control" name="memo"><?= htmlspecialchars($memo); ?></textarea>
+    <textarea class="form-control" name="memo"><?= e($memo); ?></textarea>
   </div>
   <button class="btn <?= $btnClass; ?>" type="submit">Save</button>
   <a href="index.php" class="btn btn-secondary">Back</a>

--- a/admin/navigation.php
+++ b/admin/navigation.php
@@ -48,7 +48,7 @@ $links = $stmt->fetchAll(PDO::FETCH_ASSOC);
 <link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css">
 <h2 class="mb-4">Navigation Links</h2>
 <?php if ($message): ?>
-  <div class="alert alert-success"><?= htmlspecialchars($message); ?></div>
+  <div class="alert alert-success"><?= e($message); ?></div>
 <?php endif; ?>
 <button type="button" class="btn btn-success mb-3" data-bs-toggle="modal" data-bs-target="#createNavModal">Create Nav Link</button>
 <form method="post" id="navForm">
@@ -57,8 +57,8 @@ $links = $stmt->fetchAll(PDO::FETCH_ASSOC);
   <ul id="navList" class="list-group">
     <?php foreach ($links as $link): ?>
       <li class="list-group-item d-flex justify-content-between align-items-center" data-id="<?= $link['id']; ?>">
-        <span><?= htmlspecialchars($link['title']); ?></span>
-        <small class="text-muted"><?= htmlspecialchars($link['path']); ?></small>
+        <span><?= e($link['title']); ?></span>
+        <small class="text-muted"><?= e($link['path']); ?></small>
       </li>
     <?php endforeach; ?>
   </ul>

--- a/admin/orgs/agency_edit.php
+++ b/admin/orgs/agency_edit.php
@@ -146,20 +146,20 @@ require '../admin_header.php';
         <select name="organization_id" class="form-select" required>
           <option value="">-- Select --</option>
           <?php foreach($orgOptions as $oid => $oname): ?>
-            <option value="<?= $oid; ?>" <?= (int)$oid === (int)$organization_id ? 'selected' : ''; ?>><?= htmlspecialchars($oname); ?></option>
+            <option value="<?= $oid; ?>" <?= (int)$oid === (int)$organization_id ? 'selected' : ''; ?>><?= e($oname); ?></option>
           <?php endforeach; ?>
         </select>
       </div>
       <div class="mb-3">
         <label class="form-label">Name</label>
-        <input type="text" name="name" class="form-control" value="<?= htmlspecialchars($name); ?>" required>
+        <input type="text" name="name" class="form-control" value="<?= e($name); ?>" required>
       </div>
       <div class="mb-3">
         <label class="form-label">Main Person</label>
         <select name="main_person" class="form-select">
           <option value="">-- None --</option>
           <?php foreach($personOptions as $pid => $pname): ?>
-            <option value="<?= $pid; ?>" <?= (int)$pid === (int)$main_person ? 'selected' : ''; ?>><?= htmlspecialchars($pname); ?></option>
+            <option value="<?= $pid; ?>" <?= (int)$pid === (int)$main_person ? 'selected' : ''; ?>><?= e($pname); ?></option>
           <?php endforeach; ?>
         </select>
       </div>
@@ -167,7 +167,7 @@ require '../admin_header.php';
         <label class="form-label">Status</label>
         <select name="status" class="form-select">
           <?php foreach($statusOptions as $sid => $slabel): ?>
-            <option value="<?= $sid; ?>" <?= (int)$sid === (int)$status ? 'selected' : ''; ?>><?= htmlspecialchars($slabel); ?></option>
+            <option value="<?= $sid; ?>" <?= (int)$sid === (int)$status ? 'selected' : ''; ?>><?= e($slabel); ?></option>
           <?php endforeach; ?>
         </select>
       </div>
@@ -175,12 +175,12 @@ require '../admin_header.php';
         <label class="form-label">Upload File</label>
         <?php if ($file_path): ?>
           <div class="mb-2">
-            <a href="/module/agency/download.php?type=agency&id=<?= $id; ?>" target="_blank"><?= htmlspecialchars($file_name); ?></a>
+            <a href="/module/agency/download.php?type=agency&id=<?= $id; ?>" target="_blank"><?= e($file_name); ?></a>
             <button class="btn btn-outline-danger btn-sm ms-2" name="remove_file" value="1" formnovalidate>Remove File</button>
             <?php if (strpos($file_type,'image/') === 0): ?>
-              <img src="/module/agency/uploads/agency/<?= htmlspecialchars($file_path); ?>" class="img-fluid mt-2" alt="Preview">
+              <img src="/module/agency/uploads/agency/<?= e($file_path); ?>" class="img-fluid mt-2" alt="Preview">
             <?php elseif ($file_type === 'application/pdf'): ?>
-              <embed src="/module/agency/uploads/agency/<?= htmlspecialchars($file_path); ?>" type="application/pdf" class="w-100 mt-2" style="height:200px;"></embed>
+              <embed src="/module/agency/uploads/agency/<?= e($file_path); ?>" type="application/pdf" class="w-100 mt-2" style="height:200px;"></embed>
             <?php endif; ?>
           </div>
         <?php endif; ?>
@@ -202,8 +202,8 @@ require '../admin_header.php';
         <tbody>
           <?php foreach($assignedPersons as $ap): ?>
             <tr>
-              <td><?= htmlspecialchars($ap['name']); ?></td>
-              <td><?= htmlspecialchars($ap['role_label'] ?? ''); ?></td>
+              <td><?= e($ap['name']); ?></td>
+              <td><?= e($ap['role_label'] ?? ''); ?></td>
               <td><?= $ap['is_lead'] ? 'Yes' : 'No'; ?></td>
               <td>
                 <form method="post" action="functions/agency_remove_person.php" class="d-inline">
@@ -224,7 +224,7 @@ require '../admin_header.php';
           <select name="person_id" class="form-select" required>
             <option value="">-- Person --</option>
             <?php foreach($personOptions as $pid=>$pname): ?>
-              <option value="<?= $pid; ?>"><?= htmlspecialchars($pname); ?></option>
+              <option value="<?= $pid; ?>"><?= e($pname); ?></option>
             <?php endforeach; ?>
           </select>
         </div>
@@ -232,7 +232,7 @@ require '../admin_header.php';
           <select name="role_id" class="form-select">
             <option value="">-- Role --</option>
             <?php foreach($roleOptions as $rid=>$rlabel): ?>
-              <option value="<?= $rid; ?>"><?= htmlspecialchars($rlabel); ?></option>
+              <option value="<?= $rid; ?>"><?= e($rlabel); ?></option>
             <?php endforeach; ?>
           </select>
         </div>

--- a/admin/orgs/division_edit.php
+++ b/admin/orgs/division_edit.php
@@ -144,20 +144,20 @@ require '../admin_header.php';
         <select name="agency_id" class="form-select" required>
           <option value="">-- Select --</option>
           <?php foreach($agencyOptions as $aid => $aname): ?>
-            <option value="<?= $aid; ?>" <?= (int)$aid === (int)$agency_id ? 'selected' : ''; ?>><?= htmlspecialchars($aname); ?></option>
+            <option value="<?= $aid; ?>" <?= (int)$aid === (int)$agency_id ? 'selected' : ''; ?>><?= e($aname); ?></option>
           <?php endforeach; ?>
         </select>
       </div>
       <div class="mb-3">
         <label class="form-label">Name</label>
-        <input type="text" name="name" class="form-control" value="<?= htmlspecialchars($name); ?>" required>
+        <input type="text" name="name" class="form-control" value="<?= e($name); ?>" required>
       </div>
       <div class="mb-3">
         <label class="form-label">Main Person</label>
         <select name="main_person" class="form-select">
           <option value="">-- None --</option>
           <?php foreach($personOptions as $pid => $pname): ?>
-            <option value="<?= $pid; ?>" <?= (int)$pid === (int)$main_person ? 'selected' : ''; ?>><?= htmlspecialchars($pname); ?></option>
+            <option value="<?= $pid; ?>" <?= (int)$pid === (int)$main_person ? 'selected' : ''; ?>><?= e($pname); ?></option>
           <?php endforeach; ?>
         </select>
       </div>
@@ -165,7 +165,7 @@ require '../admin_header.php';
         <label class="form-label">Status</label>
         <select name="status" class="form-select">
           <?php foreach($statusOptions as $sid => $slabel): ?>
-            <option value="<?= $sid; ?>" <?= (int)$sid === (int)$status ? 'selected' : ''; ?>><?= htmlspecialchars($slabel); ?></option>
+            <option value="<?= $sid; ?>" <?= (int)$sid === (int)$status ? 'selected' : ''; ?>><?= e($slabel); ?></option>
           <?php endforeach; ?>
         </select>
       </div>
@@ -173,12 +173,12 @@ require '../admin_header.php';
         <label class="form-label">Upload File</label>
         <?php if ($file_path): ?>
           <div class="mb-2">
-            <a href="/module/agency/download.php?type=division&id=<?= $id; ?>" target="_blank"><?= htmlspecialchars($file_name); ?></a>
+            <a href="/module/agency/download.php?type=division&id=<?= $id; ?>" target="_blank"><?= e($file_name); ?></a>
             <button class="btn btn-outline-danger btn-sm ms-2" name="remove_file" value="1" formnovalidate>Remove File</button>
             <?php if (strpos($file_type,'image/') === 0): ?>
-              <img src="/module/agency/uploads/division/<?= htmlspecialchars($file_path); ?>" class="img-fluid mt-2" alt="Preview">
+              <img src="/module/agency/uploads/division/<?= e($file_path); ?>" class="img-fluid mt-2" alt="Preview">
             <?php elseif ($file_type === 'application/pdf'): ?>
-              <embed src="/module/agency/uploads/division/<?= htmlspecialchars($file_path); ?>" type="application/pdf" class="w-100 mt-2" style="height:200px;"></embed>
+              <embed src="/module/agency/uploads/division/<?= e($file_path); ?>" type="application/pdf" class="w-100 mt-2" style="height:200px;"></embed>
             <?php endif; ?>
           </div>
         <?php endif; ?>
@@ -200,8 +200,8 @@ require '../admin_header.php';
         <tbody>
           <?php foreach($assignedPersons as $ap): ?>
             <tr>
-              <td><?= htmlspecialchars($ap['name']); ?></td>
-              <td><?= htmlspecialchars($ap['role_label'] ?? ''); ?></td>
+              <td><?= e($ap['name']); ?></td>
+              <td><?= e($ap['role_label'] ?? ''); ?></td>
               <td><?= $ap['is_lead'] ? 'Yes' : 'No'; ?></td>
               <td>
                 <form method="post" action="functions/division_remove_person.php" class="d-inline">
@@ -222,7 +222,7 @@ require '../admin_header.php';
           <select name="person_id" class="form-select" required>
             <option value="">-- Person --</option>
             <?php foreach($personOptions as $pid=>$pname): ?>
-              <option value="<?= $pid; ?>"><?= htmlspecialchars($pname); ?></option>
+              <option value="<?= $pid; ?>"><?= e($pname); ?></option>
             <?php endforeach; ?>
           </select>
         </div>
@@ -230,7 +230,7 @@ require '../admin_header.php';
           <select name="role_id" class="form-select">
             <option value="">-- Role --</option>
             <?php foreach($roleOptions as $rid=>$rlabel): ?>
-              <option value="<?= $rid; ?>"><?= htmlspecialchars($rlabel); ?></option>
+              <option value="<?= $rid; ?>"><?= e($rlabel); ?></option>
             <?php endforeach; ?>
           </select>
         </div>

--- a/admin/orgs/index.php
+++ b/admin/orgs/index.php
@@ -149,9 +149,9 @@ function render_file_attachment($file_path, $file_name, $file_type, $downloadUrl
     $path = "/module/agency/uploads/{$subdir}/{$path}";
   }
   $src = getURLDir() . ltrim($path, '/');
-  $downloadUrl = htmlspecialchars($downloadUrl, ENT_QUOTES);
-  $escName = htmlspecialchars($file_name);
-  $src = htmlspecialchars($src, ENT_QUOTES);
+  $downloadUrl = e($downloadUrl, ENT_QUOTES);
+  $escName = e($file_name);
+  $src = e($src, ENT_QUOTES);
   if (strpos($file_type, 'image/') === 0) {
     return "<div class=\"mt-2\"><a href=\"{$downloadUrl}\" target=\"_blank\"><img src=\"{$src}\" class=\"img-thumbnail\" style=\"max-width:100px;\" alt=\"{$escName}\"></a></div>";
   }
@@ -159,7 +159,7 @@ function render_file_attachment($file_path, $file_name, $file_type, $downloadUrl
 }
 ?>
 <h2 class="mb-4">Organizations</h2>
-<?php if($message){ echo '<div class="alert alert-success">'.htmlspecialchars($message).'</div>'; } ?>
+<?php if($message){ echo '<div class="alert alert-success">'.e($message).'</div>'; } ?>
 <?php if (user_has_permission('organization','create')): ?>
   <a href="organization_edit.php" class="btn btn-sm btn-success mb-3">Add Organization</a>
 <?php endif; ?>
@@ -168,7 +168,7 @@ function render_file_attachment($file_path, $file_name, $file_type, $downloadUrl
   <div class="card mb-3">
     <div class="card-header d-flex justify-content-between align-items-start">
       <div>
-        <span class="badge bg-primary me-1">Org</span><span class="fw-semibold"><?= htmlspecialchars($org['name']); ?></span>
+        <span class="badge bg-primary me-1">Org</span><span class="fw-semibold"><?= e($org['name']); ?></span>
         <?= render_file_attachment($org['file_path'], $org['file_name'], $org['file_type'], "/module/agency/download.php?type=organization&id={$org['id']}", 'organization'); ?>
         <?php if (!empty($org['persons'])): ?>
           <br><small>
@@ -178,7 +178,7 @@ function render_file_attachment($file_path, $file_name, $file_type, $downloadUrl
                 $label = $p['name'];
                 if ($p['role_label']) $label .= ' ('.$p['role_label'].')';
                 if ($p['is_lead']) $label .= ' [Lead]';
-                $parts[] = htmlspecialchars($label);
+                $parts[] = e($label);
               }
               echo implode(', ', $parts);
             ?>
@@ -208,7 +208,7 @@ function render_file_attachment($file_path, $file_name, $file_type, $downloadUrl
           <div class="card mb-2">
             <div class="card-header d-flex justify-content-between align-items-start">
               <div>
-                <span class="badge bg-success me-1">Agency</span><span class="fw-semibold"><?= htmlspecialchars($agency['name']); ?></span>
+                <span class="badge bg-success me-1">Agency</span><span class="fw-semibold"><?= e($agency['name']); ?></span>
                 <?= render_file_attachment($agency['file_path'], $agency['file_name'], $agency['file_type'], "/module/agency/download.php?type=agency&id={$agency['id']}", 'agency'); ?>
                 <?php if (!empty($agency['persons'])): ?>
                   <br><small>
@@ -218,7 +218,7 @@ function render_file_attachment($file_path, $file_name, $file_type, $downloadUrl
                         $label = $p['name'];
                         if ($p['role_label']) $label .= ' ('.$p['role_label'].')';
                         if ($p['is_lead']) $label .= ' [Lead]';
-                        $parts[] = htmlspecialchars($label);
+                        $parts[] = e($label);
                       }
                       echo implode(', ', $parts);
                     ?>
@@ -247,7 +247,7 @@ function render_file_attachment($file_path, $file_name, $file_type, $downloadUrl
                 <?php foreach ($agency['divisions'] as $division): ?>
                   <li class="list-group-item d-flex justify-content-between align-items-start">
                     <div>
-                      <span class="badge bg-warning me-1">Division</span><?= htmlspecialchars($division['name']); ?>
+                      <span class="badge bg-warning me-1">Division</span><?= e($division['name']); ?>
                       <?= render_file_attachment($division['file_path'], $division['file_name'], $division['file_type'], "/module/agency/download.php?type=division&id={$division['id']}", 'division'); ?>
                     </div>
                     <div class="text-end">

--- a/admin/orgs/organization_edit.php
+++ b/admin/orgs/organization_edit.php
@@ -136,14 +136,14 @@ require '../admin_header.php';
       <input type="hidden" name="csrf_token" value="<?= $token; ?>">
       <div class="mb-3">
         <label class="form-label">Name</label>
-        <input type="text" name="name" class="form-control" value="<?= htmlspecialchars($name); ?>" required>
+        <input type="text" name="name" class="form-control" value="<?= e($name); ?>" required>
       </div>
       <div class="mb-3">
         <label class="form-label">Main Person</label>
         <select name="main_person" class="form-select">
           <option value="">-- None --</option>
           <?php foreach($personOptions as $pid => $pname): ?>
-            <option value="<?= $pid; ?>" <?= (int)$pid === (int)$main_person ? 'selected' : ''; ?>><?= htmlspecialchars($pname); ?></option>
+            <option value="<?= $pid; ?>" <?= (int)$pid === (int)$main_person ? 'selected' : ''; ?>><?= e($pname); ?></option>
           <?php endforeach; ?>
         </select>
       </div>
@@ -151,7 +151,7 @@ require '../admin_header.php';
         <label class="form-label">Status</label>
         <select name="status" class="form-select">
           <?php foreach($statusOptions as $sid => $slabel): ?>
-            <option value="<?= $sid; ?>" <?= (int)$sid === (int)$status ? 'selected' : ''; ?>><?= htmlspecialchars($slabel); ?></option>
+            <option value="<?= $sid; ?>" <?= (int)$sid === (int)$status ? 'selected' : ''; ?>><?= e($slabel); ?></option>
           <?php endforeach; ?>
         </select>
       </div>
@@ -159,12 +159,12 @@ require '../admin_header.php';
         <label class="form-label">Upload File</label>
         <?php if ($file_path): ?>
           <div class="mb-2">
-            <a href="/module/agency/download.php?type=organization&id=<?= $id; ?>" target="_blank"><?= htmlspecialchars($file_name); ?></a>
+            <a href="/module/agency/download.php?type=organization&id=<?= $id; ?>" target="_blank"><?= e($file_name); ?></a>
             <button class="btn btn-outline-danger btn-sm ms-2" name="remove_file" value="1" formnovalidate>Remove File</button>
             <?php if (strpos($file_type,'image/') === 0): ?>
-              <img src="/module/agency/uploads/organization/<?= htmlspecialchars($file_path); ?>" class="img-fluid mt-2" alt="Preview">
+              <img src="/module/agency/uploads/organization/<?= e($file_path); ?>" class="img-fluid mt-2" alt="Preview">
             <?php elseif ($file_type === 'application/pdf'): ?>
-              <embed src="/module/agency/uploads/organization/<?= htmlspecialchars($file_path); ?>" type="application/pdf" class="w-100 mt-2" style="height:200px;"></embed>
+              <embed src="/module/agency/uploads/organization/<?= e($file_path); ?>" type="application/pdf" class="w-100 mt-2" style="height:200px;"></embed>
             <?php endif; ?>
           </div>
         <?php endif; ?>
@@ -186,8 +186,8 @@ require '../admin_header.php';
         <tbody>
           <?php foreach($assignedPersons as $ap): ?>
             <tr>
-              <td><?= htmlspecialchars($ap['name']); ?></td>
-              <td><?= htmlspecialchars($ap['role_label'] ?? ''); ?></td>
+              <td><?= e($ap['name']); ?></td>
+              <td><?= e($ap['role_label'] ?? ''); ?></td>
               <td><?= $ap['is_lead'] ? 'Yes' : 'No'; ?></td>
               <td>
                 <form method="post" action="functions/organization_remove_person.php" class="d-inline">
@@ -208,7 +208,7 @@ require '../admin_header.php';
           <select name="person_id" class="form-select" required>
             <option value="">-- Person --</option>
             <?php foreach($personOptions as $pid=>$pname): ?>
-              <option value="<?= $pid; ?>"><?= htmlspecialchars($pname); ?></option>
+              <option value="<?= $pid; ?>"><?= e($pname); ?></option>
             <?php endforeach; ?>
           </select>
         </div>
@@ -216,7 +216,7 @@ require '../admin_header.php';
           <select name="role_id" class="form-select">
             <option value="">-- Role --</option>
             <?php foreach($roleOptions as $rid=>$rlabel): ?>
-              <option value="<?= $rid; ?>"><?= htmlspecialchars($rlabel); ?></option>
+              <option value="<?= $rid; ?>"><?= e($rlabel); ?></option>
             <?php endforeach; ?>
           </select>
         </div>

--- a/admin/person/index.php
+++ b/admin/person/index.php
@@ -38,7 +38,7 @@ $stmt->execute([':ph_status'=>$defaultPhoneStatus, ':addr_status'=>$defaultAddrS
 $persons = $stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <h2 class="mb-4">Persons</h2>
-<?php if($message){ echo '<div class="alert alert-success">'.htmlspecialchars($message).'</div>'; } ?>
+<?php if($message){ echo '<div class="alert alert-success">'.e($message).'</div>'; } ?>
 <a href="edit.php" class="btn btn-sm btn-success mb-3">Add Person</a>
 <div id="persons" data-list='{"valueNames":["name","email"],"page":20,"pagination":true}'>
   <div class="row justify-content-between g-2 mb-3">
@@ -52,22 +52,22 @@ $persons = $stmt->fetchAll(PDO::FETCH_ASSOC);
         <div class="card h-100 shadow-sm">
           <div class="card-body d-flex flex-column justify-content-between">
             <div>
-              <h5 class="name mb-1"><?= htmlspecialchars(trim(($p['first_name'] ?? '').' '.($p['last_name'] ?? ''))); ?></h5>
+              <h5 class="name mb-1"><?= e(trim(($p['first_name'] ?? '').' '.($p['last_name'] ?? ''))); ?></h5>
               <?php if($p['email']): ?>
-                <p class="email text-muted small mb-1"><?= htmlspecialchars($p['email']); ?></p>
+                <p class="email text-muted small mb-1"><?= e($p['email']); ?></p>
               <?php endif; ?>
               <?php if($p['org_name'] || $p['agency_name'] || $p['division_name']): ?>
                 <p class="text-muted small mb-1">
-                  <?= htmlspecialchars($p['org_name'] ?? ''); ?>
-                  <?php if($p['agency_name']): ?>/ <?= htmlspecialchars($p['agency_name']); ?><?php endif; ?>
-                  <?php if($p['division_name']): ?>/ <?= htmlspecialchars($p['division_name']); ?><?php endif; ?>
+                  <?= e($p['org_name'] ?? ''); ?>
+                  <?php if($p['agency_name']): ?>/ <?= e($p['agency_name']); ?><?php endif; ?>
+                  <?php if($p['division_name']): ?>/ <?= e($p['division_name']); ?><?php endif; ?>
                 </p>
               <?php endif; ?>
               <?php if($p['phone_number']): ?>
-                <p class="text-muted small mb-1">📞 <?= htmlspecialchars($p['phone_number']); ?></p>
+                <p class="text-muted small mb-1">📞 <?= e($p['phone_number']); ?></p>
               <?php endif; ?>
               <?php if($p['address_line1']): ?>
-                <p class="text-muted small mb-2">🏠 <?= htmlspecialchars($p['address_line1']); ?><?= $p['city'] ? ', '.htmlspecialchars($p['city']) : ''; ?><?= $p['state_code'] ? ' '.htmlspecialchars($p['state_code']) : ''; ?><?= $p['postal_code'] ? ' '.htmlspecialchars($p['postal_code']) : ''; ?></p>
+                <p class="text-muted small mb-2">🏠 <?= e($p['address_line1']); ?><?= $p['city'] ? ', '.e($p['city']) : ''; ?><?= $p['state_code'] ? ' '.e($p['state_code']) : ''; ?><?= $p['postal_code'] ? ' '.e($p['postal_code']) : ''; ?></p>
               <?php endif; ?>
             </div>
             <div>

--- a/admin/roles/edit.php
+++ b/admin/roles/edit.php
@@ -70,18 +70,18 @@ require '../admin_header.php';
   <input type="hidden" name="csrf_token" value="<?= $token; ?>">
   <div class="mb-3">
     <label class="form-label">Name</label>
-    <input type="text" name="name" class="form-control" value="<?= htmlspecialchars($name); ?>" required>
+    <input type="text" name="name" class="form-control" value="<?= e($name); ?>" required>
   </div>
   <div class="mb-3">
     <label class="form-label">Description</label>
-    <textarea name="description" class="form-control" rows="3"><?= htmlspecialchars($description); ?></textarea>
+    <textarea name="description" class="form-control" rows="3"><?= e($description); ?></textarea>
   </div>
   <div class="mb-3">
     <label class="form-label">Permission Groups</label>
     <?php foreach($allGroups as $g): ?>
       <div class="form-check">
         <input class="form-check-input" type="checkbox" name="groups[]" value="<?= $g['id']; ?>" <?= in_array($g['id'], $assignedGroups) ? 'checked' : '';?>>
-        <label class="form-check-label"><?= htmlspecialchars($g['name']); ?></label>
+        <label class="form-check-label"><?= e($g['name']); ?></label>
       </div>
     <?php endforeach; ?>
   </div>

--- a/admin/roles/index.php
+++ b/admin/roles/index.php
@@ -35,7 +35,7 @@ $stmt = $pdo->query('SELECT r.id, r.name, r.description, GROUP_CONCAT(pg.name OR
 $roles = $stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <h2 class="mb-4">Roles</h2>
-<?php if($message){ echo '<div class="alert alert-success">'.htmlspecialchars($message).'</div>'; } ?>
+<?php if($message){ echo '<div class="alert alert-success">'.e($message).'</div>'; } ?>
 <div class="mb-3">
   <a href="edit.php" class="btn btn-sm btn-success">Add Role</a>
   <a href="permissions.php" class="btn btn-sm btn-info">Permissions</a>
@@ -61,10 +61,10 @@ $roles = $stmt->fetchAll(PDO::FETCH_ASSOC);
       <tbody class="list">
         <?php foreach($roles as $r): ?>
           <tr>
-            <td class="id"><?= htmlspecialchars($r['id']); ?></td>
-            <td class="name"><?= htmlspecialchars($r['name']); ?></td>
-            <td class="description"><?= htmlspecialchars($r['description']); ?></td>
-            <td class="groups"><?= htmlspecialchars($r['groups'] ?: '-'); ?></td>
+            <td class="id"><?= e($r['id']); ?></td>
+            <td class="name"><?= e($r['name']); ?></td>
+            <td class="description"><?= e($r['description']); ?></td>
+            <td class="groups"><?= e($r['groups'] ?: '-'); ?></td>
             <td>
               <a class="btn btn-sm btn-warning" href="edit.php?id=<?= $r['id']; ?>">Edit</a>
               <form method="post" class="d-inline">

--- a/admin/roles/matrix.php
+++ b/admin/roles/matrix.php
@@ -60,7 +60,7 @@ foreach ($currentMap as $rid => $pids) {
 }
 ?>
   <h2 class="mb-4">Role Permission Groups</h2>
-<?php if($message){ echo '<div class="alert alert-success">'.htmlspecialchars($message).'</div>'; } ?>
+<?php if($message){ echo '<div class="alert alert-success">'.e($message).'</div>'; } ?>
 <form method="post">
   <input type="hidden" name="csrf_token" value="<?= $token; ?>">
   <div class="table-responsive">
@@ -69,14 +69,14 @@ foreach ($currentMap as $rid => $pids) {
         <tr>
           <th>Permission</th>
           <?php foreach($roles as $r): ?>
-            <th><?= htmlspecialchars($r['name']); ?></th>
+            <th><?= e($r['name']); ?></th>
           <?php endforeach; ?>
         </tr>
       </thead>
       <tbody>
         <?php foreach($groups as $p): ?>
           <tr>
-            <td><?= htmlspecialchars($p['name']); ?></td>
+            <td><?= e($p['name']); ?></td>
             <?php foreach($roles as $r): ?>
               <td class="text-center">
                 <input type="checkbox" name="grp[<?= $r['id']; ?>][]" value="<?= $p['id']; ?>" <?= isset($assignedMap[$r['id']][$p['id']]) ? 'checked' : ''; ?>>

--- a/admin/roles/permission_edit.php
+++ b/admin/roles/permission_edit.php
@@ -52,11 +52,11 @@ require '../admin_header.php';
   <input type="hidden" name="csrf_token" value="<?= $token; ?>">
   <div class="mb-3">
     <label class="form-label">Module</label>
-    <input type="text" name="module" class="form-control" value="<?= htmlspecialchars($module); ?>" required>
+    <input type="text" name="module" class="form-control" value="<?= e($module); ?>" required>
   </div>
   <div class="mb-3">
     <label class="form-label">Action</label>
-    <input type="text" name="action" class="form-control" value="<?= htmlspecialchars($action); ?>" required>
+    <input type="text" name="action" class="form-control" value="<?= e($action); ?>" required>
   </div>
   <button class="btn <?= $btnClass; ?>" type="submit">Save</button>
   <a href="permissions.php" class="btn btn-secondary">Cancel</a>

--- a/admin/roles/permissions.php
+++ b/admin/roles/permissions.php
@@ -23,7 +23,7 @@ $stmt = $pdo->query('SELECT id, module, action FROM admin_permissions ORDER BY m
 $perms = $stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <h2 class="mb-4">Permissions</h2>
-<?php if($message){ echo '<div class="alert alert-success">'.htmlspecialchars($message).'</div>'; } ?>
+<?php if($message){ echo '<div class="alert alert-success">'.e($message).'</div>'; } ?>
 <a href="permission_edit.php" class="btn btn-sm btn-success mb-3">Add Permission</a>
 <div id="permissions" data-list='{"valueNames":["id","module","action"],"page":25,"pagination":true}'>
   <div class="row justify-content-between g-2 mb-3">
@@ -44,9 +44,9 @@ $perms = $stmt->fetchAll(PDO::FETCH_ASSOC);
       <tbody class="list">
         <?php foreach($perms as $p): ?>
           <tr>
-            <td class="id"><?= htmlspecialchars($p['id']); ?></td>
-            <td class="module"><?= htmlspecialchars($p['module']); ?></td>
-            <td class="action"><?= htmlspecialchars($p['action']); ?></td>
+            <td class="id"><?= e($p['id']); ?></td>
+            <td class="module"><?= e($p['module']); ?></td>
+            <td class="action"><?= e($p['action']); ?></td>
             <td>
               <a class="btn btn-sm btn-warning" href="permission_edit.php?id=<?= $p['id']; ?>">Edit</a>
               <form method="post" class="d-inline">

--- a/admin/system-properties/edit.php
+++ b/admin/system-properties/edit.php
@@ -36,13 +36,13 @@ foreach($types as $t){
 <h2 class="mb-4"><?= $id?'Edit':'Add'; ?> System Property</h2>
 <form id="propertyForm">
   <input type="hidden" name="csrf_token" value="<?= $token; ?>">
-  <input type="hidden" name="id" value="<?= htmlspecialchars($id); ?>">
+  <input type="hidden" name="id" value="<?= e($id); ?>">
   <div class="mb-3">
     <label class="form-label">Category</label>
     <select class="form-select" data-choices name="category_id">
       <option value="">Select Category</option>
       <?php foreach($categories as $c): ?>
-        <option value="<?= $c['id']; ?>" <?= $prop['category_id']==$c['id']?'selected':''; ?>><?= htmlspecialchars($c['label']); ?></option>
+        <option value="<?= $c['id']; ?>" <?= $prop['category_id']==$c['id']?'selected':''; ?>><?= e($c['label']); ?></option>
       <?php endforeach; ?>
     </select>
   </div>
@@ -51,29 +51,29 @@ foreach($types as $t){
     <select class="form-select" data-choices name="type_id">
       <option value="">Select Type</option>
       <?php foreach($types as $t): ?>
-        <option value="<?= $t['id']; ?>" <?= $prop['type_id']==$t['id']?'selected':''; ?>><?= htmlspecialchars($t['label']); ?></option>
+        <option value="<?= $t['id']; ?>" <?= $prop['type_id']==$t['id']?'selected':''; ?>><?= e($t['label']); ?></option>
       <?php endforeach; ?>
     </select>
   </div>
   <div class="mb-3">
     <label class="form-label">Name</label>
-    <input type="text" class="form-control" name="name" value="<?= htmlspecialchars($prop['name']); ?>" required>
+    <input type="text" class="form-control" name="name" value="<?= e($prop['name']); ?>" required>
   </div>
   <div class="mb-3">
     <label class="form-label">Value</label>
     <?php if($isPasswordType): ?>
     <div class="input-group" data-password="data-password">
-      <input type="password" class="form-control" name="value" value="<?= htmlspecialchars($prop['value']); ?>" data-password-input="data-password-input" required>
+      <input type="password" class="form-control" name="value" value="<?= e($prop['value']); ?>" data-password-input="data-password-input" required>
       <button class="btn btn-outline-secondary" type="button" data-password-toggle="data-password-toggle"><span class="uil uil-eye show"></span><span class="uil uil-eye-slash hide"></span></button>
     </div>
     <?php else: ?>
-    <textarea class="form-control" name="value" required><?= htmlspecialchars($prop['value']); ?></textarea>
+    <textarea class="form-control" name="value" required><?= e($prop['value']); ?></textarea>
     <?php endif; ?>
 
   </div>
   <div class="mb-3">
     <label class="form-label">Memo</label>
-    <textarea class="form-control" name="memo"><?= htmlspecialchars($prop['memo'] ?? ''); ?></textarea>
+    <textarea class="form-control" name="memo"><?= e($prop['memo'] ?? ''); ?></textarea>
   </div>
   <button type="submit" class="btn btn-primary">Save</button>
   <a href="index.php" class="btn btn-secondary">Cancel</a>

--- a/admin/system-properties/index.php
+++ b/admin/system-properties/index.php
@@ -28,19 +28,19 @@ $props = $stmt->fetchAll(PDO::FETCH_ASSOC);
       <tbody class="list">
         <?php foreach($props as $p): ?>
         <?php $isPassword = stripos($p['type'],'password') !== false || stripos($p['name'],'password') !== false; ?>
-        <tr data-id="<?= htmlspecialchars($p['id']); ?>">
-          <td class="id"><?= htmlspecialchars($p['id']); ?></td>
-          <td class="name"><?= htmlspecialchars($p['name']); ?></td>
-          <td class="category"><?= htmlspecialchars($p['category']); ?></td>
-          <td class="type"><?= htmlspecialchars($p['type']); ?></td>
+        <tr data-id="<?= e($p['id']); ?>">
+          <td class="id"><?= e($p['id']); ?></td>
+          <td class="name"><?= e($p['name']); ?></td>
+          <td class="category"><?= e($p['category']); ?></td>
+          <td class="type"><?= e($p['type']); ?></td>
           <td>
             <?php if($isPassword): ?>
             <div class="d-flex align-items-center">
-              <input type="password" class="form-control-plaintext form-control-sm w-auto" value="<?= htmlspecialchars($p['value'], ENT_QUOTES); ?>" readonly>
+              <input type="password" class="form-control-plaintext form-control-sm w-auto" value="<?= e($p['value'], ENT_QUOTES); ?>" readonly>
               <button type="button" class="btn btn-sm btn-phoenix-secondary ms-2 toggle-password"><span class="fa-solid fa-eye"></span></button>
             </div>
             <?php else: ?>
-            <?= htmlspecialchars($p['value']); ?>
+            <?= e($p['value']); ?>
             <?php endif; ?>
           </td>
           <td>

--- a/admin/system-properties/version-history.php
+++ b/admin/system-properties/version-history.php
@@ -16,16 +16,16 @@ if($id){
   $versions = $stmt->fetchAll(PDO::FETCH_ASSOC);
 }
 ?>
-<h2 class="mb-4">Version History: <?= htmlspecialchars($name); ?></h2>
+<h2 class="mb-4">Version History: <?= e($name); ?></h2>
 <table class="table table-striped table-sm">
   <thead><tr><th>Version</th><th>Date</th><th>User</th><th>Previous Value</th><th>Action</th></tr></thead>
   <tbody>
   <?php foreach($versions as $v): ?>
     <tr data-id="<?= $v['id']; ?>">
-      <td><?= htmlspecialchars($v['version_number']); ?></td>
-      <td><?= htmlspecialchars($v['date_created']); ?></td>
-      <td><?= htmlspecialchars($v['user_id']); ?></td>
-      <td><pre class="mb-0"><?= htmlspecialchars($v['previous_value']); ?></pre></td>
+      <td><?= e($v['version_number']); ?></td>
+      <td><?= e($v['date_created']); ?></td>
+      <td><?= e($v['user_id']); ?></td>
+      <td><pre class="mb-0"><?= e($v['previous_value']); ?></pre></td>
       <td><button class="btn btn-sm btn-warning restore" data-id="<?= $v['id']; ?>">Restore</button></td>
     </tr>
   <?php endforeach; ?>

--- a/admin/tasks/index.php
+++ b/admin/tasks/index.php
@@ -56,13 +56,13 @@ $tasks = $pdo->query($sql)->fetchAll(PDO::FETCH_ASSOC);
       <tbody class="list">
         <?php foreach($tasks as $t): ?>
         <tr>
-          <td class="id"><?= htmlspecialchars($t['id']); ?></td>
-          <td class="name"><?= htmlspecialchars($t['name']); ?></td>
-          <td class="type"><?= htmlspecialchars($t['type_label']); ?></td>
-          <td class="category"><?= htmlspecialchars($t['category_label']); ?></td>
-          <td class="subcategory"><?= htmlspecialchars($t['sub_category_label']); ?></td>
-          <td class="status"><?= htmlspecialchars($t['status_label']); ?></td>
-          <td class="priority"><?= htmlspecialchars($t['priority_label']); ?></td>
+          <td class="id"><?= e($t['id']); ?></td>
+          <td class="name"><?= e($t['name']); ?></td>
+          <td class="type"><?= e($t['type_label']); ?></td>
+          <td class="category"><?= e($t['category_label']); ?></td>
+          <td class="subcategory"><?= e($t['sub_category_label']); ?></td>
+          <td class="status"><?= e($t['status_label']); ?></td>
+          <td class="priority"><?= e($t['priority_label']); ?></td>
           <td>
             <a class="btn btn-sm btn-warning" href="task.php?id=<?= $t['id']; ?>">Edit</a>
             <?php if (user_has_permission('admin_task','delete')): ?>

--- a/admin/tasks/task.php
+++ b/admin/tasks/task.php
@@ -71,11 +71,11 @@ $_SESSION['csrf_token'] = $token;
   <?php endif; ?>
   <div class="mb-3">
     <label class="form-label">Name</label>
-    <input type="text" name="name" class="form-control" value="<?= htmlspecialchars($task['name']); ?>" required>
+    <input type="text" name="name" class="form-control" value="<?= e($task['name']); ?>" required>
   </div>
   <div class="mb-3">
     <label class="form-label">Description</label>
-    <textarea name="description" class="form-control" rows="3"><?= htmlspecialchars($task['description']); ?></textarea>
+    <textarea name="description" class="form-control" rows="3"><?= e($task['description']); ?></textarea>
   </div>
   <div class="row mb-3">
     <div class="col">
@@ -83,7 +83,7 @@ $_SESSION['csrf_token'] = $token;
       <select name="type_id" class="form-select">
         <option value="">--</option>
         <?php foreach ($types as $i): ?>
-        <option value="<?= $i['id']; ?>" <?= $task['type_id'] == $i['id'] ? 'selected' : ''; ?>><?= htmlspecialchars($i['label']); ?></option>
+        <option value="<?= $i['id']; ?>" <?= $task['type_id'] == $i['id'] ? 'selected' : ''; ?>><?= e($i['label']); ?></option>
         <?php endforeach; ?>
       </select>
     </div>
@@ -92,7 +92,7 @@ $_SESSION['csrf_token'] = $token;
       <select name="category_id" class="form-select">
         <option value="">--</option>
         <?php foreach ($categories as $i): ?>
-        <option value="<?= $i['id']; ?>" <?= $task['category_id'] == $i['id'] ? 'selected' : ''; ?>><?= htmlspecialchars($i['label']); ?></option>
+        <option value="<?= $i['id']; ?>" <?= $task['category_id'] == $i['id'] ? 'selected' : ''; ?>><?= e($i['label']); ?></option>
         <?php endforeach; ?>
       </select>
     </div>
@@ -101,7 +101,7 @@ $_SESSION['csrf_token'] = $token;
       <select name="sub_category_id" class="form-select">
         <option value="">--</option>
         <?php foreach ($subcategories as $i): ?>
-        <option value="<?= $i['id']; ?>" <?= $task['sub_category_id'] == $i['id'] ? 'selected' : ''; ?>><?= htmlspecialchars($i['label']); ?></option>
+        <option value="<?= $i['id']; ?>" <?= $task['sub_category_id'] == $i['id'] ? 'selected' : ''; ?>><?= e($i['label']); ?></option>
         <?php endforeach; ?>
       </select>
     </div>
@@ -112,7 +112,7 @@ $_SESSION['csrf_token'] = $token;
       <select name="status_id" class="form-select">
         <option value="">--</option>
         <?php foreach ($statuses as $i): ?>
-        <option value="<?= $i['id']; ?>" <?= $task['status_id'] == $i['id'] ? 'selected' : ''; ?>><?= htmlspecialchars($i['label']); ?></option>
+        <option value="<?= $i['id']; ?>" <?= $task['status_id'] == $i['id'] ? 'selected' : ''; ?>><?= e($i['label']); ?></option>
         <?php endforeach; ?>
       </select>
     </div>
@@ -121,7 +121,7 @@ $_SESSION['csrf_token'] = $token;
       <select name="priority_id" class="form-select">
         <option value="">--</option>
         <?php foreach ($priorities as $i): ?>
-        <option value="<?= $i['id']; ?>" <?= $task['priority_id'] == $i['id'] ? 'selected' : ''; ?>><?= htmlspecialchars($i['label']); ?></option>
+        <option value="<?= $i['id']; ?>" <?= $task['priority_id'] == $i['id'] ? 'selected' : ''; ?>><?= e($i['label']); ?></option>
         <?php endforeach; ?>
       </select>
     </div>
@@ -129,24 +129,24 @@ $_SESSION['csrf_token'] = $token;
   <div class="row mb-3">
     <div class="col">
       <label class="form-label">Start Date</label>
-      <input type="date" name="start_date" class="form-control" value="<?= htmlspecialchars($task['start_date']); ?>">
+      <input type="date" name="start_date" class="form-control" value="<?= e($task['start_date']); ?>">
     </div>
     <div class="col">
       <label class="form-label">Due Date</label>
-      <input type="date" name="due_date" class="form-control" value="<?= htmlspecialchars($task['due_date']); ?>">
+      <input type="date" name="due_date" class="form-control" value="<?= e($task['due_date']); ?>">
     </div>
   </div>
   <div class="mb-3">
     <label class="form-label">Assign Users</label>
     <select name="assignments[]" class="form-select" multiple>
       <?php foreach ($users as $u): ?>
-      <option value="<?= $u['id']; ?>" <?= in_array($u['id'], $assignedUserIds) ? 'selected' : ''; ?>><?= htmlspecialchars($u['email']); ?></option>
+      <option value="<?= $u['id']; ?>" <?= in_array($u['id'], $assignedUserIds) ? 'selected' : ''; ?>><?= e($u['email']); ?></option>
       <?php endforeach; ?>
     </select>
   </div>
   <div class="mb-3">
     <label class="form-label">Memo</label>
-    <textarea name="memo" class="form-control" rows="2"><?= htmlspecialchars($task['memo']); ?></textarea>
+    <textarea name="memo" class="form-control" rows="2"><?= e($task['memo']); ?></textarea>
   </div>
   <div class="mb-3">
     <button class="btn btn-sm btn-primary" type="submit">Save</button>
@@ -162,7 +162,7 @@ $_SESSION['csrf_token'] = $token;
 <ul class="list-unstyled">
   <?php foreach ($files as $f): ?>
   <li>
-    <a href="../tasks/uploads/<?= htmlspecialchars(basename($f['file_path'])); ?>" target="_blank"><?= htmlspecialchars($f['file_name']); ?></a>
+    <a href="../tasks/uploads/<?= e(basename($f['file_path'])); ?>" target="_blank"><?= e($f['file_name']); ?></a>
     <?php if (user_has_permission('admin_task_file','delete')): ?>
     <form method="post" action="functions/delete_file.php" class="d-inline">
       <input type="hidden" name="csrf_token" value="<?= $token; ?>">
@@ -186,8 +186,8 @@ $_SESSION['csrf_token'] = $token;
 <ul class="list-unstyled">
   <?php foreach ($comments as $c): ?>
   <li class="mb-2">
-    <strong><?= htmlspecialchars($c['email']); ?>:</strong>
-    <?= nl2br(htmlspecialchars($c['comment'])); ?>
+    <strong><?= e($c['email']); ?>:</strong>
+    <?= nl2br(e($c['comment'])); ?>
     <?php if (user_has_permission('admin_task_comment','delete')): ?>
     <form method="post" action="functions/delete_comment.php" class="d-inline">
       <input type="hidden" name="csrf_token" value="<?= $token; ?>">

--- a/admin/users/edit.php
+++ b/admin/users/edit.php
@@ -96,7 +96,7 @@ $_SESSION['csrf_token'] = $token; ?>
   <div class="alert alert-danger">
     <ul class="mb-0">
       <?php foreach ($errors as $e): ?>
-        <li><?php echo htmlspecialchars($e); ?></li>
+        <li><?php echo e($e); ?></li>
       <?php endforeach; ?>
     </ul>
   </div>
@@ -120,7 +120,7 @@ $_SESSION['csrf_token'] = $token; ?>
           <div class="position-relative bg-body-quaternary rounded-circle cursor-pointer d-flex flex-center">
             <? if(isset($gender_id)){ $user_gender = get_lookup_item_label_from_id($pdo, $gender_id); }else{ $user_gender = NULL; } ?>
             <? if(isset($gender_id) && $user_gender == "Female"){ $gender_img = 10;  }elseif($user_gender == 'Male'){ $gender_img = 65; }else{ $gender_img = "avatar"; } ?>
-            <div class="avatar avatar-5xl"><img class="rounded-circle" src="<?php echo $profile_pic ? getURLDir() . htmlspecialchars($profile_pic) : getURLDir() . "assets/img/team/150x150/$gender_img.webp"; ?>" alt="" /></div>
+            <div class="avatar avatar-5xl"><img class="rounded-circle" src="<?php echo $profile_pic ? getURLDir() . e($profile_pic) : getURLDir() . "assets/img/team/150x150/$gender_img.webp"; ?>" alt="" /></div>
             <label class="w-100 h-100 position-absolute z-1" for="upload-avatar"></label>
         </div>
         </div>
@@ -150,10 +150,10 @@ $_SESSION['csrf_token'] = $token; ?>
                   <tbody>
                     <?php foreach ($profilePics as $pic): ?>
                       <tr>
-                        <td><img src="<?php echo getURLDir(); echo htmlspecialchars($pic['file_path'] ?? ''); ?>" class="img-thumbnail" style="width:60px;height:auto;"></td>
-                        <td><?php echo htmlspecialchars($pic['status_label'] ?? ''); ?></td>
-                        <td><?php echo htmlspecialchars($pic['date_created'] ?? ''); ?></td>
-                        <td><?php echo htmlspecialchars($pic['width'] ?? ''); ?>x<?php echo htmlspecialchars($pic['height'] ?? ''); ?></td>
+                        <td><img src="<?php echo getURLDir(); echo e($pic['file_path'] ?? ''); ?>" class="img-thumbnail" style="width:60px;height:auto;"></td>
+                        <td><?php echo e($pic['status_label'] ?? ''); ?></td>
+                        <td><?php echo e($pic['date_created'] ?? ''); ?></td>
+                        <td><?php echo e($pic['width'] ?? ''); ?>x<?php echo e($pic['height'] ?? ''); ?></td>
                         <td>
                           <?php if ($pic['status_code'] !== 'ACTIVE'): ?>
                             <button type="submit" class="btn btn-sm btn-primary" form="reactivate-form" name="reactivate_pic_id" value="<?php echo $pic['id']; ?>" formnovalidate>Reactivate</button>
@@ -172,35 +172,35 @@ $_SESSION['csrf_token'] = $token; ?>
       <div class="row g-3 mb-3">
         <div class="col-sm-6 col-md-4">
           <div class="form-floating">
-            <input type="text" class="form-control" id="first_name" name="first_name" placeholder="First Name" value="<?php echo htmlspecialchars($first_name); ?>" required>
+            <input type="text" class="form-control" id="first_name" name="first_name" placeholder="First Name" value="<?php echo e($first_name); ?>" required>
             <label for="first_name">First Name</label>
             <div class="invalid-feedback">Please provide a first name.</div>
           </div>
         </div>
         <div class="col-sm-6 col-md-4">
           <div class="form-floating">
-            <input type="text" class="form-control" id="last_name" name="last_name" placeholder="Last Name" value="<?php echo htmlspecialchars($last_name); ?>" required>
+            <input type="text" class="form-control" id="last_name" name="last_name" placeholder="Last Name" value="<?php echo e($last_name); ?>" required>
             <label for="last_name">Last Name</label>
             <div class="invalid-feedback">Please provide a last name.</div>
           </div>
         </div>
         <div class="col-sm-6 col-md-4">
           <div class="form-floating">
-            <input type="email" class="form-control" id="email" name="email" placeholder="Email" value="<?php echo htmlspecialchars($email); ?>" required>
+            <input type="email" class="form-control" id="email" name="email" placeholder="Email" value="<?php echo e($email); ?>" required>
             <label for="email">Email</label>
             <div class="invalid-feedback">Please provide a valid email.</div>
           </div>
         </div>
         <div class="col-sm-6 col-md-4">
           <div class="form-floating">
-            <input type="password" class="form-control" id="password" name="password" placeholder="Password" value="<?php echo htmlspecialchars($defaultPassword); ?>" <?php echo $id ? '' : 'required'; ?>>
+            <input type="password" class="form-control" id="password" name="password" placeholder="Password" value="<?php echo e($defaultPassword); ?>" <?php echo $id ? '' : 'required'; ?>>
             <label for="password">Password</label>
             <div class="invalid-feedback">Please provide a password.</div>
           </div>
         </div>
         <div class="col-sm-6 col-md-4">
           <div class="form-floating">
-            <input type="password" class="form-control" id="confirmPassword" name="confirmPassword" placeholder="Confirm Password" value="<?php echo htmlspecialchars($defaultPassword); ?>" <?php echo $id ? '' : 'required'; ?>>
+            <input type="password" class="form-control" id="confirmPassword" name="confirmPassword" placeholder="Confirm Password" value="<?php echo e($defaultPassword); ?>" <?php echo $id ? '' : 'required'; ?>>
             <label for="confirmPassword">Confirm Password</label>
             <div class="invalid-feedback">Please confirm password.</div>
           </div>
@@ -220,7 +220,7 @@ $_SESSION['csrf_token'] = $token; ?>
             <select class="form-select" id="gender_id" name="gender_id">
               <option value="">Select...</option>
               <?php foreach ($genderItems as $item): ?>
-                <option value="<?php echo $item['id']; ?>" <?php echo (int)$gender_id === (int)$item['id'] ? 'selected' : ''; ?>><?php echo htmlspecialchars($item['label']); ?></option>
+                <option value="<?php echo $item['id']; ?>" <?php echo (int)$gender_id === (int)$item['id'] ? 'selected' : ''; ?>><?php echo e($item['label']); ?></option>
               <?php endforeach; ?>
             </select>
             <label for="gender_id">Gender</label>
@@ -228,7 +228,7 @@ $_SESSION['csrf_token'] = $token; ?>
         </div>
         <div class="col-sm-6 col-md-4">
           <div class="form-floating">
-            <input type="date" class="form-control" id="dob" name="dob" placeholder="Date of Birth" value="<?php echo htmlspecialchars($dob); ?>">
+            <input type="date" class="form-control" id="dob" name="dob" placeholder="Date of Birth" value="<?php echo e($dob); ?>">
             <label for="dob">Date of Birth</label>
           </div>
         </div>
@@ -248,19 +248,19 @@ $_SESSION['csrf_token'] = $token; ?>
           <div id="jti-details" class="row g-3 d-none">
             <div class="col-sm-6 col-md-4">
               <div class="form-floating">
-                <input type="date" class="form-control" id="JTI_start_date" name="JTI_start_date" placeholder="JTI Start Date" value="<?php echo htmlspecialchars($JTI_start_date); ?>">
+                <input type="date" class="form-control" id="JTI_start_date" name="JTI_start_date" placeholder="JTI Start Date" value="<?php echo e($JTI_start_date); ?>">
                 <label for="JTI_start_date">JTI Start Date</label>
               </div>
             </div>
             <div class="col-sm-6 col-md-4">
               <div class="form-floating">
-                <input type="date" class="form-control" id="JTI_end_date" name="JTI_end_date" placeholder="JTI End Date" value="<?php echo htmlspecialchars($JTI_end_date); ?>">
+                <input type="date" class="form-control" id="JTI_end_date" name="JTI_end_date" placeholder="JTI End Date" value="<?php echo e($JTI_end_date); ?>">
                 <label for="JTI_end_date">JTI End Date</label>
               </div>
             </div>
             <div class="col-sm-6 col-md-4">
               <div class="form-floating">
-                <input type="text" class="form-control" id="JTI_Team" name="JTI_Team" placeholder="JTI Team" value="<?php echo htmlspecialchars($JTI_Team); ?>">
+                <input type="text" class="form-control" id="JTI_Team" name="JTI_Team" placeholder="JTI Team" value="<?php echo e($JTI_Team); ?>">
                 <label for="JTI_Team">JTI Team</label>
               </div>
             </div>

--- a/admin/users/index.php
+++ b/admin/users/index.php
@@ -9,8 +9,8 @@ $error_message = $_SESSION['error_message'] ?? '';
 unset($_SESSION['message'], $_SESSION['error_message']);
 ?>
 <h2 class="mb-4">Users</h2>
-<?php if($message){ echo '<div class="alert alert-success">'.htmlspecialchars($message).'</div>'; }
-if($error_message){ echo '<div class="alert alert-danger">'.htmlspecialchars($error_message).'</div>'; } ?>
+<?php if($message){ echo '<div class="alert alert-success">'.e($message).'</div>'; }
+if($error_message){ echo '<div class="alert alert-danger">'.e($error_message).'</div>'; } ?>
 <a href="edit.php" class="btn btn-success mb-3">Add User</a>
 <table class="table table-striped">
   <thead><tr><th>Email</th></tr></thead>
@@ -21,10 +21,10 @@ if($error_message){ echo '<div class="alert alert-danger">'.htmlspecialchars($er
         <h4>
           <a href="edit.php?id=<?php echo $u['id']; ?>">
             <img src="<?php if(isset($u['file_path'])){ echo getURLDir() . $u['file_path']; }else{ echo '/_atlis/assets/img/team/avatar.webp';  }?>" class="img-thumbnail" style="width:40px;height:40px;">
-            <?php echo htmlspecialchars($u['name']); ?>
+            <?php echo e($u['name']); ?>
           </a>
         </h4>
-        <?php echo htmlspecialchars($u['email']); ?>
+        <?php echo e($u['email']); ?>
         <?php if (!empty($u['roles'])): ?>
           <div class="text-body-secondary small"><?php echo h($u['roles']); ?></div>
         <?php endif; ?>

--- a/apps/crm/leads.php
+++ b/apps/crm/leads.php
@@ -24,9 +24,9 @@ require '../../includes/html_header.php';
           <div class="card h-100 shadow-sm">
             <div class="card-body d-flex flex-column justify-content-between">
               <div>
-                <h5 class="name mb-1"><?= htmlspecialchars(trim(($p['first_name'] ?? '') . ' ' . ($p['last_name'] ?? ''))); ?></h5>
+                <h5 class="name mb-1"><?= e(trim(($p['first_name'] ?? '') . ' ' . ($p['last_name'] ?? ''))); ?></h5>
                 <?php if($p['email']): ?>
-                  <p class="email text-muted small mb-2"><?= htmlspecialchars($p['email']); ?></p>
+                  <p class="email text-muted small mb-2"><?= e($p['email']); ?></p>
                 <?php endif; ?>
               </div>
               <div>

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -11,12 +11,16 @@ function verify_csrf_token(?string $token): bool {
     return isset($_SESSION['csrf_token']) && hash_equals($_SESSION['csrf_token'], (string)$token);
 }
 
+function e(?string $value): string {
+    return htmlspecialchars($value ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+}
+
 function flash_message(string $message, string $type = 'success'): string {
     if ($message === '') {
         return '';
     }
-    $type = htmlspecialchars($type, ENT_QUOTES, 'UTF-8');
-    $msg  = htmlspecialchars($message, ENT_QUOTES, 'UTF-8');
+    $type = e($type);
+    $msg  = e($message);
     return '<div class="alert alert-' . $type . '">' . $msg . '</div>';
 }
 

--- a/includes/lookup_helpers.php
+++ b/includes/lookup_helpers.php
@@ -57,12 +57,12 @@ function render_status_badge(array $lookupList, int|string|null $id, ?string $cl
 
     $attrString = '';
     foreach ($attributes as $attr => $value) {
-        $attrString .= ' ' . htmlspecialchars($attr) . '="' . htmlspecialchars($value) . '"';
+        $attrString .= ' ' . e($attr) . '="' . e($value) . '"';
     }
 
-    $classString = trim('badge badge-phoenix badge-phoenix-' . htmlspecialchars($color) . ' ' . ($classes ?? ''));
+    $classString = trim('badge badge-phoenix badge-phoenix-' . e($color) . ' ' . ($classes ?? ''));
 
-    return '<span class="' . $classString . '"' . $attrString . '><span class="badge-label">' . htmlspecialchars($label) . '</span></span>';
+    return '<span class="' . $classString . '"' . $attrString . '><span class="badge-label">' . e($label) . '</span></span>';
 }
 
 /**

--- a/module/agency/details_view.php
+++ b/module/agency/details_view.php
@@ -30,7 +30,7 @@ require '../../includes/html_header.php';
   <?php // require '../../includes/left_navigation.php'; ?>
   <?php require '../../includes/navigation.php'; ?>
   <div id="main_content" class="content">
-    <h2 class="mb-4">Agency: <?php echo htmlspecialchars($agency['name'] ?? ''); ?></h2>
+    <h2 class="mb-4">Agency: <?php echo e($agency['name'] ?? ''); ?></h2>
 
     <div class="card mb-4">
       <div class="card-header"><h5 class="mb-0">Upload Files</h5></div>
@@ -51,9 +51,9 @@ require '../../includes/html_header.php';
             <tbody>
               <?php foreach ($files as $f): ?>
               <tr>
-                <td><a href="<?php echo htmlspecialchars($f['file_path']); ?>"><?php echo htmlspecialchars($f['file_name']); ?></a></td>
-                <td><?php echo htmlspecialchars($f['file_size']); ?></td>
-                <td><?php echo htmlspecialchars($f['file_type']); ?></td>
+                <td><a href="<?php echo e($f['file_path']); ?>"><?php echo e($f['file_name']); ?></a></td>
+                <td><?php echo e($f['file_size']); ?></td>
+                <td><?php echo e($f['file_type']); ?></td>
               </tr>
               <?php endforeach; ?>
             </tbody>
@@ -77,8 +77,8 @@ require '../../includes/html_header.php';
         <ul class="list-group mt-3">
           <?php foreach ($notes as $n): ?>
           <li class="list-group-item d-flex justify-content-between align-items-start">
-            <div><?php echo nl2br(htmlspecialchars($n['note_text'])); ?></div>
-            <small class="text-muted ms-2"><?php echo htmlspecialchars($n['date_created']); ?></small>
+            <div><?php echo nl2br(e($n['note_text'])); ?></div>
+            <small class="text-muted ms-2"><?php echo e($n['date_created']); ?></small>
           </li>
           <?php endforeach; ?>
         </ul>

--- a/module/agency/include/board_view.php
+++ b/module/agency/include/board_view.php
@@ -17,7 +17,7 @@ foreach ($agencies as $agency) {
           <?php foreach (($data['items'] ?? []) as $agency): ?>
             <div class="card mb-2">
               <div class="card-body p-2">
-                <?= htmlspecialchars($agency['name']); ?>
+                <?= e($agency['name']); ?>
                 <span class="badge bg-primary-subtle text-primary ms-1"><?= (int)$agency['user_count']; ?></span>
                 <span class="badge bg-secondary-subtle text-secondary ms-1"><?= (int)$agency['person_count']; ?></span>
               </div>

--- a/module/agency/include/card_view.php
+++ b/module/agency/include/card_view.php
@@ -8,7 +8,7 @@
         <div class="card h-100">
           <div class="card-body">
             <h5 class="card-title mb-1">
-              <?php echo htmlspecialchars($agency['name']); ?>
+              <?php echo e($agency['name']); ?>
               <span class="badge bg-primary-subtle text-primary ms-1"><?= (int)$agency['user_count']; ?></span>
               <span class="badge bg-secondary-subtle text-secondary ms-1"><?= (int)$agency['person_count']; ?></span>
             </h5>

--- a/module/agency/include/list_view.php
+++ b/module/agency/include/list_view.php
@@ -45,7 +45,7 @@
           <?php foreach ($agencies as $agency): ?>
             <tr>
               <td class="align-middle name">
-                <?php echo htmlspecialchars($agency['name']); ?>
+                <?php echo e($agency['name']); ?>
                 <span class="badge bg-primary-subtle text-primary ms-1"><?= (int)$agency['user_count']; ?></span>
                 <span class="badge bg-secondary-subtle text-secondary ms-1"><?= (int)$agency['person_count']; ?></span>
               </td>

--- a/module/calendar/include/calendar_view.php
+++ b/module/calendar/include/calendar_view.php
@@ -21,7 +21,7 @@ $default_event_type_id = $event_types[0]['id'] ?? 0;
     <?php if (!empty($calendars)) { ?>
       <select id="calendarSelect" class="form-select form-select-sm w-auto me-2">
         <?php foreach ($calendars as $cal) { ?>
-          <option value="<?php echo $cal['id']; ?>" <?php echo ($cal['id'] == $calendar_id ? 'selected' : ''); ?>><?php echo htmlspecialchars($cal['name']); ?></option>
+          <option value="<?php echo $cal['id']; ?>" <?php echo ($cal['id'] == $calendar_id ? 'selected' : ''); ?>><?php echo e($cal['name']); ?></option>
         <?php } ?>
       </select>
     <?php } ?>

--- a/module/kanban/include/board_view.php
+++ b/module/kanban/include/board_view.php
@@ -2,7 +2,7 @@
 // Expects $board and $statuses from index.php
 ?>
 <div class="container py-4">
-  <h2 class="mb-4"><?= htmlspecialchars($board['name'] ?? 'Board') ?></h2>
+  <h2 class="mb-4"><?= e($board['name'] ?? 'Board') ?></h2>
   <div class="row g-3 kanban-board" data-board-id="<?= $board['id'] ?>">
     <?php foreach ($statuses as $st):
       $tasks = fetch_tasks_for_status($pdo, $board['id'], $st['status_id']);
@@ -10,12 +10,12 @@
     <div class="col-md-3">
       <div class="card h-100">
         <div class="card-header">
-          <h5 class="mb-0"><?= htmlspecialchars($st['label']) ?></h5>
+          <h5 class="mb-0"><?= e($st['label']) ?></h5>
         </div>
         <div class="card-body min-vh-50 kanban-column" data-status-id="<?= $st['status_id'] ?>">
           <?php foreach ($tasks as $t): ?>
             <div class="card mb-2 p-2 kanban-item" data-task-id="<?= $t['id'] ?>" draggable="true">
-              <?= htmlspecialchars($t['name']) ?>
+              <?= e($t['name']) ?>
             </div>
           <?php endforeach; ?>
         </div>

--- a/module/kanban/include/form.php
+++ b/module/kanban/include/form.php
@@ -7,16 +7,16 @@ $selProjects = $selectedProjects ?? [];
 <div class="container py-4">
   <h2 class="mb-4"><?= $board_id ? 'Edit Board' : 'Create Board' ?></h2>
   <form method="post" action="index.php?action=save">
-    <input type="hidden" name="id" value="<?= htmlspecialchars($board_id) ?>">
+    <input type="hidden" name="id" value="<?= e($board_id) ?>">
     <div class="mb-3">
       <label class="form-label">Board Name</label>
-      <input class="form-control" name="name" value="<?= htmlspecialchars($name) ?>" required>
+      <input class="form-control" name="name" value="<?= e($name) ?>" required>
     </div>
     <div class="mb-3">
       <label class="form-label">Projects</label>
       <select class="form-select" name="projects[]" multiple>
         <?php foreach ($projects as $p): ?>
-          <option value="<?= $p['id'] ?>" <?= in_array($p['id'], $selProjects) ? 'selected' : '' ?>><?= htmlspecialchars($p['name']) ?></option>
+          <option value="<?= $p['id'] ?>" <?= in_array($p['id'], $selProjects) ? 'selected' : '' ?>><?= e($p['name']) ?></option>
         <?php endforeach; ?>
       </select>
     </div>

--- a/module/kanban/include/list_view.php
+++ b/module/kanban/include/list_view.php
@@ -11,7 +11,7 @@
       <div class="col-md-4">
         <div class="card h-100">
           <div class="card-body d-flex flex-column">
-            <h5 class="card-title"><?= htmlspecialchars($b['name']) ?></h5>
+            <h5 class="card-title"><?= e($b['name']) ?></h5>
             <div class="mt-auto">
               <a class="btn btn-sm btn-falcon-primary" href="index.php?action=board&id=<?= $b['id'] ?>">Open</a>
               <a class="btn btn-sm btn-falcon-secondary" href="index.php?action=edit&id=<?= $b['id'] ?>">Edit</a>

--- a/module/users/include/2fa.php
+++ b/module/users/include/2fa.php
@@ -19,7 +19,7 @@ if (!$email) {
                 <div class="auth-form-box text-center">
                   <div class="text-center mb-7">
                     <h3 class="text-body-highlight">Enter the verification code</h3>
-                    <p class="text-body-tertiary">We sent a 6-digit code to <?php echo htmlspecialchars($masked); ?></p>
+                    <p class="text-body-tertiary">We sent a 6-digit code to <?php echo e($masked); ?></p>
                     <?
                     $stmt = $pdo->prepare("SELECT code FROM users_2fa WHERE used = 0 ORDER BY date_created DESC LIMIT 1");
                     $stmt->execute();


### PR DESCRIPTION
## Summary
- add `e()` helper for null-safe HTML escaping
- refactor tasks and other modules to use `e()` instead of `htmlspecialchars`

## Testing
- `php admin/tasks/functions/quick_add.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*
- `git status --short | awk '{print $2}' | xargs -I{} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_68ad3ef27bf88333a79d44fc53745daa