### PR TITLE
Verify CSRF token for meeting data fetches

### DIFF
--- a/admin/meetings/functions/get_agenda.php
+++ b/admin/meetings/functions/get_agenda.php
@@ -4,7 +4,14 @@ require_permission('meeting', 'read');
 
 header('Content-Type: application/json');
 
-$meeting_id = (int)($_GET['meeting_id'] ?? 0);
+$method = $_SERVER['REQUEST_METHOD'];
+$data = $method === 'POST' ? $_POST : $_GET;
+$meeting_id = (int)($data['meeting_id'] ?? 0);
+
+if (!verify_csrf_token($data['csrf_token'] ?? '')) {
+    echo json_encode(['success' => false, 'message' => 'Invalid CSRF token']);
+    exit;
+}
 
 if ($meeting_id) {
     $stmt = $pdo->prepare('SELECT id, meeting_id, order_index, title, status_id, linked_task_id, linked_project_id FROM module_meeting_agenda WHERE meeting_id = ? ORDER BY order_index');

--- a/admin/meetings/functions/get_attendees.php
+++ b/admin/meetings/functions/get_attendees.php
@@ -3,7 +3,15 @@ require '../../../includes/php_header.php';
 require_permission('meeting', 'read');
 
 header('Content-Type: application/json');
-$meeting_id = (int)($_GET['meeting_id'] ?? 0);
+
+$method = $_SERVER['REQUEST_METHOD'];
+$data = $method === 'POST' ? $_POST : $_GET;
+$meeting_id = (int)($data['meeting_id'] ?? 0);
+
+if (!verify_csrf_token($data['csrf_token'] ?? '')) {
+    echo json_encode(['success' => false, 'message' => 'Invalid CSRF token']);
+    exit;
+}
 
 if ($meeting_id) {
     $stmt = $pdo->prepare('SELECT a.id, a.attendee_user_id, a.role, a.check_in_time, a.check_out_time, CONCAT(u.first_name, " ", u.last_name) AS name FROM module_meeting_attendees a LEFT JOIN users u ON a.attendee_user_id = u.id WHERE a.meeting_id = ? ORDER BY a.id');

--- a/admin/meetings/functions/get_questions.php
+++ b/admin/meetings/functions/get_questions.php
@@ -4,7 +4,14 @@ require_permission('meeting', 'read');
 
 header('Content-Type: application/json');
 
-$meeting_id = (int)($_GET['meeting_id'] ?? 0);
+$method = $_SERVER['REQUEST_METHOD'];
+$data = $method === 'POST' ? $_POST : $_GET;
+$meeting_id = (int)($data['meeting_id'] ?? 0);
+
+if (!verify_csrf_token($data['csrf_token'] ?? '')) {
+    echo json_encode(['success' => false, 'message' => 'Invalid CSRF token']);
+    exit;
+}
 
 if ($meeting_id) {
     $stmt = $pdo->prepare('SELECT id, meeting_id, agenda_id, question_text, answer_text, status_id FROM module_meeting_questions WHERE meeting_id = ? ORDER BY id');


### PR DESCRIPTION
## Summary
- Verify CSRF token before querying meeting agendas, questions, and attendees
- Support GET or POST requests for meeting data fetch endpoints

## Testing
- `php -l admin/meetings/functions/get_agenda.php`
- `php -l admin/meetings/functions/get_questions.php`
- `php -l admin/meetings/functions/get_attendees.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad4a485ce88333ae3058abcc9969d5