### PR TITLE
Handle meetings via JSON and streamline admin routing

### DIFF
--- a/admin/meetings/functions/create.php
+++ b/admin/meetings/functions/create.php
@@ -2,14 +2,9 @@
 require '../../../includes/php_header.php';
 require_permission('meeting', 'create');
 
-$isAjax = isset($_POST['ajax']) || (strpos($_SERVER['HTTP_ACCEPT'] ?? '', 'application/json') !== false);
-if ($isAjax) {
-  header('Content-Type: application/json');
-}
-
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  header('Content-Type: application/json');
   if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
-    header('Content-Type: application/json');
     echo json_encode(['success' => false, 'message' => 'Invalid CSRF token']);
     exit;
   }
@@ -167,34 +162,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
       }
 
       $pdo->commit();
-      $meeting = ['id'=>$id,'title'=>$title,'start_time'=>$start_time];
+      echo json_encode(['success'=>true,'id'=>$id]);
+      exit;
     } catch (Exception $e) {
       $pdo->rollBack();
       $errors[] = $e->getMessage();
     }
   }
-
-  if ($isAjax) {
-    if (empty($errors)) {
-      echo json_encode(['success'=>true,'meeting'=>$meeting]);
-    } else {
-      echo json_encode(['success'=>false,'errors'=>$errors]);
-    }
-    exit;
-  } else {
-    if (empty($errors)) {
-      header('Location: ../index.php');
-    } else {
-      echo implode('\n', $errors);
-    }
-    exit;
-  }
-}
-
-if ($isAjax) {
-  echo json_encode(['success'=>false]);
+  echo json_encode(['success'=>false,'errors'=>$errors]);
   exit;
 }
 
-header('Location: ../index.php');
+header('Content-Type: application/json');
+echo json_encode(['success'=>false]);
 exit;

--- a/admin/meetings/index.php
+++ b/admin/meetings/index.php
@@ -4,13 +4,11 @@ require '../admin_header.php';
 $action = $_GET['action'] ?? 'list';
 
 switch ($action) {
-  case 'create':
   case 'edit':
-    $perm = ($action === 'create') ? 'create' : 'update';
-    require_permission('meeting', $perm);
+    require_permission('meeting', 'update');
     $id = (int)($_GET['id'] ?? 0);
     $meeting = [];
-    if ($action === 'edit' && $id) {
+    if ($id) {
       $stmt = $pdo->prepare('SELECT id, title, description, start_time, end_time, recur_daily, recur_weekly, recur_monthly FROM module_meetings WHERE id = ?');
       $stmt->execute([$id]);
       $meeting = $stmt->fetch(PDO::FETCH_ASSOC) ?: [];


### PR DESCRIPTION
## Summary
- Return JSON success response with meeting ID on meeting creation
- Remove unused HTML fallbacks and meeting array from creation
- Limit meetings admin index routing to edit, details, and list views

## Testing
- `php -l admin/meetings/functions/create.php`
- `php -l admin/meetings/index.php`
- `composer validate --no-check-all`


------
https://chatgpt.com/codex/tasks/task_e_68aea29585e48333aea11bee7bbcc923