### PR TITLE
Handle AJAX and CSRF in task create/update

### DIFF
--- a/admin/tasks/functions/create.php
+++ b/admin/tasks/functions/create.php
@@ -3,22 +3,43 @@ if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../includes/php_header.php';
 require_permission('admin_task', 'create');
 
-header('Content-Type: application/json');
+$isAjax = ($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '') === 'XMLHttpRequest'
+    || str_contains($_SERVER['HTTP_ACCEPT'] ?? '', 'application/json');
+if ($isAjax) {
+  header('Content-Type: application/json');
+}
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
-  http_response_code(405);
-  echo json_encode(['success' => false, 'error' => 'Method not allowed']);
+  if ($isAjax) {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'error' => 'Method not allowed']);
+  } else {
+    $_SESSION['error_message'] = 'Method not allowed';
+    header('Location: ../task.php');
+  }
   exit;
 }
 
-if (!hash_equals($_SESSION['csrf_token'] ?? '', $_POST['csrf_token'] ?? '')) {
-  echo json_encode(['success' => false, 'error' => 'Invalid CSRF token']);
+if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+  if ($isAjax) {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'error' => 'Invalid CSRF token']);
+  } else {
+    $_SESSION['error_message'] = 'Invalid CSRF token';
+    header('Location: ../task.php');
+  }
   exit;
 }
 
 $name = trim($_POST['name'] ?? '');
 if ($name === '') {
-  echo json_encode(['success' => false, 'error' => 'Name required']);
+  if ($isAjax) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'error' => 'Name required']);
+  } else {
+    $_SESSION['error_message'] = 'Name required';
+    header('Location: ../task.php');
+  }
   exit;
 }
 $description = $_POST['description'] ?? null;
@@ -58,8 +79,14 @@ foreach ($assigned_user_ids as $assigned_user_id) {
 }
 
 admin_audit_log($pdo, $this_user_id, 'admin_task', $taskId, 'CREATE', null, json_encode(['name'=>$name]), 'Created task');
+
+if ($isAjax) {
   $fetchStmt = $pdo->prepare('SELECT t.id, t.name, type.label AS type_label, cat.label AS category_label, sub.label AS sub_category_label, st.label AS status_label, pr.label AS priority_label FROM admin_task t LEFT JOIN lookup_list_items type ON t.type_id = type.id LEFT JOIN lookup_list_items cat ON t.category_id = cat.id LEFT JOIN lookup_list_items sub ON t.sub_category_id = sub.id LEFT JOIN lookup_list_items st ON t.status_id = st.id LEFT JOIN lookup_list_items pr ON t.priority_id = pr.id WHERE t.id = :id');
   $fetchStmt->execute([':id' => $taskId]);
   $task = $fetchStmt->fetch(PDO::FETCH_ASSOC);
   echo json_encode(['success' => true, 'task' => $task]);
-  exit;
+} else {
+  $_SESSION['message'] = 'Task saved';
+  header('Location: ../index.php');
+}
+exit;

--- a/admin/tasks/functions/update.php
+++ b/admin/tasks/functions/update.php
@@ -3,22 +3,43 @@ if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../includes/php_header.php';
 require_permission('admin_task', 'update');
 
-header('Content-Type: application/json');
+$isAjax = ($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '') === 'XMLHttpRequest'
+    || str_contains($_SERVER['HTTP_ACCEPT'] ?? '', 'application/json');
+if ($isAjax) {
+  header('Content-Type: application/json');
+}
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
-  http_response_code(405);
-  echo json_encode(['success' => false, 'error' => 'Method not allowed']);
+  if ($isAjax) {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'error' => 'Method not allowed']);
+  } else {
+    $_SESSION['error_message'] = 'Method not allowed';
+    header('Location: ../task.php');
+  }
   exit;
 }
 
-if (!hash_equals($_SESSION['csrf_token'] ?? '', $_POST['csrf_token'] ?? '')) {
-  echo json_encode(['success' => false, 'error' => 'Invalid CSRF token']);
+if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+  if ($isAjax) {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'error' => 'Invalid CSRF token']);
+  } else {
+    $_SESSION['error_message'] = 'Invalid CSRF token';
+    header('Location: ../task.php');
+  }
   exit;
 }
 
 $id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
 if (!$id) {
-  echo json_encode(['success' => false, 'error' => 'Invalid ID']);
+  if ($isAjax) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'error' => 'Invalid ID']);
+  } else {
+    $_SESSION['error_message'] = 'Invalid ID';
+    header('Location: ../task.php');
+  }
   exit;
 }
 
@@ -28,7 +49,13 @@ $old = $oldStmt->fetch(PDO::FETCH_ASSOC);
 
 $name = trim($_POST['name'] ?? '');
 if ($name === '') {
-  echo json_encode(['success' => false, 'error' => 'Name required']);
+  if ($isAjax) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'error' => 'Name required']);
+  } else {
+    $_SESSION['error_message'] = 'Name required';
+    header('Location: ../task.php');
+  }
   exit;
 }
 $description = $_POST['description'] ?? null;
@@ -69,8 +96,14 @@ foreach ($assigned_user_ids as $assigned_user_id) {
 }
 
 admin_audit_log($pdo, $this_user_id, 'admin_task', $id, 'UPDATE', json_encode($old), json_encode(['name'=>$name]), 'Updated task');
+
+if ($isAjax) {
   $fetchStmt = $pdo->prepare('SELECT t.id, t.name, type.label AS type_label, cat.label AS category_label, sub.label AS sub_category_label, st.label AS status_label, pr.label AS priority_label FROM admin_task t LEFT JOIN lookup_list_items type ON t.type_id = type.id LEFT JOIN lookup_list_items cat ON t.category_id = cat.id LEFT JOIN lookup_list_items sub ON t.sub_category_id = sub.id LEFT JOIN lookup_list_items st ON t.status_id = st.id LEFT JOIN lookup_list_items pr ON t.priority_id = pr.id WHERE t.id = :id');
   $fetchStmt->execute([':id' => $id]);
   $task = $fetchStmt->fetch(PDO::FETCH_ASSOC);
   echo json_encode(['success' => true, 'task' => $task]);
-  exit;
+} else {
+  $_SESSION['message'] = 'Task saved';
+  header('Location: ../task.php?id=' . $id);
+}
+exit;


### PR DESCRIPTION
## Summary
- Replace manual CSRF checks with `verify_csrf_token()` in task create/update handlers
- Return JSON only for AJAX requests and redirect otherwise
- Send user/session messages on success or error with proper redirects

## Testing
- `php -l admin/tasks/functions/create.php`
- `php -l admin/tasks/functions/update.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad571744b8833398b78b91d682be4f