### PR TITLE
Configure PHP error handling

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -26,8 +26,5 @@ try{
         echo "Connection failed: " . $e->getMessage();
 }
 
-ini_set('display_errors', 1);
-ini_set('display_startup_errors', 1);
-error_reporting(E_ALL);
 
 ?>

--- a/includes/php_header.php
+++ b/includes/php_header.php
@@ -1,4 +1,8 @@
 <?php
+error_reporting(E_ALL & ~E_DEPRECATED & ~E_WARNING);
+ini_set('display_errors', '0');
+ini_set('log_errors', '1');
+ini_set('error_log', __DIR__ . '/../logs/php-error.log');
 ob_start();
 if (session_status() !== PHP_SESSION_ACTIVE) {
   session_start();

--- a/logs/.gitignore
+++ b/logs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## Summary
- suppress deprecated and warning messages while hiding on-screen errors
- log PHP errors to `logs/php-error.log`
- remove development error settings from config to centralize error handling

## Testing
- `php -l includes/php_header.php`
- `php -l includes/config.php`
- `php -r "error_reporting(E_ALL & ~E_DEPRECATED & ~E_WARNING); ini_set('display_errors','0'); filemtime('nonexistent'); echo 'done';"`


------
https://chatgpt.com/codex/tasks/task_e_68ad3ef2af6c8333a99a3c8a2add7ffa