### PR TITLE
refactor: simplify event type loading in calendar view

### DIFF
--- a/module/calendar/include/calendar_view.php
+++ b/module/calendar/include/calendar_view.php
@@ -4,9 +4,6 @@ $calendars = [];
 $stmt = $pdo->query('SELECT id, name FROM module_calendar ORDER BY name');
 $calendars = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
-$event_types = $pdo->query("SELECT id,label FROM lookup_list_items WHERE list_id=37 ORDER BY sort_order,label")->fetchAll(PDO::FETCH_ASSOC);
-
-$visibilities = get_lookup_items($pdo, 38);
 $event_types = get_lookup_items($pdo, 37);
 
 $selected_calendar_id = $_SESSION['selected_calendar_id'] ?? 0;


### PR DESCRIPTION
## Summary
- remove direct event type query and rely on helper lookup
- drop unused visibilities variable in calendar view

## Testing
- `php -l module/calendar/include/calendar_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad4a52dd0c8333940e69ef0c65a4ec