### PR TITLE
Enforce calendar ownership for calendar events

### DIFF
--- a/module/calendar/functions/delete.php
+++ b/module/calendar/functions/delete.php
@@ -7,14 +7,27 @@ header('Content-Type: application/json');
 
 $id = (int)($_POST['id'] ?? 0);
 if ($id) {
-  $chk = $pdo->prepare('SELECT user_id, visibility_id FROM module_calendar_events WHERE id = ?');
+  $chk = $pdo->prepare('SELECT user_id, visibility_id, calendar_id FROM module_calendar_events WHERE id = ?');
   $chk->execute([$id]);
   $existing = $chk->fetch(PDO::FETCH_ASSOC);
   if (!$existing) {
     http_response_code(404);
     exit;
   }
+
+  $calendarChk = $pdo->prepare('SELECT user_id FROM module_calendar WHERE id = ?');
+  $calendarChk->execute([$existing['calendar_id']]);
+  $calendar = $calendarChk->fetch(PDO::FETCH_ASSOC);
+  if (!$calendar) {
+    http_response_code(404);
+    exit;
+  }
+
   if ($existing['user_id'] != $this_user_id && !user_has_role('Admin')) {
+    http_response_code(403);
+    exit;
+  }
+  if ($calendar['user_id'] != $this_user_id && !user_has_role('Admin')) {
     http_response_code(403);
     exit;
   }

--- a/module/calendar/functions/update.php
+++ b/module/calendar/functions/update.php
@@ -26,7 +26,20 @@ if ($id && $title && $start_time && $calendar_id) {
     http_response_code(404);
     exit;
   }
+
+  $calendarChk = $pdo->prepare('SELECT user_id FROM module_calendar WHERE id = ?');
+  $calendarChk->execute([$calendar_id]);
+  $calendar = $calendarChk->fetch(PDO::FETCH_ASSOC);
+  if (!$calendar) {
+    http_response_code(404);
+    exit;
+  }
+
   if ($existing['user_id'] != $this_user_id && !user_has_role('Admin')) {
+    http_response_code(403);
+    exit;
+  }
+  if ($calendar['user_id'] != $this_user_id && !user_has_role('Admin')) {
     http_response_code(403);
     exit;
   }


### PR DESCRIPTION
## Summary
- Ensure updates to calendar events verify calendar ownership
- Confirm calendar ownership before deleting calendar events

## Testing
- `php -l module/calendar/functions/update.php`
- `php -l module/calendar/functions/delete.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad5a76fe648333bab7561ec621652c