### PR TITLE
Prevent duplicate meeting attendee entries

### DIFF
--- a/admin/meetings/functions/add_attendee.php
+++ b/admin/meetings/functions/add_attendee.php
@@ -18,6 +18,35 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $meeting_id = (int)($_POST['meeting_id'] ?? 0);
     $attendee_user_id = isset($_POST['attendee_user_id']) && $_POST['attendee_user_id'] !== '' ? (int)$_POST['attendee_user_id'] : null;
 
+    $rosterStmt = $pdo->prepare(
+        'SELECT a.id,
+                a.attendee_user_id,
+                COALESCE(CONCAT(p.first_name, " ", p.last_name), u.email) AS name
+         FROM module_meeting_attendees a
+         LEFT JOIN users u ON a.attendee_user_id = u.id
+         LEFT JOIN person p ON u.id = p.user_id
+         WHERE a.meeting_id = ?
+         ORDER BY name'
+    );
+
+    $currentRoster = [];
+    if ($meeting_id) {
+        $rosterStmt->execute([$meeting_id]);
+        $currentRoster = $rosterStmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    // Check for existing attendee before attempting to insert
+    $checkStmt = $pdo->prepare('SELECT id FROM module_meeting_attendees WHERE meeting_id = ? AND attendee_user_id = ?');
+    $checkStmt->execute([$meeting_id, $attendee_user_id]);
+    if ($checkStmt->fetch()) {
+        echo json_encode([
+            'success' => false,
+            'message' => 'Attendee already added',
+            'attendees' => $currentRoster
+        ]);
+        exit;
+    }
+
     try {
         if ($meeting_id && $attendee_user_id) {
             $stmt = $pdo->prepare(
@@ -37,16 +66,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             admin_audit_log($pdo, $this_user_id, 'module_meeting_attendees', $id, 'CREATE', 'Added attendee');
         }
 
-        $rosterStmt = $pdo->prepare(
-            'SELECT a.id,
-                    a.attendee_user_id,
-                    COALESCE(CONCAT(p.first_name, " ", p.last_name), u.email) AS name
-             FROM module_meeting_attendees a
-             LEFT JOIN users u ON a.attendee_user_id = u.id
-             LEFT JOIN person p ON u.id = p.user_id
-             WHERE a.meeting_id = ?
-             ORDER BY name'
-        );
+        // Refresh roster after successful insert
         $rosterStmt->execute([$meeting_id]);
         $attendees = $rosterStmt->fetchAll(PDO::FETCH_ASSOC);
         echo json_encode(['success' => true, 'attendees' => $attendees]);
@@ -55,7 +75,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         echo json_encode([
             'success' => false,
             'message' => $e->getMessage(),
-            'attendees' => []
+            'attendees' => $currentRoster
         ]);
     }
     exit;


### PR DESCRIPTION
## Summary
- Avoid inserting duplicate meeting attendee records and return an informative message
- Wrap attendee insert in try/catch and report errors with existing roster

## Testing
- `php -l admin/meetings/functions/add_attendee.php`


------
https://chatgpt.com/codex/tasks/task_e_68ae0cdf613483339e9270c213eadc01