### PR TITLE
Use admin layout for task admin page

### DIFF
--- a/admin/tasks/task.php
+++ b/admin/tasks/task.php
@@ -1,6 +1,5 @@
 <?php
-require_once '../includes/php_header.php';
-require_once '../includes/functions.php';
+require_once __DIR__ . '/../admin_header.php';
 
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 $editing = $id > 0;
@@ -141,3 +140,4 @@ $_SESSION['csrf_token'] = $token;
     <?php endif; ?>
   </div>
 </form>
+<?php require_once __DIR__ . '/../admin_footer.php'; ?>


### PR DESCRIPTION
## Summary
- load admin header for admin task page and retain permission checks
- include admin footer for full layout

## Testing
- `php -l admin/tasks/task.php`
- `php -d short_open_tag=1 admin/tasks/task.php`
- `grep -ni "failed to open stream" /tmp/task_output.html`

------
https://chatgpt.com/codex/tasks/task_e_68ad5022cda883339898a8d678364710