### PR TITLE
Refactor calendar list query

### DIFF
--- a/module/calendar/functions/list.php
+++ b/module/calendar/functions/list.php
@@ -8,53 +8,44 @@ require_once 'microsoft_events.php';
 
 $calendar_id = isset($_GET['calendar_id']) ? (int)$_GET['calendar_id'] : 0;
 $events = [];
-if (user_has_role('Admin')) {
-  if ($calendar_id) {
-    $stmt = $pdo->prepare('SELECT id, calendar_id, title, start_time, end_time, link_module, link_record_id, user_id, event_type_id, visibility_id FROM module_calendar_events WHERE calendar_id = :calid');
-    $stmt->execute([':calid' => $calendar_id]);
-  } else {
-    $stmt = $pdo->query('SELECT id, calendar_id, title, start_time, end_time, link_module, link_record_id, user_id, event_type_id, visibility_id FROM module_calendar_events');
-  }
-} else {
-  if ($calendar_id) {
-    $stmt = $pdo->prepare('SELECT id, calendar_id, title, start_time, end_time, link_module, link_record_id, user_id, event_type_id, visibility_id FROM module_calendar_events WHERE (visibility_id = 198 OR user_id = :uid) AND calendar_id = :calid');
-    $stmt->execute([':uid' => $this_user_id, ':calid' => $calendar_id]);
-  } else {
-    $stmt = $pdo->prepare('SELECT id, calendar_id, title, start_time, end_time, link_module, link_record_id, user_id, event_type_id, visibility_id FROM module_calendar_events WHERE visibility_id = 198 OR user_id = :uid');
-    $stmt->execute([':uid' => $this_user_id]);
-  }
 
 try {
     if (user_has_role('Admin')) {
         if ($calendar_id) {
-            $stmt = $pdo->prepare('SELECT id, calendar_id, title, start_time, end_time, link_module, link_record_id, user_id, event_type_id, is_private FROM module_calendar_events WHERE calendar_id = :calid');
+            $stmt = $pdo->prepare('SELECT id, calendar_id, title, start_time, end_time, link_module, link_record_id, user_id, event_type_id, visibility_id FROM module_calendar_events WHERE calendar_id = :calid');
             $stmt->execute([':calid' => $calendar_id]);
         } else {
-            $stmt = $pdo->query('SELECT id, calendar_id, title, start_time, end_time, link_module, link_record_id, user_id, event_type_id, is_private FROM module_calendar_events');
+            $stmt = $pdo->query('SELECT id, calendar_id, title, start_time, end_time, link_module, link_record_id, user_id, event_type_id, visibility_id FROM module_calendar_events');
         }
     } else {
         if ($calendar_id) {
-            $stmt = $pdo->prepare('SELECT id, calendar_id, title, start_time, end_time, link_module, link_record_id, user_id, event_type_id, is_private FROM module_calendar_events WHERE (is_private = 0 OR user_id = :uid) AND calendar_id = :calid');
+            $stmt = $pdo->prepare('SELECT id, calendar_id, title, start_time, end_time, link_module, link_record_id, user_id, event_type_id, visibility_id FROM module_calendar_events WHERE (visibility_id = 198 OR user_id = :uid) AND calendar_id = :calid');
             $stmt->execute([':uid' => $this_user_id, ':calid' => $calendar_id]);
         } else {
-            $stmt = $pdo->prepare('SELECT id, calendar_id, title, start_time, end_time, link_module, link_record_id, user_id, event_type_id, is_private FROM module_calendar_events WHERE is_private = 0 OR user_id = :uid');
+            $stmt = $pdo->prepare('SELECT id, calendar_id, title, start_time, end_time, link_module, link_record_id, user_id, event_type_id, visibility_id FROM module_calendar_events WHERE visibility_id = 198 OR user_id = :uid');
             $stmt->execute([':uid' => $this_user_id]);
         }
     }
 
-while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-  $events[] = [
-    'id' => (int)$row['id'],
-    'calendar_id' => (int)$row['calendar_id'],
-    'title' => $row['title'],
-    'start' => $row['start_time'],
-    'end' => $row['end_time'],
-    'related_module' => $row['link_module'],
-    'related_id' => $row['link_record_id'],
-    'event_type_id' => $row['event_type_id'],
-    'visibility_id' => (int)$row['visibility_id'],
-    'is_private' => (int)($row['visibility_id'] == 199)
-  ];
+    while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+        $events[] = [
+            'id' => (int)$row['id'],
+            'calendar_id' => (int)$row['calendar_id'],
+            'title' => $row['title'],
+            'start' => $row['start_time'],
+            'end' => $row['end_time'],
+            'related_module' => $row['link_module'],
+            'related_id' => $row['link_record_id'],
+            'event_type_id' => $row['event_type_id'],
+            'visibility_id' => (int)$row['visibility_id'],
+            'is_private' => (int)($row['visibility_id'] == 199)
+        ];
+    }
+} catch (Exception $e) {
+    http_response_code(500);
+    ob_clean();
+    echo json_encode(['error' => $e->getMessage()]);
+    exit;
 }
 
 try {


### PR DESCRIPTION
## Summary
- Remove duplicate calendar event query path
- Use a single visibility-based query wrapped in try/catch
- Add error handling and ensure conditional blocks close properly

## Testing
- `php -l module/calendar/functions/list.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad5016f00c8333a9f6b00868f8dce4