### PR TITLE
Use person names or email for meeting attendees

### DIFF
--- a/admin/meetings/functions/add_attendee.php
+++ b/admin/meetings/functions/add_attendee.php
@@ -32,7 +32,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             admin_audit_log($pdo, $this_user_id, 'module_meeting_attendees', $id, 'CREATE', 'Added attendee');
         }
 
-        $rosterStmt = $pdo->prepare('SELECT a.id, a.attendee_user_id, a.role, a.check_in_time, a.check_out_time, CONCAT(u.first_name, " ", u.last_name) AS name FROM module_meeting_attendees a LEFT JOIN users u ON a.attendee_user_id = u.id WHERE a.meeting_id =? ORDER BY a.id');
+        $rosterStmt = $pdo->prepare('SELECT a.id, a.attendee_user_id, a.role, a.check_in_time, a.check_out_time, COALESCE(CONCAT(p.first_name, " ", p.last_name), u.email) AS name FROM module_meeting_attendees a LEFT JOIN users u ON a.attendee_user_id = u.id LEFT JOIN person p ON u.id = p.user_id WHERE a.meeting_id =? ORDER BY name');
         $rosterStmt->execute([$meeting_id]);
         $attendees = $rosterStmt->fetchAll(PDO::FETCH_ASSOC);
         echo json_encode(['success' => true, 'attendees' => $attendees]);

--- a/admin/meetings/functions/get_attendees.php
+++ b/admin/meetings/functions/get_attendees.php
@@ -14,7 +14,7 @@ if (!verify_csrf_token($data['csrf_token'] ?? '')) {
 }
 
 if ($meeting_id) {
-    $stmt = $pdo->prepare('SELECT a.id, a.attendee_user_id, a.role, a.check_in_time, a.check_out_time, CONCAT(u.first_name, " ", u.last_name) AS name FROM module_meeting_attendees a LEFT JOIN users u ON a.attendee_user_id = u.id WHERE a.meeting_id = ? ORDER BY a.id');
+    $stmt = $pdo->prepare('SELECT a.id, a.attendee_user_id, a.role, a.check_in_time, a.check_out_time, COALESCE(CONCAT(p.first_name, " ", p.last_name), u.email) AS name FROM module_meeting_attendees a LEFT JOIN users u ON a.attendee_user_id = u.id LEFT JOIN person p ON u.id = p.user_id WHERE a.meeting_id = ? ORDER BY name');
     $stmt->execute([$meeting_id]);
     $attendees = $stmt->fetchAll(PDO::FETCH_ASSOC);
     echo json_encode(['success' => true, 'attendees' => $attendees]);

--- a/admin/meetings/functions/remove_attendee.php
+++ b/admin/meetings/functions/remove_attendee.php
@@ -20,7 +20,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             admin_audit_log($pdo, $this_user_id, 'module_meeting_attendees', $id, 'DELETE', 'Removed attendee');
         }
 
-        $rosterStmt = $pdo->prepare('SELECT a.id, a.attendee_user_id, a.role, a.check_in_time, a.check_out_time, CONCAT(u.first_name, " ", u.last_name) AS name FROM module_meeting_attendees a LEFT JOIN users u ON a.attendee_user_id = u.id WHERE a.meeting_id =? ORDER BY a.id');
+        $rosterStmt = $pdo->prepare('SELECT a.id, a.attendee_user_id, a.role, a.check_in_time, a.check_out_time, COALESCE(CONCAT(p.first_name, " ", p.last_name), u.email) AS name FROM module_meeting_attendees a LEFT JOIN users u ON a.attendee_user_id = u.id LEFT JOIN person p ON u.id = p.user_id WHERE a.meeting_id =? ORDER BY name');
         $rosterStmt->execute([$meeting_id]);
         $attendees = $rosterStmt->fetchAll(PDO::FETCH_ASSOC);
         echo json_encode(['success' => true, 'attendees' => $attendees]);

--- a/admin/meetings/functions/search_users.php
+++ b/admin/meetings/functions/search_users.php
@@ -10,7 +10,7 @@ if ($q === '') {
     exit;
 }
 
-$stmt = $pdo->prepare('SELECT u.id, COALESCE(CONCAT(p.first_name, " ", p.last_name), CONCAT(u.first_name, " ", u.last_name)) AS name FROM users u LEFT JOIN person p ON u.id = p.user_id WHERE COALESCE(CONCAT(p.first_name, " ", p.last_name), CONCAT(u.first_name, " ", u.last_name)) LIKE :q ORDER BY name LIMIT 10');
+$stmt = $pdo->prepare('SELECT u.id, COALESCE(CONCAT(p.first_name, " ", p.last_name), u.email) AS name FROM users u LEFT JOIN person p ON u.id = p.user_id WHERE COALESCE(CONCAT(p.first_name, " ", p.last_name), u.email) LIKE :q ORDER BY name LIMIT 10');
 $stmt->execute([':q' => "%" . $q . "%"]);
 
 echo json_encode($stmt->fetchAll(PDO::FETCH_ASSOC));


### PR DESCRIPTION
## Summary
- Resolve user lookup to display person's name when available, falling back to email, with join to `person` table
- Return attendee rosters ordered by name and include the new name field after add/remove operations

## Testing
- `php -l admin/meetings/functions/search_users.php`
- `php -l admin/meetings/functions/add_attendee.php`
- `php -l admin/meetings/functions/get_attendees.php`
- `php -l admin/meetings/functions/remove_attendee.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad5cb68b88833393428a8dbeb9d827