### PR TITLE
Refactor admin task function paths and permissions

### DIFF
--- a/admin/tasks/functions/add_assignment.php
+++ b/admin/tasks/functions/add_assignment.php
@@ -1,9 +1,7 @@
 <?php
-if (session_status() !== PHP_SESSION_ACTIVE) {
-  session_start();
-}
-require_once '../../../includes/php_header.php';
-require_permission('admin_task_assignment','create');
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/php_header.php';
+require_permission('admin_task', 'create');
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
   http_response_code(405);

--- a/admin/tasks/functions/add_comment.php
+++ b/admin/tasks/functions/add_comment.php
@@ -1,9 +1,7 @@
 <?php
-if (session_status() !== PHP_SESSION_ACTIVE) {
-  session_start();
-}
-require_once '../../../includes/php_header.php';
-require_permission('admin_task_comment','create');
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/php_header.php';
+require_permission('admin_task', 'create');
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
   http_response_code(405);

--- a/admin/tasks/functions/create.php
+++ b/admin/tasks/functions/create.php
@@ -1,9 +1,7 @@
 <?php
-if (session_status() !== PHP_SESSION_ACTIVE) {
-  session_start();
-}
-require_once '../../../includes/php_header.php';
-require_permission('admin_task','create');
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/php_header.php';
+require_permission('admin_task', 'create');
 
 header('Content-Type: application/json');
 

--- a/admin/tasks/functions/delete.php
+++ b/admin/tasks/functions/delete.php
@@ -1,9 +1,7 @@
 <?php
-if (session_status() !== PHP_SESSION_ACTIVE) {
-  session_start();
-}
-require_once '../../../includes/php_header.php';
-require_permission('admin_task','delete');
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/php_header.php';
+require_permission('admin_task', 'delete');
 
 $method = $_SERVER['REQUEST_METHOD'];
 if ($method !== 'POST' && $method !== 'GET') {

--- a/admin/tasks/functions/delete_comment.php
+++ b/admin/tasks/functions/delete_comment.php
@@ -1,9 +1,7 @@
 <?php
-if (session_status() !== PHP_SESSION_ACTIVE) {
-  session_start();
-}
-require_once '../../../includes/php_header.php';
-require_permission('admin_task_comment','delete');
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/php_header.php';
+require_permission('admin_task', 'delete');
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
   http_response_code(405);

--- a/admin/tasks/functions/delete_file.php
+++ b/admin/tasks/functions/delete_file.php
@@ -1,9 +1,7 @@
 <?php
-if (session_status() !== PHP_SESSION_ACTIVE) {
-  session_start();
-}
-require_once '../../../includes/php_header.php';
-require_permission('admin_task_file','delete');
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/php_header.php';
+require_permission('admin_task', 'delete');
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
   http_response_code(405);
@@ -22,7 +20,7 @@ $stmt->execute([':id' => $id]);
 $file = $stmt->fetch(PDO::FETCH_ASSOC);
 if ($file) {
   $pdo->prepare('DELETE FROM admin_task_files WHERE id = :id')->execute([':id' => $id]);
-  $path = '../../' . basename($file['file_path']);
+  $path = dirname(__DIR__, 2) . '/' . basename($file['file_path']);
   $fullPath = realpath(__DIR__ . '/../uploads/' . basename($file['file_path']));
   if ($fullPath && file_exists($fullPath)) {
     unlink($fullPath);

--- a/admin/tasks/functions/quick_add.php
+++ b/admin/tasks/functions/quick_add.php
@@ -1,9 +1,7 @@
 <?php
-if (session_status() !== PHP_SESSION_ACTIVE) {
-  session_start();
-}
-require_once '../../../includes/php_header.php';
-require_permission('admin_task','create');
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/php_header.php';
+require_permission('admin_task', 'create');
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
   http_response_code(405);

--- a/admin/tasks/functions/remove_assignment.php
+++ b/admin/tasks/functions/remove_assignment.php
@@ -1,9 +1,7 @@
 <?php
-if (session_status() !== PHP_SESSION_ACTIVE) {
-  session_start();
-}
-require_once '../../../includes/php_header.php';
-require_permission('admin_task_assignment','delete');
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/php_header.php';
+require_permission('admin_task', 'delete');
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
   http_response_code(405);

--- a/admin/tasks/functions/update.php
+++ b/admin/tasks/functions/update.php
@@ -1,9 +1,7 @@
 <?php
-if (session_status() !== PHP_SESSION_ACTIVE) {
-  session_start();
-}
-require_once '../../../includes/php_header.php';
-require_permission('admin_task','update');
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/php_header.php';
+require_permission('admin_task', 'update');
 
 header('Content-Type: application/json');
 

--- a/admin/tasks/functions/upload_file.php
+++ b/admin/tasks/functions/upload_file.php
@@ -1,9 +1,7 @@
 <?php
-if (session_status() !== PHP_SESSION_ACTIVE) {
-  session_start();
-}
-require_once '../../../includes/php_header.php';
-require_permission('admin_task_file','create');
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/php_header.php';
+require_permission('admin_task', 'create');
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
   http_response_code(405);
@@ -34,7 +32,7 @@ finfo_close($finfo);
 $safe = preg_replace('/[^a-zA-Z0-9_-]/', '_', pathinfo($file['name'], PATHINFO_FILENAME));
 $ext = pathinfo($file['name'], PATHINFO_EXTENSION);
 $filename = $safe . '_' . time() . '.' . $ext;
-$destDir = '../uploads/';
+$destDir = __DIR__ . '/../uploads/';
 if (!is_dir($destDir)) { mkdir($destDir, 0755, true); }
 $dest = $destDir . $filename;
 if (!move_uploaded_file($file['tmp_name'], $dest)) {


### PR DESCRIPTION
## Summary
- Standardize admin task functions to use `__DIR__` for header includes and file paths
- Use `require_permission('admin_task', ...)` consistently
- Adjust upload and delete utilities to reference upload directories via `__DIR__`

## Testing
- `php -l admin/tasks/functions/*.php`
- `REQUEST_METHOD=POST php admin/tasks/functions/create.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*
- `REQUEST_METHOD=POST php admin/tasks/functions/update.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68ad50234010833392032af5cc0950b6