### PR TITLE
Improve lookup list header and load Font Awesome

### DIFF
--- a/admin/lookup-lists/items.php
+++ b/admin/lookup-lists/items.php
@@ -59,13 +59,16 @@ if($items){
 }
 ?>
 
-<div class="row">
-  <div class="col-12">
-    <h2 class="mb-4">Items for <?= h($list['name']); ?>
-      <br />
-      <a class="btn btn-secondary" href="index.php">Back</a>
-    </h2>
+<div class="row align-items-center mb-4">
+  <div class="col-auto">
+    <a class="btn btn-secondary" href="index.php">
+      <i class="fa-solid fa-arrow-left me-1"></i>Back to All Lookup Lists
+    </a>
   </div>
+  <div class="col text-center">
+    <h2 class="mb-0">Items for <?= h($list['name']); ?></h2>
+  </div>
+  <div class="col-auto"></div>
 </div>
 
 <?= flash_message($error, 'danger'); ?>

--- a/includes/html_header.php
+++ b/includes/html_header.php
@@ -18,6 +18,7 @@
 
   <script src="<?php echo getURLDir(); ?>vendors/popper/popper.min.js"></script>
   <script src="<?php echo getURLDir(); ?>vendors/bootstrap/bootstrap.min.js"></script>
+  <script src="<?php echo getURLDir(); ?>vendors/fontawesome/all.min.js"></script>
 
   <!-- Vendor CSS (Phoenix, FontAwesome, etc) -->
   <link href="<?php echo getURLDir(); ?>vendors/glightbox/glightbox.min.css" rel="stylesheet">


### PR DESCRIPTION
## Summary
- Replace lookup list items header with flex layout and back button with arrow icon
- Load Font Awesome to support new iconography

## Testing
- `php -l admin/lookup-lists/items.php`
- `php -l includes/html_header.php`


------
https://chatgpt.com/codex/tasks/task_e_68ae915f367c833388be8ce81e07653e