### PR TITLE
Improve agenda details escaping and status labels

### DIFF
--- a/admin/meetings/include/details_view.php
+++ b/admin/meetings/include/details_view.php
@@ -252,6 +252,7 @@ document.addEventListener('DOMContentLoaded', function(){
   var canEditAttendees = <?php echo user_has_permission('meeting','update') ? 'true' : 'false'; ?>;
   var csrfToken = '<?= $token; ?>';
   var questionStatusMap = <?php echo json_encode($questionStatusMap); ?>;
+  var agendaStatusMap = <?php echo json_encode($agendaStatusMap); ?>;
   var agendaMap = {};
   var questionsData = [];
   var attendeesData = [];
@@ -331,17 +332,20 @@ document.addEventListener('DOMContentLoaded', function(){
         li.dataset.projectId = item.linked_project_id || '';
         var left = '<span><span class="drag-handle me-2 fas fa-grip-vertical"></span><span class="agenda-title">'+esc(item.title)+'</span>';
         var meta = [];
-        if(item.status_id){ meta.push('Status '+esc(item.status_id)); }
-        if(item.linked_task_id){ meta.push('<a href="'+baseUrl+'module/task/index.php?id='+item.linked_task_id+'">Task '+esc(item.linked_task_id)+'</a>'); }
-        if(item.linked_project_id){ meta.push('<a href="'+baseUrl+'module/project/index.php?id='+item.linked_project_id+'">Project '+esc(item.linked_project_id)+'</a>'); }
+        if(item.status_id){
+          var statusLabel = agendaStatusMap[item.status_id]?.label;
+          if(statusLabel) meta.push('Status '+esc(statusLabel));
+        }
+        if(item.linked_task_id){ meta.push('<a href="'+baseUrl+'module/task/index.php?id='+item.linked_task_id+'">Task '+esc(String(item.linked_task_id))+'</a>'); }
+        if(item.linked_project_id){ meta.push('<a href="'+baseUrl+'module/project/index.php?id='+item.linked_project_id+'">Project '+esc(String(item.linked_project_id))+'</a>'); }
         if(meta.length){ left += ' <small class="text-body-secondary">'+meta.join(' | ')+'</small>'; }
         left += '</span>';
         var buttons = canEdit ? '<div class="btn-group btn-group-sm"><button class="btn btn-outline-secondary edit-agenda-item">Edit</button><button class="btn btn-outline-danger delete-agenda-item">Delete</button></div>' : '';
         li.innerHTML = left + buttons
           + '<input type="hidden" name="agenda_title[]" value="'+esc(item.title)+'">'
-          + '<input type="hidden" name="agenda_status_id[]" value="'+esc(item.status_id || '')+'">'
-          + '<input type="hidden" name="agenda_linked_task_id[]" value="'+esc(item.linked_task_id || '')+'">'
-          + '<input type="hidden" name="agenda_linked_project_id[]" value="'+esc(item.linked_project_id || '')+'">';
+          + '<input type="hidden" name="agenda_status_id[]" value="'+esc(String(item.status_id || ''))+'">'
+          + '<input type="hidden" name="agenda_linked_task_id[]" value="'+esc(String(item.linked_task_id || ''))+'">'
+          + '<input type="hidden" name="agenda_linked_project_id[]" value="'+esc(String(item.linked_project_id || ''))+'">';
         agendaList.appendChild(li);
       });
     } else {
@@ -746,7 +750,13 @@ document.addEventListener('DOMContentLoaded', function(){
   });
 
   function esc(str){
-    return str ? str.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#039;') : '';
-  }
+      if (str === null || str === undefined) return '';
+      return String(str)
+        .replace(/&/g,'&amp;')
+        .replace(/</g,'&lt;')
+        .replace(/>/g,'&gt;')
+        .replace(/"/g,'&quot;')
+        .replace(/'/g,'&#039;');
+    }
 });
 </script>


### PR DESCRIPTION
## Summary
- Export agenda status map to JavaScript and render agenda item status labels
- Harden escaping helper and ensure numeric fields are stringified before escaping

## Testing
- `php -l admin/meetings/include/details_view.php`
- `node <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68ad706e02f48333b21e65872992ed04