### PR TITLE
Enforce calendar update and delete permissions

### DIFF
--- a/module/calendar/functions/delete.php
+++ b/module/calendar/functions/delete.php
@@ -1,5 +1,6 @@
 <?php
 require '../../../includes/php_header.php';
+require_permission('calendar','delete');
 header('Content-Type: application/json');
 
 $id = (int)($_POST['id'] ?? 0);

--- a/module/calendar/functions/update.php
+++ b/module/calendar/functions/update.php
@@ -1,5 +1,6 @@
 <?php
 require '../../../includes/php_header.php';
+require_permission('calendar','update');
 header('Content-Type: application/json');
 
 $id = (int)($_POST['id'] ?? 0);


### PR DESCRIPTION
## Summary
- Add calendar update permission check in update.php
- Add calendar delete permission check in delete.php

## Testing
- `php -l module/calendar/functions/update.php`
- `php -l module/calendar/functions/delete.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad547a6f9883338a5ac1716aab283c