### PR TITLE
Add client-side item filtering

### DIFF
--- a/admin/lookup-lists/items.php
+++ b/admin/lookup-lists/items.php
@@ -292,7 +292,17 @@ function loadItems(){
       tbody.innerHTML='';
       d.items.forEach(it=>tbody.appendChild(renderItem(it)));
       initSortable();
+      filterItems();
     }
+  });
+}
+
+function filterItems(){
+  const term = document.querySelector('.search').value.toLowerCase();
+  document.querySelectorAll('#items tbody tr').forEach(row => {
+    const code = row.querySelector('.code')?.textContent.toLowerCase() || '';
+    const label = row.querySelector('.label')?.textContent.toLowerCase() || '';
+    row.style.display = (code.includes(term) || label.includes(term)) ? '' : 'none';
   });
 }
 
@@ -339,6 +349,7 @@ document.getElementById('items').addEventListener('submit',function(e){
 });
 
 document.getElementById('statusFilter').addEventListener('change',loadItems);
+document.querySelector('.search').addEventListener('input', filterItems);
 loadItems();
 
 


### PR DESCRIPTION
## Summary
- filter lookup list items by search term
- reapply filter after reloading items and listen to keystrokes

## Testing
- `php -l admin/lookup-lists/items.php`


------
https://chatgpt.com/codex/tasks/task_e_68ae915caefc833383e8d257a6dac9e2