### PR TITLE
Improve admin navigation path normalization

### DIFF
--- a/admin/left_navigation.php
+++ b/admin/left_navigation.php
@@ -5,9 +5,9 @@ $navLinks = $stmt->fetchAll(PDO::FETCH_ASSOC);
 // Determine the current request path relative to /admin/
 $requestUri = $_SERVER['SCRIPT_NAME'];
 
-// Normalize a path by removing the /admin/ prefix and trailing /index.php
+// Normalize a path by removing any base directory and trailing /index.php
 $normalize = function(string $path): string {
-    $path = preg_replace('#^/admin/#', '', $path);
+    $path = preg_replace('#^.*?/admin/#', '', $path); // strips any base directory plus /admin/
     $path = preg_replace('#/index\\.php$#', '', $path);
     return trim($path, '/');
 };


### PR DESCRIPTION
## Summary
- refine path normalization to strip base directories before `/admin`
- ensure admin navigation uses `$_SERVER['SCRIPT_NAME']`

## Testing
- `php -l admin/left_navigation.php`


------
https://chatgpt.com/codex/tasks/task_e_68ae985d9d248333b84532b9a663b482