### PR TITLE
Add file cabinet list and move endpoints

### DIFF
--- a/module/project/assets/file_cabinet.js
+++ b/module/project/assets/file_cabinet.js
@@ -119,7 +119,7 @@ document.addEventListener('DOMContentLoaded', () => {
       fetch(moveUrl, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ id: fileId, parent: target.dataset.id })
+        body: JSON.stringify({ project_id: projectId, id: fileId, parent: target.dataset.id })
       }).then(() => fetchList());
     }
   });
@@ -148,7 +148,7 @@ document.addEventListener('DOMContentLoaded', () => {
       fetch(moveUrl, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ create: true, path: path.join('/'), name })
+        body: JSON.stringify({ project_id: projectId, create: true, path: path.join('/'), name })
       }).then(() => fetchList());
     });
   });

--- a/module/project/functions/file_cabinet_list.php
+++ b/module/project/functions/file_cabinet_list.php
@@ -1,0 +1,66 @@
+<?php
+require '../../../includes/php_header.php';
+require_permission('project','view');
+
+$project_id = (int)($_GET['project_id'] ?? 0);
+$pathStr    = trim($_GET['path'] ?? '');
+
+header('Content-Type: application/json');
+
+if(!$project_id){
+  http_response_code(400);
+  echo json_encode(['error'=>'Missing project_id']);
+  exit;
+}
+
+// Sanitize path segments similar to create_folder.php
+$cleanPath = '';
+if($pathStr !== ''){
+  $segments = array_filter(explode('/', $pathStr), 'strlen');
+  $segments = array_map(fn($s) => preg_replace('/[^A-Za-z0-9._-]/','_', $s), $segments);
+  $cleanPath = implode('/', $segments);
+}
+
+$folder_id = null;
+if($cleanPath !== ''){
+  $stmt = $pdo->prepare('SELECT id FROM module_projects_folders WHERE project_id=:pid AND path=:path');
+  $stmt->execute([':pid'=>$project_id, ':path'=>$cleanPath]);
+  $folder_id = $stmt->fetchColumn();
+  if($folder_id === false){
+    http_response_code(404);
+    echo json_encode(['error'=>'Folder not found']);
+    exit;
+  }
+}else{
+  $folder_id = get_project_root_folder($pdo,$project_id);
+}
+
+$files = [];
+// folders
+$stmt = $pdo->prepare('SELECT id,name,date_updated FROM module_projects_folders WHERE project_id=:pid AND parent_id'.($folder_id?'=:fid':' IS NULL').' ORDER BY name');
+$stmt->execute([':pid'=>$project_id, ':fid'=>$folder_id]);
+while($row = $stmt->fetch(PDO::FETCH_ASSOC)){
+  $files[] = [
+    'id'       => (int)$row['id'],
+    'type'     => 'folder',
+    'name'     => $row['name'],
+    'size'     => null,
+    'modified' => $row['date_updated']
+  ];
+}
+
+// files
+$stmt = $pdo->prepare('SELECT id,file_name,file_size,date_updated FROM module_projects_files WHERE project_id=:pid AND folder_id'.($folder_id?'=:fid':' IS NULL').' AND note_id IS NULL AND question_id IS NULL ORDER BY sort_order, date_created DESC');
+$stmt->execute([':pid'=>$project_id, ':fid'=>$folder_id]);
+while($row = $stmt->fetch(PDO::FETCH_ASSOC)){
+  $files[] = [
+    'id'       => (int)$row['id'],
+    'type'     => 'file',
+    'name'     => $row['file_name'],
+    'size'     => $row['file_size'],
+    'modified' => $row['date_updated']
+  ];
+}
+
+echo json_encode(['files'=>$files]);
+exit;

--- a/module/project/functions/file_cabinet_move.php
+++ b/module/project/functions/file_cabinet_move.php
@@ -1,0 +1,83 @@
+<?php
+require '../../../includes/php_header.php';
+require_permission('project','update');
+
+header('Content-Type: application/json');
+
+$input = json_decode(file_get_contents('php://input'), true) ?? [];
+
+if(isset($input['create'])){
+  $project_id = (int)($input['project_id'] ?? 0);
+  $name       = trim($input['name'] ?? '');
+  $pathStr    = trim($input['path'] ?? '');
+
+  if(!$project_id || $name === ''){
+    http_response_code(400);
+    echo json_encode(['error'=>'Missing project_id or name']);
+    exit;
+  }
+
+  $cleanPath = '';
+  if($pathStr !== ''){
+    $segments = array_filter(explode('/', $pathStr), 'strlen');
+    $segments = array_map(fn($s) => preg_replace('/[^A-Za-z0-9._-]/','_', $s), $segments);
+    $cleanPath = implode('/', $segments);
+  }
+
+  $parent_id = null;
+  if($cleanPath !== ''){
+    $stmt = $pdo->prepare('SELECT id FROM module_projects_folders WHERE project_id=:pid AND path=:path');
+    $stmt->execute([':pid'=>$project_id, ':path'=>$cleanPath]);
+    $parent_id = $stmt->fetchColumn();
+    if($parent_id === false){
+      http_response_code(404);
+      echo json_encode(['error'=>'Parent path not found']);
+      exit;
+    }
+  }else{
+    $parent_id = get_project_root_folder($pdo,$project_id);
+  }
+
+  $_POST = [
+    'project_id' => $project_id,
+    'name'       => $name,
+    'parent_id'  => $parent_id
+  ];
+  require 'create_folder.php';
+  exit;
+}
+
+$id     = (int)($input['id'] ?? 0);
+$parent = isset($input['parent']) && $input['parent'] !== '' ? (int)$input['parent'] : null;
+
+if(!$id){
+  http_response_code(400);
+  echo json_encode(['error'=>'Missing id']);
+  exit;
+}
+
+$stmt = $pdo->prepare('SELECT id FROM module_projects_files WHERE id=:id');
+$stmt->execute([':id'=>$id]);
+if($stmt->fetchColumn()){
+  $_POST = [
+    'id' => $id,
+    'target_folder_id' => $parent
+  ];
+  require 'move_file.php';
+  exit;
+}
+
+$stmt = $pdo->prepare('SELECT id FROM module_projects_folders WHERE id=:id');
+$stmt->execute([':id'=>$id]);
+if($stmt->fetchColumn()){
+  $_POST = [
+    'id' => $id,
+    'target_parent_id' => $parent
+  ];
+  require 'move_folder.php';
+  exit;
+}
+
+http_response_code(404);
+echo json_encode(['error'=>'Item not found']);
+exit;


### PR DESCRIPTION
## Summary
- add file_cabinet_list.php to resolve paths and list folders/files
- add file_cabinet_move.php to create folders and move items via existing helpers
- send project_id in file_cabinet.js for move and folder creation requests

## Testing
- `php -l module/project/functions/file_cabinet_list.php`
- `php -l module/project/functions/file_cabinet_move.php`
- `node --check module/project/assets/file_cabinet.js`


------
https://chatgpt.com/codex/tasks/task_e_68ad3f4b4cf0833397c369580f8bb0cb