### PR TITLE
Ensure meeting attendee endpoints return roster data

### DIFF
--- a/admin/meetings/functions/add_attendee.php
+++ b/admin/meetings/functions/add_attendee.php
@@ -7,7 +7,11 @@ header('Content-Type: application/json');
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
-        echo json_encode(['success' => false, 'message' => 'Invalid CSRF token']);
+        echo json_encode([
+            'success' => false,
+            'message' => 'Invalid CSRF token',
+            'attendees' => []
+        ]);
         exit;
     }
 
@@ -19,7 +23,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     try {
         if ($meeting_id && $attendee_user_id) {
-            $stmt = $pdo->prepare('INSERT INTO module_meeting_attendees (user_id, user_updated, meeting_id, attendee_user_id, role,check_in_time, check_out_time) VALUES (:uid,:uid,:mid,:attendee,:role,:check_in,:check_out)');
+            $stmt = $pdo->prepare(
+                'INSERT INTO module_meeting_attendees (
+                    user_id,
+                    user_updated,
+                    meeting_id,
+                    attendee_user_id,
+                    role,
+                    check_in_time,
+                    check_out_time
+                ) VALUES (:uid,:uid,:mid,:attendee,:role,:check_in,:check_out)'
+            );
             $stmt->execute([
                 ':uid' => $this_user_id,
                 ':mid' => $meeting_id,
@@ -32,15 +46,35 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             admin_audit_log($pdo, $this_user_id, 'module_meeting_attendees', $id, 'CREATE', 'Added attendee');
         }
 
-        $rosterStmt = $pdo->prepare('SELECT a.id, a.attendee_user_id, a.role, a.check_in_time, a.check_out_time, COALESCE(CONCAT(p.first_name, " ", p.last_name), u.email) AS name FROM module_meeting_attendees a LEFT JOIN users u ON a.attendee_user_id = u.id LEFT JOIN person p ON u.id = p.user_id WHERE a.meeting_id =? ORDER BY name');
+        $rosterStmt = $pdo->prepare(
+            'SELECT a.id,
+                    a.attendee_user_id,
+                    a.role,
+                    a.check_in_time,
+                    a.check_out_time,
+                    COALESCE(CONCAT(p.first_name, " ", p.last_name), u.email) AS name
+             FROM module_meeting_attendees a
+             LEFT JOIN users u ON a.attendee_user_id = u.id
+             LEFT JOIN person p ON u.id = p.user_id
+             WHERE a.meeting_id = ?
+             ORDER BY name'
+        );
         $rosterStmt->execute([$meeting_id]);
         $attendees = $rosterStmt->fetchAll(PDO::FETCH_ASSOC);
         echo json_encode(['success' => true, 'attendees' => $attendees]);
     } catch (Exception $e) {
         http_response_code(400);
-        echo json_encode(['success' => false, 'message' => $e->getMessage()]);
+        echo json_encode([
+            'success' => false,
+            'message' => $e->getMessage(),
+            'attendees' => []
+        ]);
     }
     exit;
 }
 
-echo json_encode(['success' => false, 'message' => 'Invalid request']);
+echo json_encode([
+    'success' => false,
+    'message' => 'Invalid request',
+    'attendees' => []
+]);

--- a/admin/meetings/functions/get_attendees.php
+++ b/admin/meetings/functions/get_attendees.php
@@ -9,17 +9,36 @@ $data = $method === 'POST' ? $_POST : $_GET;
 $meeting_id = (int)($data['meeting_id'] ?? 0);
 
 if (!verify_csrf_token($data['csrf_token'] ?? '')) {
-    echo json_encode(['success' => false, 'message' => 'Invalid CSRF token']);
+    echo json_encode([
+        'success' => false,
+        'message' => 'Invalid CSRF token',
+        'attendees' => []
+    ]);
     exit;
 }
 
 if ($meeting_id) {
-    $stmt = $pdo->prepare('SELECT a.id, a.attendee_user_id, a.role, a.check_in_time, a.check_out_time, COALESCE(CONCAT(p.first_name, " ", p.last_name), u.email) AS name FROM module_meeting_attendees a LEFT JOIN users u ON a.attendee_user_id = u.id LEFT JOIN person p ON u.id = p.user_id WHERE a.meeting_id = ? ORDER BY name');
+    $stmt = $pdo->prepare(
+        'SELECT a.id,
+                a.attendee_user_id,
+                a.role,
+                a.check_in_time,
+                a.check_out_time,
+                COALESCE(CONCAT(p.first_name, " ", p.last_name), u.email) AS name
+         FROM module_meeting_attendees a
+         LEFT JOIN users u ON a.attendee_user_id = u.id
+         LEFT JOIN person p ON u.id = p.user_id
+         WHERE a.meeting_id = ?
+         ORDER BY name'
+    );
     $stmt->execute([$meeting_id]);
     $attendees = $stmt->fetchAll(PDO::FETCH_ASSOC);
     echo json_encode(['success' => true, 'attendees' => $attendees]);
     exit;
 }
 
-echo json_encode(['success' => false, 'attendees' => []]);
+echo json_encode([
+    'success' => false,
+    'attendees' => []
+]);
 

--- a/admin/meetings/functions/remove_attendee.php
+++ b/admin/meetings/functions/remove_attendee.php
@@ -7,7 +7,11 @@ header('Content-Type: application/json');
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
-        echo json_encode(['success' => false, 'message' => 'Invalid CSRF token']);
+        echo json_encode([
+            'success' => false,
+            'message' => 'Invalid CSRF token',
+            'attendees' => []
+        ]);
         exit;
     }
 
@@ -16,19 +20,40 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     try {
         if ($id && $meeting_id) {
-            $pdo->prepare('DELETE FROM module_meeting_attendees WHERE id=:id AND meeting_id=:mid')->execute([':id' => $id, ':mid' => $meeting_id]);
+            $pdo->prepare('DELETE FROM module_meeting_attendees WHERE id=:id AND meeting_id=:mid')
+                ->execute([':id' => $id, ':mid' => $meeting_id]);
             admin_audit_log($pdo, $this_user_id, 'module_meeting_attendees', $id, 'DELETE', 'Removed attendee');
         }
 
-        $rosterStmt = $pdo->prepare('SELECT a.id, a.attendee_user_id, a.role, a.check_in_time, a.check_out_time, COALESCE(CONCAT(p.first_name, " ", p.last_name), u.email) AS name FROM module_meeting_attendees a LEFT JOIN users u ON a.attendee_user_id = u.id LEFT JOIN person p ON u.id = p.user_id WHERE a.meeting_id =? ORDER BY name');
+        $rosterStmt = $pdo->prepare(
+            'SELECT a.id,
+                    a.attendee_user_id,
+                    a.role,
+                    a.check_in_time,
+                    a.check_out_time,
+                    COALESCE(CONCAT(p.first_name, " ", p.last_name), u.email) AS name
+             FROM module_meeting_attendees a
+             LEFT JOIN users u ON a.attendee_user_id = u.id
+             LEFT JOIN person p ON u.id = p.user_id
+             WHERE a.meeting_id = ?
+             ORDER BY name'
+        );
         $rosterStmt->execute([$meeting_id]);
         $attendees = $rosterStmt->fetchAll(PDO::FETCH_ASSOC);
         echo json_encode(['success' => true, 'attendees' => $attendees]);
     } catch (Exception $e) {
         http_response_code(400);
-        echo json_encode(['success' => false, 'message' => $e->getMessage()]);
+        echo json_encode([
+            'success' => false,
+            'message' => $e->getMessage(),
+            'attendees' => []
+        ]);
     }
     exit;
 }
 
-echo json_encode(['success' => false, 'message' => 'Invalid request']);
+echo json_encode([
+    'success' => false,
+    'message' => 'Invalid request',
+    'attendees' => []
+]);

--- a/admin/meetings/include/details_view.php
+++ b/admin/meetings/include/details_view.php
@@ -351,7 +351,7 @@ document.addEventListener('DOMContentLoaded', function(){
   }
 
   function fetchAgenda(){
-    fetchJson('functions/get_agenda.php?meeting_id=' + meetingId + '&csrf_token=' + csrfToken)
+    return fetchJson('functions/get_agenda.php?meeting_id=' + meetingId + '&csrf_token=' + csrfToken)
       .then(function(data){
         if(data.success){
           renderAgenda(data.items);
@@ -417,7 +417,7 @@ document.addEventListener('DOMContentLoaded', function(){
     });
   }
 
-  fetchAgenda();
+  fetchAgenda().then(fetchAttendees);
 
   function loadQuestions(){
     fetchJson('functions/get_questions.php?meeting_id=' + meetingId + '&csrf_token=' + csrfToken)
@@ -536,6 +536,21 @@ document.addEventListener('DOMContentLoaded', function(){
     }
   }
 
+  function fetchAttendees(){
+    return fetchJson('functions/get_attendees.php?meeting_id=' + meetingId + '&csrf_token=' + csrfToken)
+      .then(function(data){
+        if(data.success){
+          renderAttendees(data.attendees);
+        } else {
+          renderAttendees([]);
+        }
+      })
+      .catch(function(err){
+        console.error(err);
+        showToast('Failed to load attendees');
+      });
+  }
+
   function renderAttachments(files){
     attachmentsList.innerHTML = '';
     if(files && files.length){
@@ -644,19 +659,6 @@ document.addEventListener('DOMContentLoaded', function(){
       }
     });
   }
-
-  fetchJson('functions/get_attendees.php?meeting_id=' + meetingId + '&csrf_token=' + csrfToken)
-    .then(function(data){
-      if(data.success){
-        renderAttendees(data.attendees);
-      } else {
-        renderAttendees([]);
-      }
-    })
-    .catch(function(err){
-      console.error(err);
-      showToast('Failed to load attendees');
-    });
 
   fetchJson('functions/get_attachments.php?meeting_id=' + meetingId + '&csrf_token=' + csrfToken)
     .then(function(data){


### PR DESCRIPTION
## Summary
- Return roster data from get_attendees, add_attendee, and remove_attendee endpoints
- Always include `attendees` array in JSON responses
- Load attendees after agenda fetch in details view and update client state from server results

## Testing
- `php -l admin/meetings/functions/get_attendees.php`
- `php -l admin/meetings/functions/add_attendee.php`
- `php -l admin/meetings/functions/remove_attendee.php`
- `php -l admin/meetings/include/details_view.php`
- ⚠️ `php admin/meetings/functions/get_attendees.php` (missing database)
- ⚠️ `php add_attendee.php` (missing database)
- ⚠️ `php remove_attendee.php` (missing database)


------
https://chatgpt.com/codex/tasks/task_e_68ad706fc5948333954efb90661d3bca