### PR TITLE
Add calendar ownership checks for update and delete

### DIFF
--- a/module/calendar/functions/delete_calendar.php
+++ b/module/calendar/functions/delete_calendar.php
@@ -1,10 +1,22 @@
 <?php
 require '../../../includes/php_header.php';
+require_permission('calendar','delete');
 header('Content-Type: application/json');
 
 $id = (int)($_POST['id'] ?? 0);
 
 if ($id) {
+  $chk = $pdo->prepare('SELECT user_id FROM module_calendar WHERE id = ?');
+  $chk->execute([$id]);
+  $owner = $chk->fetchColumn();
+  if (!$owner) {
+    echo json_encode(['success' => false]);
+    exit;
+  }
+  if ($owner != $this_user_id && !user_has_role('Admin')) {
+    http_response_code(403);
+    exit;
+  }
   $stmt = $pdo->prepare('DELETE FROM module_calendar WHERE id = ?');
   $stmt->execute([$id]);
   echo json_encode(['success' => true]);

--- a/module/calendar/functions/update_calendar.php
+++ b/module/calendar/functions/update_calendar.php
@@ -1,5 +1,6 @@
 <?php
 require '../../../includes/php_header.php';
+require_permission('calendar','update');
 header('Content-Type: application/json');
 
 $id = (int)($_POST['id'] ?? 0);
@@ -7,6 +8,17 @@ $name = trim($_POST['name'] ?? '');
 $is_private = !empty($_POST['is_private']) ? 1 : 0;
 
 if ($id && $name !== '') {
+  $chk = $pdo->prepare('SELECT user_id FROM module_calendar WHERE id = ?');
+  $chk->execute([$id]);
+  $owner = $chk->fetchColumn();
+  if (!$owner) {
+    echo json_encode(['success' => false]);
+    exit;
+  }
+  if ($owner != $this_user_id && !user_has_role('Admin')) {
+    http_response_code(403);
+    exit;
+  }
   $stmt = $pdo->prepare('UPDATE module_calendar SET name=?, is_private=?, user_updated=? WHERE id=?');
   $stmt->execute([$name, $is_private, $this_user_id, $id]);
   echo json_encode(['success' => true]);


### PR DESCRIPTION
## Summary
- Require calendar update/delete permissions for update_calendar.php and delete_calendar.php
- Validate calendar ownership before allowing updates or deletes, returning HTTP 403 when mismatched and user isn't Admin

## Testing
- `php -l module/calendar/functions/update_calendar.php`
- `php -l module/calendar/functions/delete_calendar.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad55c472f483339693ab159a6d1429