### PR TITLE
Fix canEdit block closure in meeting details view

### DIFF
--- a/admin/meetings/include/details_view.php
+++ b/admin/meetings/include/details_view.php
@@ -468,6 +468,8 @@ document.addEventListener('DOMContentLoaded', function(){
       }
     });
 
+  }
+
   var attendeesList = document.getElementById('attendeesList');
   var attachmentsList = document.getElementById('attachmentsList');
 


### PR DESCRIPTION
## Summary
- close `if (canEdit)` block after questions list handler
- ensure attendee, attachment, task, and project JS handlers execute

## Testing
- `php -l admin/meetings/include/details_view.php`
- `node --check /tmp/details_view.js`


------
https://chatgpt.com/codex/tasks/task_e_68ad518fe11083339a545dae15b17657