### PR TITLE
Handle typeahead fetch errors in meetings

### DIFF
--- a/admin/meetings/include/create_edit_view.php
+++ b/admin/meetings/include/create_edit_view.php
@@ -128,9 +128,9 @@ document.addEventListener('DOMContentLoaded', function(){
       fetch(url)
         .then(r => r.ok ? r.json() : Promise.reject(new Error('Search failed')))
         .then(renderOptions)
-        .catch(() => {
+        .catch(err => {
           list.innerHTML = '<option value="">Error</option>';
-          console.error('Search failed');
+          console.error('Search failed', err);
         });
     });
     textInput.addEventListener('change', function(){


### PR DESCRIPTION
## Summary
- Handle fetch failures in meeting typeahead search to avoid unhandled promise rejections
- Log typeahead search failures to console and show fallback option

## Testing
- `php -l admin/meetings/include/create_edit_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad6cb815a08333ba4586b0a91e0892