### PR TITLE
Add default calendar user setting

### DIFF
--- a/module/users/functions/save_settings.php
+++ b/module/users/functions/save_settings.php
@@ -14,6 +14,7 @@ $fields = [
   'project_type' => 'PROJECT_TYPE',
   'task_status' => 'TASK_STATUS',
   'task_priority' => 'TASK_PRIORITY',
+  'calendar_default' => 'CALENDAR_DEFAULT',
 ];
 
 foreach ($fields as $postField => $listName) {

--- a/module/users/include/settings.php
+++ b/module/users/include/settings.php
@@ -76,6 +76,23 @@
           <label for="defaultTaskPriority">Priority</label>
         </div>
       </div>
+      <div class="col-12 mt-3">
+        <h6 class="mb-2">Calendar</h6>
+      </div>
+      <div class="col-sm-6 col-md-4">
+        <div class="form-floating">
+          <select class="form-select" id="defaultCalendar" name="calendar_default">
+            <option value="">No default</option>
+            <?php foreach ($userCalendars as $cal): ?>
+              <option value="<?= $cal['id']; ?>"
+                <?= ($userDefaults['CALENDAR_DEFAULT'] ?? '') == $cal['id'] ? 'selected' : ''; ?>>
+                <?= h($cal['name']); ?>
+              </option>
+            <?php endforeach; ?>
+          </select>
+          <label for="defaultCalendar">Default Calendar</label>
+        </div>
+      </div>
       <div class="col-12 gy-6">
         <div class="row g-3 justify-content-end mt-3">
           <div class="col-auto">

--- a/module/users/index.php
+++ b/module/users/index.php
@@ -47,12 +47,17 @@ if ($action === 'settings') {
   $taskStatusItems      = get_lookup_items($pdo, 'TASK_STATUS');
   $taskPriorityItems    = get_lookup_items($pdo, 'TASK_PRIORITY');
 
+  $userCalendars = $pdo->prepare('SELECT id, name FROM module_calendar WHERE user_id = :uid');
+  $userCalendars->execute([':uid' => $this_user_id]);
+  $userCalendars = $userCalendars->fetchAll(PDO::FETCH_ASSOC);
+
   $userDefaults = [
     'PROJECT_STATUS'   => get_user_default_lookup_item($pdo, $this_user_id, 'PROJECT_STATUS'),
     'PROJECT_PRIORITY' => get_user_default_lookup_item($pdo, $this_user_id, 'PROJECT_PRIORITY'),
     'PROJECT_TYPE'     => get_user_default_lookup_item($pdo, $this_user_id, 'PROJECT_TYPE'),
     'TASK_STATUS'      => get_user_default_lookup_item($pdo, $this_user_id, 'TASK_STATUS'),
     'TASK_PRIORITY'    => get_user_default_lookup_item($pdo, $this_user_id, 'TASK_PRIORITY'),
+    'CALENDAR_DEFAULT' => get_user_default_lookup_item($pdo, $this_user_id, 'CALENDAR_DEFAULT'),
   ];
 
   require '../../includes/html_header.php';


### PR DESCRIPTION
## Summary
- allow querying and selection of a user's calendars in settings
- store a default calendar for each user

## Testing
- `php -l module/users/index.php`
- `php -l module/users/include/settings.php`
- `php -l module/users/functions/save_settings.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad638ab2348333987bee8520c53419