### PR TITLE
Map calendar event privacy checkbox to visibility ID

### DIFF
--- a/module/calendar/include/calendar_view.php
+++ b/module/calendar/include/calendar_view.php
@@ -149,6 +149,16 @@ document.addEventListener('DOMContentLoaded', function() {
   const defaultEventTypeId = <?php echo (int)$default_event_type_id; ?>;
   const calendarEl = document.getElementById('calendar');
 
+  const VISIBILITY_PUBLIC = 198;
+  const VISIBILITY_PRIVATE = 199;
+
+  function isEventPrivate(props) {
+    if ('visibility_id' in props) {
+      return String(props.visibility_id) === String(VISIBILITY_PRIVATE);
+    }
+    return String(props.is_private) === '1';
+  }
+
   function getCalendarId() {
     const sel = document.getElementById('calendarSelect');
     return sel ? sel.value : defaultCalendarId;
@@ -179,7 +189,7 @@ document.addEventListener('DOMContentLoaded', function() {
       form.start_time.value = dayjs(info.event.start).format('YYYY-MM-DD HH:mm');
       form.end_time.value = info.event.end ? dayjs(info.event.end).format('YYYY-MM-DD HH:mm') : '';
       form.event_type_id.value = info.event.extendedProps.event_type_id || defaultEventTypeId;
-      form.is_private.checked = info.event.extendedProps.is_private == 1;
+      form.is_private.checked = isEventPrivate(info.event.extendedProps);
       bootstrap.Modal.getOrCreateInstance(document.getElementById('editEventModal')).show();
     },
     dateClick: function(info) {
@@ -225,6 +235,8 @@ document.addEventListener('DOMContentLoaded', function() {
     e.preventDefault();
     this.calendar_id.value = getCalendarId();
     const fd = new FormData(this);
+    fd.append('visibility_id', this.is_private.checked ? VISIBILITY_PRIVATE : VISIBILITY_PUBLIC);
+    fd.delete('is_private');
     fetch('<?php echo getURLDir(); ?>module/calendar/functions/create.php', {
       method: 'POST',
       body: fd
@@ -252,6 +264,8 @@ document.addEventListener('DOMContentLoaded', function() {
     e.preventDefault();
     this.calendar_id.value = getCalendarId();
     const fd = new FormData(this);
+    fd.append('visibility_id', this.is_private.checked ? VISIBILITY_PRIVATE : VISIBILITY_PUBLIC);
+    fd.delete('is_private');
     fetch('<?php echo getURLDir(); ?>module/calendar/functions/update.php', {
       method: 'POST',
       body: fd


### PR DESCRIPTION
## Summary
- map is_private checkbox to visibility_id before submitting add/edit forms
- ensure eventClick interprets event data visibility for is_private checkbox

## Testing
- `php -l module/calendar/include/calendar_view.php`
- `composer test` *(fails: Command "test" is not defined)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4a4e99bc8333aefd5bf3d4e2a096