### PR TITLE
Refactor fetchJson error flow for meeting details

### DIFF
--- a/admin/meetings/include/details_view.php
+++ b/admin/meetings/include/details_view.php
@@ -279,12 +279,8 @@ document.addEventListener('DOMContentLoaded', function(){
       if(!r.ok){
         return r.text().then(function(t){ throw new Error(t || 'Request failed'); });
       }
-      return r.text().then(function(text){
-        try{
-          return JSON.parse(text);
-        } catch(e){
-          throw new Error('Invalid JSON: ' + e.message);
-        }
+      return r.json().catch(function(e){
+        throw new Error('Invalid JSON: ' + e.message);
       });
     });
   }
@@ -649,7 +645,10 @@ document.addEventListener('DOMContentLoaded', function(){
         renderAttendees([]);
       }
     })
-    .catch(function(err){ console.error(err); showToast('Failed to load attendees'); });
+    .catch(function(err){
+      console.error(err);
+      showToast('Failed to load attendees');
+    });
 
   fetchJson('functions/get_attachments.php?meeting_id=' + meetingId + '&csrf_token=' + csrfToken)
     .then(function(data){


### PR DESCRIPTION
## Summary
- Refactor `fetchJson` to reject with `Error` on non-OK responses or invalid JSON
- Ensure `get_attendees` request shows a single contextual toast on failure

## Testing
- `php -l admin/meetings/include/details_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad615ea004833385ea38b307602474