### PR TITLE
Support visibility_id in calendar event APIs

### DIFF
--- a/module/calendar/functions/create.php
+++ b/module/calendar/functions/create.php
@@ -12,8 +12,8 @@ $link_module = $_POST['link_module'] ?? null;
 $link_record_id = $_POST['link_record_id'] ?? null;
 $calendar_id = (int)($_POST['calendar_id'] ?? 0);
 $event_type_id = $_POST['event_type_id'] ?? null;
-$is_private = !empty($_POST['is_private']) ? 1 : 0;
-$visibility_id = $is_private ? 199 : 198;
+$visibility_id = (int)($_POST['visibility_id'] ?? 198);
+$is_private   = $visibility_id === 199 ? 1 : 0;
 $attendees = $_POST['attendees'] ?? [];
 
 if ($title && $start_time && $calendar_id) {
@@ -46,6 +46,7 @@ if ($title && $start_time && $calendar_id) {
     'title' => $title,
     'start' => $start_time,
     'end' => $end_time,
+    'visibility_id' => $visibility_id,
     'is_private' => $is_private
   ]);
   exit;

--- a/module/calendar/functions/update.php
+++ b/module/calendar/functions/update.php
@@ -11,8 +11,8 @@ $link_module = $_POST['link_module'] ?? null;
 $link_record_id = $_POST['link_record_id'] ?? null;
 $calendar_id = (int)($_POST['calendar_id'] ?? 0);
 $event_type_id = $_POST['event_type_id'] ?? null;
-$is_private = !empty($_POST['is_private']) ? 1 : 0;
-$visibility_id = $is_private ? 199 : 198;
+$visibility_id = (int)($_POST['visibility_id'] ?? 198);
+$is_private   = $visibility_id === 199 ? 1 : 0;
 $attendees = $_POST['attendees'] ?? [];
 
 if ($id && $title && $start_time && $calendar_id) {
@@ -45,6 +45,7 @@ if ($id && $title && $start_time && $calendar_id) {
     'title' => $title,
     'start' => $start_time,
     'end' => $end_time,
+    'visibility_id' => $visibility_id,
     'is_private' => $is_private
   ]);
   exit;


### PR DESCRIPTION
## Summary
- accept explicit `visibility_id` in calendar create/update handlers and derive `is_private` from it
- include both `visibility_id` and `is_private` in JSON responses

## Testing
- `php -l module/calendar/functions/create.php`
- `php -l module/calendar/functions/update.php`
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ad501baef48333b87578114cd5ca79