### PR TITLE
Remove question status UI and default backend status

### DIFF
--- a/admin/meetings/functions/add_question.php
+++ b/admin/meetings/functions/add_question.php
@@ -16,6 +16,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $question_text = trim($_POST['question_text'] ?? '');
     $answer_text = trim($_POST['answer_text'] ?? '');
     $status_id = isset($_POST['status_id']) && $_POST['status_id'] !== '' ? (int)$_POST['status_id'] : null;
+    if ($status_id === null) {
+        $defaultStatus = get_lookup_items($pdo, 'MEETING_QUESTION_STATUS');
+        if (!empty($defaultStatus)) {
+            $status_id = (int)$defaultStatus[0]['id'];
+        }
+    }
 
     try {
         if ($meeting_id && $question_text !== '') {

--- a/admin/meetings/functions/update_question.php
+++ b/admin/meetings/functions/update_question.php
@@ -17,6 +17,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $question_text = trim($_POST['question_text'] ?? '');
     $answer_text = trim($_POST['answer_text'] ?? '');
     $status_id = isset($_POST['status_id']) && $_POST['status_id'] !== '' ? (int)$_POST['status_id'] : null;
+    if ($status_id === null) {
+        $defaultStatus = get_lookup_items($pdo, 'MEETING_QUESTION_STATUS');
+        if (!empty($defaultStatus)) {
+            $status_id = (int)$defaultStatus[0]['id'];
+        }
+    }
 
     try {
         if ($id && $meeting_id) {

--- a/admin/meetings/include/create_edit_view.php
+++ b/admin/meetings/include/create_edit_view.php
@@ -1,8 +1,7 @@
 <?php
 $isEdit = !empty($meeting);
-// Lookup items for agenda and question statuses
+// Lookup items for agenda statuses
 $agendaStatusMap   = array_column(get_lookup_items($pdo, 'MEETING_AGENDA_STATUS'), null, 'id');
-$questionStatusMap = array_column(get_lookup_items($pdo, 'MEETING_QUESTION_STATUS'), null, 'id');
 // Lookup items for meeting status and type
 $meetingStatusList = get_lookup_items($pdo, 'MEETING_STATUS');
 $meetingTypeList   = get_lookup_items($pdo, 'MEETING_TYPE');
@@ -98,7 +97,6 @@ document.addEventListener('DOMContentLoaded', function(){
   var isEdit = <?php echo $isEdit ? 'true' : 'false'; ?>;
   var csrfToken = '<?php echo h($token); ?>';
   var agendaStatusMap   = <?php echo json_encode($agendaStatusMap); ?>;
-  var questionStatusMap = <?php echo json_encode($questionStatusMap); ?>;
   var agendaList = document.getElementById('agendaList');
   var attendeesContainer = document.getElementById('attendeesContainer');
 
@@ -221,21 +219,13 @@ document.addEventListener('DOMContentLoaded', function(){
   function addQuestion(data){
     var div = document.createElement('div');
     div.className = 'border rounded p-3 mb-2';
-    var statusOptions = '<option value="">Select status</option>';
-    for (var id in questionStatusMap) {
-      if (Object.prototype.hasOwnProperty.call(questionStatusMap, id)) {
-        statusOptions += '<option value="' + id + '">' + esc(questionStatusMap[id].label) + '</option>';
-      }
-    }
     div.innerHTML = '<input type="text" name="question_text[]" class="form-control mb-2" placeholder="Question" required>' +
       '<textarea name="answer_text[]" class="form-control mb-2" placeholder="Answer"></textarea>' +
-      '<input type="number" name="agenda_id[]" class="form-control mb-2" placeholder="Agenda ID (optional)">' +
-      '<select name="status_id[]" class="form-select">' + statusOptions + '</select>';
+      '<input type="number" name="agenda_id[]" class="form-control mb-2" placeholder="Agenda ID (optional)">';
     if(data){
-      div.querySelector('input[name="question_text[]"]').value = data.question || '';
-      div.querySelector('textarea[name="answer_text[]"]').value = data.answer || '';
+      div.querySelector('input[name="question_text[]"]').value = data.question_text || '';
+      div.querySelector('textarea[name="answer_text[]"]').value = data.answer_text || '';
       div.querySelector('input[name="agenda_id[]"]').value = data.agenda_id || '';
-      if(data.status_id){ div.querySelector('select[name="status_id[]"]').value = data.status_id; }
     }
     document.getElementById('questionsContainer').appendChild(div);
   }

--- a/admin/meetings/include/details_view.php
+++ b/admin/meetings/include/details_view.php
@@ -1,5 +1,4 @@
 <?php
-$questionStatusMap = array_column(get_lookup_items($pdo, 'MEETING_QUESTION_STATUS'), null, 'id');
 $agendaStatusMap  = array_column(get_lookup_items($pdo, 'MEETING_AGENDA_STATUS'), null, 'id');
 $meetingStatusMap = array_column(get_lookup_items($pdo, 'MEETING_STATUS'), null, 'id');
 $meetingTypeMap   = array_column(get_lookup_items($pdo, 'MEETING_TYPE'), null, 'id');
@@ -225,15 +224,6 @@ $_SESSION['csrf_token'] = $token;
             <option value="">None</option>
           </select>
         </div>
-        <div class="mb-3">
-          <label class="form-label">Status</label>
-          <select name="status_id" id="statusSelect" class="form-select">
-            <option value="">None</option>
-            <?php foreach ($questionStatusMap as $sid => $s): ?>
-              <option value="<?= (int)$sid ?>"><?= h($s['label']); ?></option>
-            <?php endforeach; ?>
-          </select>
-        </div>
       </div>
       <div class="modal-footer">
         <button type="submit" class="btn btn-primary">Save</button>
@@ -251,7 +241,6 @@ document.addEventListener('DOMContentLoaded', function(){
   var canEdit = <?php echo user_has_permission('meeting','update') ? 'true' : 'false'; ?>;
   var canEditAttendees = <?php echo user_has_permission('meeting','update') ? 'true' : 'false'; ?>;
   var csrfToken = '<?= $token; ?>';
-  var questionStatusMap = <?php echo json_encode($questionStatusMap); ?>;
   var agendaStatusMap = <?php echo json_encode($agendaStatusMap); ?>;
   var agendaMap = {};
   var questionsData = [];
@@ -442,11 +431,6 @@ document.addEventListener('DOMContentLoaded', function(){
         var div = document.createElement('div');
         div.className = 'mb-3';
         div.dataset.id = q.id;
-        var statusHtml = '';
-        if(q.status_id && questionStatusMap[q.status_id]){
-          var s = questionStatusMap[q.status_id];
-          statusHtml = '<span class="badge bg-' + esc(s.color_class || 'secondary') + ' me-2">' + esc(s.label) + '</span>';
-        }
         var agendaHtml = '';
         if(q.agenda_id && agendaMap[q.agenda_id]){
           agendaHtml = '<p class="mb-1"><small>Agenda: ' + esc(agendaMap[q.agenda_id]) + '</small></p>';
@@ -457,9 +441,8 @@ document.addEventListener('DOMContentLoaded', function(){
           + (q.answer_text ? '<p class="mb-1">' + esc(q.answer_text) + '</p>' : '')
           + agendaHtml
           + '</div>'
-          + statusHtml
           + '</div>'
-          + (canEdit ? '<div class="mt-2 text-end"><button class="btn btn-sm btn-secondary me-1 edit-question" data-id="'+q.id+'">Edit</button><button class="btn btn-sm btn-danger delete-question" data-id="'+q.id+'">Delete</button></div>' : '');
+          + (canEdit ? '<div class="mt-2 text-end"><button class="btn btn-sm btn-warning me-1 edit-question" data-id="'+q.id+'">Edit</button><button class="btn btn-sm btn-danger delete-question" data-id="'+q.id+'">Delete</button></div>' : '');
         container.appendChild(div);
       });
     } else {
@@ -488,7 +471,6 @@ document.addEventListener('DOMContentLoaded', function(){
           document.getElementById('questionText').value = q.question_text;
           document.getElementById('answerText').value = q.answer_text || '';
           document.getElementById('agendaSelect').value = q.agenda_id || '';
-          document.getElementById('statusSelect').value = q.status_id || '';
           document.getElementById('questionModalLabel').textContent = 'Edit Question';
           updateAgendaSelect();
           bootstrap.Modal.getOrCreateInstance(document.getElementById('questionModal')).show();


### PR DESCRIPTION
## Summary
- remove question status dropdown and badge from meeting views and switch edit button to warning style
- load only question text, answer, and agenda link when editing questions
- set default question status server-side when none is provided

## Testing
- `php -l admin/meetings/include/details_view.php`
- `php -l admin/meetings/include/create_edit_view.php`
- `php -l admin/meetings/functions/add_question.php`
- `php -l admin/meetings/functions/update_question.php`


------
https://chatgpt.com/codex/tasks/task_e_68ae03e499dc8333ae6379080ad8b8c9