### PR TITLE
Include global helpers in php header

### DIFF
--- a/includes/php_header.php
+++ b/includes/php_header.php
@@ -12,6 +12,7 @@ date_default_timezone_set('America/Denver');
 // connect to Database
 require __DIR__ . '/config.php';
 require_once __DIR__ . '/lookup_helpers.php';
+require_once __DIR__ . '/helpers.php';
 require_once __DIR__ . '/contractor_helpers.php';
 
 // Composer autoload (for third-party libraries)


### PR DESCRIPTION
## Summary
- Load global helper functions in php_header.php so they are available across pages

## Testing
- `php -l includes/php_header.php`
- `php -r "chdir('module/project'); parse_str('action=details&id=12', \$_GET); \$_SERVER['REQUEST_METHOD']='GET'; \$_SERVER['HTTP_HOST']='localhost'; \$_SERVER['REQUEST_URI']='/module/project/index.php?action=details&id=12'; \$_SERVER['SCRIPT_NAME']='/module/project/index.php'; include 'index.php';"` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4548b6d88333aa5677dd061640ab