### PR TITLE
Remove calendar connect buttons

### DIFF
--- a/module/calendar/include/calendar_view.php
+++ b/module/calendar/include/calendar_view.php
@@ -31,8 +31,6 @@ $default_event_type_id = $event_types[0]['id'] ?? 0;
       <a class="btn btn-outline-primary btn-sm me-2" href="index.php?action=create">Create Calendar</a>
     <?php } ?>
 
-    <button class="btn btn-outline-secondary btn-sm me-2" type="button" id="connectGoogle">Connect Google Calendar</button>
-    <button class="btn btn-outline-secondary btn-sm me-2" type="button" id="connectMicrosoft">Connect Microsoft Calendar</button>
     <?php if ($owns_calendar) { ?>
       <button class="btn btn-primary btn-sm" type="button" data-bs-toggle="modal" data-bs-target="#addEventModal">
         <span class="fas fa-plus pe-2 fs-10"></span>Add Event


### PR DESCRIPTION
## Summary
- remove Google and Microsoft connect buttons from calendar toolbar

## Testing
- `php -l module/calendar/include/calendar_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad6387be5883338460b37fd1a93c20