### PR TITLE
Guard file manager init and conditionally load script

### DIFF
--- a/assets/js/file-manager.js
+++ b/assets/js/file-manager.js
@@ -2378,10 +2378,12 @@
   ];
 
   const fileManagerInit = () => {
-    const fileContainer = document.querySelector('[data-files-container]');
     const fileDetailsContainer = document.querySelector(
       '[data-details-container]'
     );
+    if (!fileDetailsContainer) return;
+    const fileContainer = document.querySelector('[data-files-container]');
+    if (!fileContainer) return;
     const fileDetails = fileDetailsContainer.querySelector('[data-file-details]');
     const filesSelected = document.querySelector('[data-files-selected]');
     const fileManager = document.querySelector(

--- a/includes/js_footer.php
+++ b/includes/js_footer.php
@@ -18,7 +18,9 @@
     <!-- Phoenix Core & Config -->
     <script src="<?php echo getURLDir(); ?>assets/js/config.js"></script>
     <script src="<?php echo getURLDir(); ?>assets/js/phoenix.js"></script>
-    <script src="<?php echo getURLDir(); ?>assets/js/file-manager.js"></script>
+    <?php if (!empty($loadFileManagerJs)): ?>
+      <script src="<?php echo getURLDir(); ?>assets/js/file-manager.js"></script>
+    <?php endif; ?>
 
     <!-- Project-specific JS (if any) -->
     <script src="<?php echo getURLDir(); ?>assets/js/projectmanagement-dashboard.js"></script>

--- a/module/project/include/details_view.php
+++ b/module/project/include/details_view.php
@@ -3,6 +3,7 @@
 require_once __DIR__ . '/../../../includes/functions.php';
 
 if (!empty($current_project)) {
+    $loadFileManagerJs = true;
     $statusId  = $current_project['status'] ?? null;
     $priorityId = $current_project['priority'] ?? null;
     $totalTasks = count($tasks ?? []);


### PR DESCRIPTION
## Summary
- Prevent file manager JS from running when details container is absent
- Load file-manager.js only on pages with a File Cabinet

## Testing
- `php -l includes/js_footer.php`
- `php -l module/project/include/details_view.php`
- `node --check assets/js/file-manager.js`


------
https://chatgpt.com/codex/tasks/task_e_68ad44901c148333a3e1ebf37d81a46b