### PR TITLE
Prevent premature lookup list initialization

### DIFF
--- a/admin/lookup-lists/index.php
+++ b/admin/lookup-lists/index.php
@@ -6,7 +6,7 @@ $token = generate_csrf_token();
 <h2 class="mb-4">Lookup Lists</h2>
 <div id="mainAlert"></div>
 <button id="addListBtn" class="btn btn-sm btn-success mb-3">Add Lookup List</button>
-<div id="lookup-lists" data-list='{"valueNames":["id","name","description","item-count", "date_updated"],"page":25,"pagination":true}'>
+<div id="lookup-lists" data-list-manual>
   <div class="row justify-content-between g-2 mb-3">
     <div class="col-auto">
       <input class="form-control form-control-sm search" placeholder="Search" />
@@ -78,6 +78,11 @@ document.addEventListener('DOMContentLoaded', function () {
   const listsTableBody = document.getElementById('listsTableBody');
   const listModalLabel = document.getElementById('listModalLabel');
   const listLoading = document.getElementById('listLoading');
+  const listOptions = {
+    valueNames: ['id', 'name', 'description', 'item-count', 'date_updated'],
+    page: 25,
+    pagination: true
+  };
   let listJs;
 
   function showAlert(container, message, type = 'danger') {
@@ -118,8 +123,7 @@ document.addEventListener('DOMContentLoaded', function () {
       });
     }
     if (!listJs && lists.length) {
-      const options = JSON.parse(document.getElementById('lookup-lists').dataset.list);
-      listJs = new window.List('lookup-lists', options);
+      listJs = new window.List('lookup-lists', listOptions);
     } else if (listJs) {
       listJs.reIndex();
     }

--- a/src/js/theme/list.js
+++ b/src/js/theme/list.js
@@ -15,6 +15,7 @@ const listInit = () => {
 
     if (lists.length) {
       lists.forEach(el => {
+        if (el.closest('[data-list-manual]')) return;
         const bulkSelect = el.querySelector('[data-bulk-select]');
 
         let options = getData(el, 'list');


### PR DESCRIPTION
## Summary
- Remove auto data-list config from lookup lists table and provide JS options constant
- Initialize List.js only after rows render
- Allow opting out of Phoenix list auto-init via `data-list-manual`

## Testing
- `php -l admin/lookup-lists/index.php`
- `node --check src/js/theme/list.js && echo 'Syntax OK'`


------
https://chatgpt.com/codex/tasks/task_e_68adff5ed7188333adf472e6838347a9