### PR TITLE
Add conference module tables

### DIFF
--- a/_SQL/20250701_module_conferences.sql
+++ b/_SQL/20250701_module_conferences.sql
@@ -1,0 +1,135 @@
+-- Conference module tables
+
+CREATE TABLE `module_conferences` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT CURRENT_TIMESTAMP,
+  `date_updated` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `memo` text DEFAULT NULL,
+  `name` varchar(255) NOT NULL,
+  `event_type_id` int(11) DEFAULT NULL,
+  `topic_id` int(11) DEFAULT NULL,
+  `mode` enum('ONLINE','OFFLINE','BOTH') DEFAULT 'ONLINE',
+  `venue` varchar(255) DEFAULT NULL,
+  `country_id` int(11) DEFAULT NULL,
+  `state_id` int(11) DEFAULT NULL,
+  `city` varchar(255) DEFAULT NULL,
+  `start_datetime` datetime DEFAULT NULL,
+  `end_datetime` datetime DEFAULT NULL,
+  `timezone` varchar(64) DEFAULT NULL,
+  `registration_deadline` date DEFAULT NULL,
+  `description` text DEFAULT NULL,
+  `organizers` varchar(255) DEFAULT NULL,
+  `sponsors` varchar(255) DEFAULT NULL,
+  `is_private` tinyint(1) DEFAULT 0,
+  `show_ticket_count` tinyint(1) DEFAULT 1,
+  `going_count` int(11) DEFAULT 0,
+  `interested_count` int(11) DEFAULT 0,
+  `share_count` int(11) DEFAULT 0,
+  PRIMARY KEY (`id`),
+  KEY `fk_module_conferences_user_id` (`user_id`),
+  KEY `fk_module_conferences_user_updated` (`user_updated`),
+  CONSTRAINT `fk_module_conferences_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+  CONSTRAINT `fk_module_conferences_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `module_conference_tags` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT CURRENT_TIMESTAMP,
+  `date_updated` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `memo` text DEFAULT NULL,
+  `conference_id` int(11) NOT NULL,
+  `tag` varchar(100) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `fk_module_conference_tags_user_id` (`user_id`),
+  KEY `fk_module_conference_tags_user_updated` (`user_updated`),
+  KEY `fk_module_conference_tags_conference_id` (`conference_id`),
+  CONSTRAINT `fk_module_conference_tags_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+  CONSTRAINT `fk_module_conference_tags_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`),
+  CONSTRAINT `fk_module_conference_tags_conference_id` FOREIGN KEY (`conference_id`) REFERENCES `module_conferences` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `module_conference_images` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT CURRENT_TIMESTAMP,
+  `date_updated` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `memo` text DEFAULT NULL,
+  `conference_id` int(11) NOT NULL,
+  `file_name` varchar(255) DEFAULT NULL,
+  `file_path` varchar(255) DEFAULT NULL,
+  `file_size` int(11) DEFAULT NULL,
+  `file_type` varchar(50) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `fk_module_conference_images_user_id` (`user_id`),
+  KEY `fk_module_conference_images_user_updated` (`user_updated`),
+  KEY `fk_module_conference_images_conference_id` (`conference_id`),
+  CONSTRAINT `fk_module_conference_images_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+  CONSTRAINT `fk_module_conference_images_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`),
+  CONSTRAINT `fk_module_conference_images_conference_id` FOREIGN KEY (`conference_id`) REFERENCES `module_conferences` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `module_conference_ticket_options` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT CURRENT_TIMESTAMP,
+  `date_updated` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `memo` text DEFAULT NULL,
+  `conference_id` int(11) NOT NULL,
+  `option_name` varchar(255) NOT NULL,
+  `price` decimal(10,2) DEFAULT 0,
+  PRIMARY KEY (`id`),
+  KEY `fk_module_conference_ticket_options_user_id` (`user_id`),
+  KEY `fk_module_conference_ticket_options_user_updated` (`user_updated`),
+  KEY `fk_module_conference_ticket_options_conference_id` (`conference_id`),
+  CONSTRAINT `fk_module_conference_ticket_options_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+  CONSTRAINT `fk_module_conference_ticket_options_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`),
+  CONSTRAINT `fk_module_conference_ticket_options_conference_id` FOREIGN KEY (`conference_id`) REFERENCES `module_conferences` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `module_conference_custom_fields` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT CURRENT_TIMESTAMP,
+  `date_updated` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `memo` text DEFAULT NULL,
+  `conference_id` int(11) NOT NULL,
+  `name` varchar(255) NOT NULL,
+  `field_type` varchar(50) NOT NULL,
+  `field_options` text DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `fk_module_conference_custom_fields_user_id` (`user_id`),
+  KEY `fk_module_conference_custom_fields_user_updated` (`user_updated`),
+  KEY `fk_module_conference_custom_fields_conference_id` (`conference_id`),
+  CONSTRAINT `fk_module_conference_custom_fields_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+  CONSTRAINT `fk_module_conference_custom_fields_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`),
+  CONSTRAINT `fk_module_conference_custom_fields_conference_id` FOREIGN KEY (`conference_id`) REFERENCES `module_conferences` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `module_conference_attendees` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) DEFAULT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT CURRENT_TIMESTAMP,
+  `date_updated` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `memo` text DEFAULT NULL,
+  `conference_id` int(11) NOT NULL,
+  `attendee_user_id` int(11) NOT NULL,
+  `status` enum('GOING','INTERESTED') DEFAULT 'GOING',
+  PRIMARY KEY (`id`),
+  KEY `fk_module_conference_attendees_user_id` (`user_id`),
+  KEY `fk_module_conference_attendees_user_updated` (`user_updated`),
+  KEY `fk_module_conference_attendees_conference_id` (`conference_id`),
+  KEY `fk_module_conference_attendees_attendee_user_id` (`attendee_user_id`),
+  CONSTRAINT `fk_module_conference_attendees_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+  CONSTRAINT `fk_module_conference_attendees_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`),
+  CONSTRAINT `fk_module_conference_attendees_conference_id` FOREIGN KEY (`conference_id`) REFERENCES `module_conferences` (`id`),
+  CONSTRAINT `fk_module_conference_attendees_attendee_user_id` FOREIGN KEY (`attendee_user_id`) REFERENCES `users` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+


### PR DESCRIPTION
## Summary
- add SQL definitions for conference module and related tables

## Testing
- `composer validate`

------
https://chatgpt.com/codex/tasks/task_e_68aea9b1334483338630c90b1a2f2f10