### PR TITLE
Use Atlis button styles for lookup list bulk add

### DIFF
--- a/admin/lookup-lists/items.php
+++ b/admin/lookup-lists/items.php
@@ -82,7 +82,7 @@ if($items){
 </form>
 <div class="row align-items-center g-2 mb-3">
   <div class="col-auto">
-    <button class="btn btn-sm btn-phoenix-primary" type="button" data-bs-toggle="modal" data-bs-target="#bulkItemsModal">
+    <button class="btn btn-atlis btn-sm" type="button" data-bs-toggle="modal" data-bs-target="#bulkItemsModal">
       Bulk Add Items
     </button>
   </div>


### PR DESCRIPTION
## Summary
- restyle bulk add button in lookup list items screen to use Atlis button class

## Testing
- `php -l admin/lookup-lists/items.php`


------
https://chatgpt.com/codex/tasks/task_e_68ae915b35548333868c5027f4e6e704