### PR TITLE
Enforce ownership checks for calendar event updates and deletions

### DIFF
--- a/module/calendar/functions/delete.php
+++ b/module/calendar/functions/delete.php
@@ -1,5 +1,6 @@
 <?php
 require '../../../includes/php_header.php';
+require_permission('calendar', 'delete');
 header('Content-Type: application/json');
 
 $id = (int)($_POST['id'] ?? 0);
@@ -9,6 +10,10 @@ if ($id) {
   $existing = $chk->fetch(PDO::FETCH_ASSOC);
   if (!$existing) {
     http_response_code(404);
+    exit;
+  }
+  if ($existing['user_id'] != $this_user_id && !user_has_role('Admin')) {
+    http_response_code(403);
     exit;
   }
   if ($existing['visibility_id'] == 199 && $existing['user_id'] != $this_user_id && !user_has_role('Admin')) {

--- a/module/calendar/functions/update.php
+++ b/module/calendar/functions/update.php
@@ -1,5 +1,6 @@
 <?php
 require '../../../includes/php_header.php';
+require_permission('calendar', 'update');
 header('Content-Type: application/json');
 
 $id = (int)($_POST['id'] ?? 0);
@@ -21,6 +22,10 @@ if ($id && $title && $start_time && $calendar_id) {
   $existing = $chk->fetch(PDO::FETCH_ASSOC);
   if (!$existing) {
     http_response_code(404);
+    exit;
+  }
+  if ($existing['user_id'] != $this_user_id && !user_has_role('Admin')) {
+    http_response_code(403);
     exit;
   }
   if ($existing['visibility_id'] == 199 && $existing['user_id'] != $this_user_id && !user_has_role('Admin')) {


### PR DESCRIPTION
## Summary
- Require calendar module permissions for updating and deleting events
- Block non-admins from editing or deleting others' events, with existing private-event check as backup

## Testing
- `php -l module/calendar/functions/update.php`
- `php -l module/calendar/functions/delete.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad54796cb8833386cfa69f08cc5e53