### PR TITLE
Add start_time index to calendar events SQL dump

### DIFF
--- a/_SQL/atlis.sql
+++ b/_SQL/atlis.sql
@@ -3720,7 +3720,8 @@ ALTER TABLE `module_calendar_events`
   ADD KEY `fk_module_calendar_events_link_record_id` (`link_record_id`),
   ADD KEY `fk_module_calendar_events_user_id` (`user_id`),
   ADD KEY `fk_module_calendar_events_user_updated` (`user_updated`),
-  ADD KEY `fk_module_calendar_events_visibility_id` (`visibility_id`);
+  ADD KEY `fk_module_calendar_events_visibility_id` (`visibility_id`),
+  ADD KEY `idx_calendar_events_start_time` (`start_time`);
 
 --
 -- Indexes for table `module_calendar_event_attendees`


### PR DESCRIPTION
## Summary
- index module_calendar_events.start_time for faster filtering

## Testing
- `mysql -u root -e "ALTER TABLE module_calendar_events ADD KEY idx_calendar_events_start_time (start_time);" atlisware` *(fails: Can't connect to local server through socket '/run/mysqld/mysqld.sock' (2))*
- `mysqldump -u root atlisware > /tmp/atlis_dump.sql` *(fails: Can't connect to local server through socket '/run/mysqld/mysqld.sock' (2))*

------
https://chatgpt.com/codex/tasks/task_e_68ad547f1b8c83339137c6d46be4dd3d