### PR TITLE
Use descriptive keys in meeting function responses

### DIFF
--- a/admin/meetings/functions/add_agenda_item.php
+++ b/admin/meetings/functions/add_agenda_item.php
@@ -49,7 +49,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $listStmt = $pdo->prepare('SELECT id, meeting_id, order_index, title, status_id, linked_task_id, linked_project_id FROM module_meeting_agenda WHERE meeting_id=? ORDER BY order_index');
         $listStmt->execute([$meeting_id]);
         $items = $listStmt->fetchAll(PDO::FETCH_ASSOC);
-        echo json_encode(['success' => true, 'data' => $items]);
+        echo json_encode(['success' => true, 'items' => $items]);
     } catch (Exception $e) {
         http_response_code(400);
         echo json_encode(['success' => false, 'message' => $e->getMessage()]);

--- a/admin/meetings/functions/add_question.php
+++ b/admin/meetings/functions/add_question.php
@@ -35,7 +35,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $listStmt = $pdo->prepare('SELECT id, meeting_id, agenda_id, question_text, answer_text, status_id FROM module_meeting_questions WHERE meeting_id=? ORDER BY id');
         $listStmt->execute([$meeting_id]);
         $questions = $listStmt->fetchAll(PDO::FETCH_ASSOC);
-        echo json_encode(['success' => true, 'data' => $questions]);
+        echo json_encode(['success' => true, 'questions' => $questions]);
     } catch (Exception $e) {
         http_response_code(400);
         echo json_encode(['success' => false, 'message' => $e->getMessage()]);

--- a/admin/meetings/functions/delete_agenda_item.php
+++ b/admin/meetings/functions/delete_agenda_item.php
@@ -35,7 +35,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $listStmt = $pdo->prepare('SELECT id, meeting_id, order_index, title, status_id, linked_task_id, linked_project_id FROM module_meeting_agenda WHERE meeting_id=? ORDER BY order_index');
         $listStmt->execute([$meeting_id]);
         $items = $listStmt->fetchAll(PDO::FETCH_ASSOC);
-        echo json_encode(['success' => true, 'data' => $items]);
+        echo json_encode(['success' => true, 'items' => $items]);
     } catch (Exception $e) {
         http_response_code(400);
         echo json_encode(['success' => false, 'message' => $e->getMessage()]);

--- a/admin/meetings/functions/delete_file.php
+++ b/admin/meetings/functions/delete_file.php
@@ -41,7 +41,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             ];
         }
 
-        echo json_encode(['success' => true, 'data' => $files]);
+        echo json_encode(['success' => true, 'files' => $files]);
     } catch (Exception $e) {
         http_response_code(400);
         echo json_encode(['success' => false, 'message' => $e->getMessage()]);

--- a/admin/meetings/functions/delete_question.php
+++ b/admin/meetings/functions/delete_question.php
@@ -23,7 +23,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $listStmt = $pdo->prepare('SELECT id, meeting_id, agenda_id, question_text, answer_text, status_id FROM module_meeting_questions WHERE meeting_id=? ORDER BY id');
         $listStmt->execute([$meeting_id]);
         $questions = $listStmt->fetchAll(PDO::FETCH_ASSOC);
-        echo json_encode(['success' => true, 'data' => $questions]);
+        echo json_encode(['success' => true, 'questions' => $questions]);
     } catch (Exception $e) {
         http_response_code(400);
         echo json_encode(['success' => false, 'message' => $e->getMessage()]);

--- a/admin/meetings/functions/update_agenda_item.php
+++ b/admin/meetings/functions/update_agenda_item.php
@@ -50,7 +50,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $listStmt = $pdo->prepare('SELECT id, meeting_id, order_index, title, status_id, linked_task_id, linked_project_id FROM module_meeting_agenda WHERE meeting_id=? ORDER BY order_index');
         $listStmt->execute([$meeting_id]);
         $items = $listStmt->fetchAll(PDO::FETCH_ASSOC);
-        echo json_encode(['success' => true, 'data' => $items]);
+        echo json_encode(['success' => true, 'items' => $items]);
     } catch (Exception $e) {
         http_response_code(400);
         echo json_encode(['success' => false, 'message' => $e->getMessage()]);

--- a/admin/meetings/functions/update_question.php
+++ b/admin/meetings/functions/update_question.php
@@ -36,7 +36,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $listStmt = $pdo->prepare('SELECT id, meeting_id, agenda_id, question_text, answer_text, status_id FROM module_meeting_questions WHERE meeting_id=? ORDER BY id');
         $listStmt->execute([$meeting_id]);
         $questions = $listStmt->fetchAll(PDO::FETCH_ASSOC);
-        echo json_encode(['success' => true, 'data' => $questions]);
+        echo json_encode(['success' => true, 'questions' => $questions]);
     } catch (Exception $e) {
         http_response_code(400);
         echo json_encode(['success' => false, 'message' => $e->getMessage()]);


### PR DESCRIPTION
## Summary
- return agenda items under `items` instead of `data`
- return meeting questions under `questions` instead of `data`
- return remaining files under `files` after deletion

## Testing
- `php -l admin/meetings/functions/add_agenda_item.php && php -l admin/meetings/functions/update_agenda_item.php && php -l admin/meetings/functions/delete_agenda_item.php && php -l admin/meetings/functions/add_question.php && php -l admin/meetings/functions/update_question.php && php -l admin/meetings/functions/delete_question.php && php -l admin/meetings/functions/delete_file.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad4a43cca88333a528b4d17e2a5820