### PR TITLE
Allow admin override in calendar ownership checks

### DIFF
--- a/module/calendar/functions/create.php
+++ b/module/calendar/functions/create.php
@@ -17,6 +17,18 @@ $is_private   = $visibility_id === 199 ? 1 : 0;
 $attendees = $_POST['attendees'] ?? [];
 
 if ($title && $start_time && $calendar_id) {
+  $chk = $pdo->prepare('SELECT user_id, is_private FROM module_calendar WHERE id = ?');
+  $chk->execute([$calendar_id]);
+  $calendar = $chk->fetch(PDO::FETCH_ASSOC);
+  if (!$calendar) {
+    http_response_code(404);
+    exit;
+  }
+  if ($calendar['is_private'] && $calendar['user_id'] != $this_user_id && !user_has_role('Admin')) {
+    // Only the calendar owner may add events to a private calendar; Admins can override.
+    http_response_code(403);
+    exit;
+  }
   $stmt = $pdo->prepare('INSERT INTO module_calendar_events (user_id, calendar_id, title, start_time, end_time, event_type_id, link_module, link_record_id, visibility_id) VALUES (:uid, :calendar_id, :title, :start_time, :end_time, :event_type_id, :link_module, :link_record_id, :visibility_id)');
 
   $stmt->execute([

--- a/module/calendar/functions/delete.php
+++ b/module/calendar/functions/delete.php
@@ -12,6 +12,7 @@ if ($id) {
     exit;
   }
   if ($existing['visibility_id'] == 199 && $existing['user_id'] != $this_user_id && !user_has_role('Admin')) {
+    // Only the event owner or an Admin can delete a private event.
     http_response_code(403);
     exit;
   }

--- a/module/calendar/functions/delete_calendar.php
+++ b/module/calendar/functions/delete_calendar.php
@@ -5,6 +5,18 @@ header('Content-Type: application/json');
 $id = (int)($_POST['id'] ?? 0);
 
 if ($id) {
+  $chk = $pdo->prepare('SELECT user_id FROM module_calendar WHERE id = ?');
+  $chk->execute([$id]);
+  $existing = $chk->fetch(PDO::FETCH_ASSOC);
+  if (!$existing) {
+    http_response_code(404);
+    exit;
+  }
+  if ($existing['user_id'] != $this_user_id && !user_has_role('Admin')) {
+    // Calendar deletions are limited to the owner; Admins may override.
+    http_response_code(403);
+    exit;
+  }
   $stmt = $pdo->prepare('DELETE FROM module_calendar WHERE id = ?');
   $stmt->execute([$id]);
   echo json_encode(['success' => true]);

--- a/module/calendar/functions/update.php
+++ b/module/calendar/functions/update.php
@@ -24,6 +24,7 @@ if ($id && $title && $start_time && $calendar_id) {
     exit;
   }
   if ($existing['visibility_id'] == 199 && $existing['user_id'] != $this_user_id && !user_has_role('Admin')) {
+    // Prevent non-owners from editing private events unless they are Admins.
     http_response_code(403);
     exit;
   }

--- a/module/calendar/functions/update_calendar.php
+++ b/module/calendar/functions/update_calendar.php
@@ -7,6 +7,18 @@ $name = trim($_POST['name'] ?? '');
 $is_private = !empty($_POST['is_private']) ? 1 : 0;
 
 if ($id && $name !== '') {
+  $chk = $pdo->prepare('SELECT user_id FROM module_calendar WHERE id = ?');
+  $chk->execute([$id]);
+  $existing = $chk->fetch(PDO::FETCH_ASSOC);
+  if (!$existing) {
+    http_response_code(404);
+    exit;
+  }
+  if ($existing['user_id'] != $this_user_id && !user_has_role('Admin')) {
+    // Calendar updates are restricted to the owner unless the user is an Admin.
+    http_response_code(403);
+    exit;
+  }
   $stmt = $pdo->prepare('UPDATE module_calendar SET name=?, is_private=?, user_updated=? WHERE id=?');
   $stmt->execute([$name, $is_private, $this_user_id, $id]);
   echo json_encode(['success' => true]);


### PR DESCRIPTION
## Summary
- Guard private calendar event creation with owner check, allowing Admin override
- Document Admin override in event update/delete ownership checks
- Restrict calendar updates/deletes to calendar owner unless Admin

## Testing
- `php -l module/calendar/functions/create.php`
- `php -l module/calendar/functions/update.php`
- `php -l module/calendar/functions/delete.php`
- `php -l module/calendar/functions/update_calendar.php`
- `php -l module/calendar/functions/delete_calendar.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad54800a6c8333b88b73b8d45d303b