### PR TITLE
Add corporate settings page with note and file management

### DIFF
--- a/admin/corporate/functions/add_note.php
+++ b/admin/corporate/functions/add_note.php
@@ -1,0 +1,23 @@
+<?php
+require '../../../includes/php_header.php';
+require_permission('admin_corporate','create');
+header('Content-Type: application/json');
+
+if(!verify_csrf_token($_POST['csrf_token'] ?? '')){
+  echo json_encode(['success'=>false,'error'=>'Invalid CSRF token']);
+  exit;
+}
+
+$cid = (int)($_POST['corporate_id'] ?? 0);
+$note = trim($_POST['note_text'] ?? '');
+
+if($cid && $note !== ''){
+  $stmt = $pdo->prepare('INSERT INTO module_corporate_notes (user_id,user_updated,corporate_id,note_text) VALUES (:uid,:uid,:cid,:note)');
+  $stmt->execute([':uid'=>$this_user_id, ':cid'=>$cid, ':note'=>$note]);
+  $nid = $pdo->lastInsertId();
+  admin_audit_log($pdo,$this_user_id,'module_corporate_notes',$nid,'NOTE','', $note);
+  echo json_encode(['success'=>true,'note'=>['id'=>$nid,'note_text'=>$note]]);
+  exit;
+}
+
+echo json_encode(['success'=>false,'error'=>'Unable to add note']);

--- a/admin/corporate/functions/delete_file.php
+++ b/admin/corporate/functions/delete_file.php
@@ -1,0 +1,28 @@
+<?php
+require '../../../includes/php_header.php';
+require_permission('admin_corporate','delete');
+header('Content-Type: application/json');
+
+if(!verify_csrf_token($_POST['csrf_token'] ?? '')){
+  echo json_encode(['success'=>false,'error'=>'Invalid CSRF token']);
+  exit;
+}
+
+$id = (int)($_POST['id'] ?? 0);
+if($id){
+  $stmt = $pdo->prepare('SELECT file_path FROM module_corporate_files WHERE id = :id');
+  $stmt->execute([':id'=>$id]);
+  $path = $stmt->fetchColumn();
+  if($path){
+    $full = __DIR__ . '/../../' . $path;
+    if(file_exists($full)){
+      unlink($full);
+    }
+  }
+  $pdo->prepare('DELETE FROM module_corporate_files WHERE id = :id')->execute([':id'=>$id]);
+  admin_audit_log($pdo,$this_user_id,'module_corporate_files',$id,'DELETE','', '');
+  echo json_encode(['success'=>true]);
+  exit;
+}
+
+echo json_encode(['success'=>false,'error'=>'Unable to delete file']);

--- a/admin/corporate/functions/delete_note.php
+++ b/admin/corporate/functions/delete_note.php
@@ -1,0 +1,20 @@
+<?php
+require '../../../includes/php_header.php';
+require_permission('admin_corporate','delete');
+header('Content-Type: application/json');
+
+if(!verify_csrf_token($_POST['csrf_token'] ?? '')){
+  echo json_encode(['success'=>false,'error'=>'Invalid CSRF token']);
+  exit;
+}
+
+$id = (int)($_POST['id'] ?? 0);
+if($id){
+  $stmt = $pdo->prepare('DELETE FROM module_corporate_notes WHERE id = :id');
+  $stmt->execute([':id'=>$id]);
+  admin_audit_log($pdo,$this_user_id,'module_corporate_notes',$id,'DELETE','', '');
+  echo json_encode(['success'=>true]);
+  exit;
+}
+
+echo json_encode(['success'=>false,'error'=>'Unable to delete note']);

--- a/admin/corporate/functions/edit_note.php
+++ b/admin/corporate/functions/edit_note.php
@@ -1,0 +1,22 @@
+<?php
+require '../../../includes/php_header.php';
+require_permission('admin_corporate','update');
+header('Content-Type: application/json');
+
+if(!verify_csrf_token($_POST['csrf_token'] ?? '')){
+  echo json_encode(['success'=>false,'error'=>'Invalid CSRF token']);
+  exit;
+}
+
+$id = (int)($_POST['id'] ?? 0);
+$text = trim($_POST['note_text'] ?? '');
+
+if($id && $text !== ''){
+  $stmt = $pdo->prepare('UPDATE module_corporate_notes SET note_text = :text, user_updated = :uid WHERE id = :id');
+  $stmt->execute([':text'=>$text, ':uid'=>$this_user_id, ':id'=>$id]);
+  admin_audit_log($pdo,$this_user_id,'module_corporate_notes',$id,'UPDATE','',$text);
+  echo json_encode(['success'=>true]);
+  exit;
+}
+
+echo json_encode(['success'=>false,'error'=>'Unable to edit note']);

--- a/admin/corporate/functions/update.php
+++ b/admin/corporate/functions/update.php
@@ -1,0 +1,30 @@
+<?php
+require '../../../includes/php_header.php';
+require_permission('admin_corporate','update');
+header('Content-Type: application/json');
+
+if(!verify_csrf_token($_POST['csrf_token'] ?? '')){
+  echo json_encode(['success'=>false,'error'=>'Invalid CSRF token']);
+  exit;
+}
+
+$id = (int)($_POST['id'] ?? 0);
+$name = trim($_POST['name'] ?? '');
+$description = trim($_POST['description'] ?? '');
+$feature_id = $_POST['feature_id'] !== '' ? (int)$_POST['feature_id'] : null;
+
+if($id && $name !== ''){
+  $stmt = $pdo->prepare('UPDATE module_corporate SET name = :name, description = :description, feature_id = :feature_id, user_updated = :uid WHERE id = :id');
+  $stmt->execute([
+    ':name'=>$name,
+    ':description'=>$description,
+    ':feature_id'=>$feature_id,
+    ':uid'=>$this_user_id,
+    ':id'=>$id
+  ]);
+  admin_audit_log($pdo,$this_user_id,'module_corporate',$id,'UPDATE','',json_encode(['name'=>$name]));
+  echo json_encode(['success'=>true]);
+  exit;
+}
+
+echo json_encode(['success'=>false,'error'=>'Missing data']);

--- a/admin/corporate/functions/upload_file.php
+++ b/admin/corporate/functions/upload_file.php
@@ -1,0 +1,39 @@
+<?php
+require '../../../includes/php_header.php';
+require_permission('admin_corporate','create');
+header('Content-Type: application/json');
+
+if(!verify_csrf_token($_POST['csrf_token'] ?? '')){
+  echo json_encode(['success'=>false,'error'=>'Invalid CSRF token']);
+  exit;
+}
+
+$cid = (int)($_POST['corporate_id'] ?? 0);
+if($cid && !empty($_FILES['file']) && $_FILES['file']['error'] === UPLOAD_ERR_OK){
+  $uploadDir = __DIR__ . '/../uploads/';
+  if(!is_dir($uploadDir)){
+    mkdir($uploadDir,0777,true);
+  }
+  $orig = $_FILES['file']['name'];
+  $safe = preg_replace('/[^A-Za-z0-9._-]/','_', basename($orig));
+  $targetName = 'corp_' . $cid . '_' . time() . '_' . $safe;
+  $targetPath = $uploadDir . $targetName;
+  if(move_uploaded_file($_FILES['file']['tmp_name'],$targetPath)){
+    $dbPath = 'admin/corporate/uploads/' . $targetName;
+    $stmt = $pdo->prepare('INSERT INTO module_corporate_files (user_id,user_updated,corporate_id,file_name,file_path,file_size,file_type) VALUES (:uid,:uid,:cid,:name,:path,:size,:type)');
+    $stmt->execute([
+      ':uid'=>$this_user_id,
+      ':cid'=>$cid,
+      ':name'=>$orig,
+      ':path'=>$dbPath,
+      ':size'=>$_FILES['file']['size'],
+      ':type'=>$_FILES['file']['type']
+    ]);
+    $fid = $pdo->lastInsertId();
+    admin_audit_log($pdo,$this_user_id,'module_corporate_files',$fid,'UPLOAD','',json_encode(['file'=>$orig]));
+    echo json_encode(['success'=>true,'file'=>['id'=>$fid,'file_name'=>$orig,'file_path'=>getURLDir() . $dbPath]]);
+    exit;
+  }
+}
+
+echo json_encode(['success'=>false,'error'=>'Upload failed']);

--- a/admin/corporate/index.php
+++ b/admin/corporate/index.php
@@ -1,325 +1,196 @@
 <?php
 require '../admin_header.php';
-require_permission('corporate','read');
+require_permission('admin_corporate','read');
 
 $token = generate_csrf_token();
 
-$sql = "SELECT c.id, c.name, f.label AS feature_label
-        FROM module_corporate c
-        LEFT JOIN lookup_list_items f ON c.feature_id = f.id
-        ORDER BY c.date_created DESC";
-$corporates = $pdo->query($sql)->fetchAll(PDO::FETCH_ASSOC);
-
+// Load corporate settings (single row)
+$stmt = $pdo->query('SELECT * FROM module_corporate LIMIT 1');
+$corporate = $stmt->fetch(PDO::FETCH_ASSOC) ?: ['id'=>0,'name'=>'','description'=>'','feature_id'=>null];
 $features = get_lookup_items($pdo, 'CORPORATE_FEATURE');
 ?>
-<h2 class="mb-4">Corporate</h2>
-<?= flash_message($_SESSION['message'] ?? '', 'success'); ?>
-<?= flash_message($_SESSION['error_message'] ?? '', 'danger'); ?>
-<?php unset($_SESSION['message'], $_SESSION['error_message']); ?>
-<?php if (user_has_permission('corporate','create')): ?>
-<div class="mb-3">
-  <button class="btn btn-sm btn-success" id="addCorporateBtn">Add Corporate</button>
-</div>
-<?php endif; ?>
-<div id="corporates" data-list='{"valueNames":["id","name","feature"],"page":25,"pagination":true}'>
-  <div class="row justify-content-between g-2 mb-3">
-    <div class="col-auto">
-      <input class="form-control form-control-sm search" placeholder="Search" />
+<h2 class="mb-4">Corporate Settings</h2>
+<div id="flash"></div>
+<form id="corporateForm" class="card mb-4">
+  <div class="card-body">
+    <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+    <input type="hidden" name="id" value="<?= (int)$corporate['id']; ?>">
+    <div class="mb-3">
+      <label class="form-label" for="name">Name</label>
+      <input class="form-control" type="text" id="name" name="name" value="<?= e($corporate['name']); ?>" required>
+    </div>
+    <div class="mb-3">
+      <label class="form-label" for="description">Description</label>
+      <textarea class="form-control" id="description" name="description" rows="3"><?= e($corporate['description']); ?></textarea>
+    </div>
+    <div class="mb-3">
+      <label class="form-label" for="feature_id">Feature</label>
+      <select class="form-select" id="feature_id" name="feature_id">
+        <option value="">Select</option>
+        <?php foreach ($features as $f): ?>
+        <option value="<?= (int)$f['id']; ?>" <?= (int)$corporate['feature_id'] === (int)$f['id'] ? 'selected' : ''; ?>><?= e($f['label']); ?></option>
+        <?php endforeach; ?>
+      </select>
+    </div>
+    <?php if (user_has_permission('admin_corporate','update')): ?>
+    <button class="btn btn-primary" type="submit">Save Settings</button>
+    <?php endif; ?>
+  </div>
+</form>
+
+<div class="row">
+  <div class="col-md-6">
+    <div class="card mb-4">
+      <div class="card-header d-flex justify-content-between align-items-center">
+        <h5 class="mb-0">Notes</h5>
+      </div>
+      <div class="card-body">
+        <ul class="list-unstyled" id="notesList">
+          <?php
+          $nstmt = $pdo->prepare('SELECT id, note_text FROM module_corporate_notes WHERE corporate_id = :id ORDER BY date_created DESC');
+          $nstmt->execute([':id' => $corporate['id']]);
+          foreach ($nstmt as $n): ?>
+          <li class="d-flex justify-content-between align-items-start mb-2" data-note-id="<?= (int)$n['id']; ?>">
+            <span><?= e($n['note_text']); ?></span>
+            <span>
+              <?php if (user_has_permission('admin_corporate','update')): ?><button class="btn btn-sm btn-outline-secondary edit-note">Edit</button><?php endif; ?>
+              <?php if (user_has_permission('admin_corporate','delete')): ?><button class="btn btn-sm btn-outline-danger delete-note">Delete</button><?php endif; ?>
+            </span>
+          </li>
+          <?php endforeach; ?>
+        </ul>
+        <?php if (user_has_permission('admin_corporate','create')): ?>
+        <form id="noteForm" class="mt-3">
+          <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+          <input type="hidden" name="corporate_id" value="<?= (int)$corporate['id']; ?>">
+          <textarea class="form-control mb-2" name="note_text" rows="2" placeholder="Add note" required></textarea>
+          <button class="btn btn-sm btn-primary" type="submit">Add Note</button>
+        </form>
+        <?php endif; ?>
+      </div>
     </div>
   </div>
-  <div class="table-responsive">
-    <table class="table table-striped table-sm mb-0">
-      <thead>
-        <tr>
-          <th class="sort" data-sort="id">ID</th>
-          <th class="sort" data-sort="name">Name</th>
-          <th class="sort" data-sort="feature">Feature</th>
-          <th>Actions</th>
-        </tr>
-      </thead>
-      <tbody class="list">
-        <?php foreach ($corporates as $c): ?>
-        <tr data-corporate-id="<?= (int)$c['id']; ?>">
-          <td class="id"><?= e($c['id']); ?></td>
-          <td class="name"><?= e($c['name']); ?></td>
-          <td class="feature"><?= e($c['feature_label']); ?></td>
-          <td>
-            <?php if (user_has_permission('corporate','update')): ?>
-            <button class="btn btn-sm btn-warning edit-corporate" data-id="<?= (int)$c['id']; ?>">Edit</button>
-            <?php endif; ?>
-            <?php if (user_has_permission('corporate','delete')): ?>
-            <form method="post" action="functions/delete.php" class="d-inline" onsubmit="return confirm('Delete this record?');">
-              <input type="hidden" name="id" value="<?= (int)$c['id']; ?>">
-              <input type="hidden" name="csrf_token" value="<?= $token; ?>">
-              <button class="btn btn-sm btn-danger">Delete</button>
-            </form>
-            <?php endif; ?>
-          </td>
-        </tr>
-        <tr>
-          <td colspan="4">
-            <div class="row g-3">
-              <div class="col-md-6">
-                <h5>Notes</h5>
-                <ul class="list-unstyled" id="notes-<?= (int)$c['id']; ?>">
-                  <?php
-                  $nstmt = $pdo->prepare('SELECT id, note_text FROM module_corporate_notes WHERE corporate_id = :id ORDER BY date_created DESC');
-                  $nstmt->execute([':id' => $c['id']]);
-                  foreach ($nstmt as $n): ?>
-                  <li data-note-id="<?= (int)$n['id']; ?>" class="d-flex justify-content-between">
-                    <span><?= e($n['note_text']); ?></span>
-                    <?php if (user_has_permission('corporate','update')): ?>
-                    <div>
-                      <button class="btn btn-sm btn-outline-warning edit-note" data-id="<?= (int)$n['id']; ?>">Edit</button>
-                      <?php endif; if (user_has_permission('corporate','delete')): ?>
-                      <button class="btn btn-sm btn-outline-danger delete-note" data-id="<?= (int)$n['id']; ?>">Delete</button>
-                    </div>
-                    <?php endif; ?>
-                  </li>
-                  <?php endforeach; ?>
-                </ul>
-                <?php if (user_has_permission('corporate','update')): ?>
-                <form class="note-form" data-id="<?= (int)$c['id']; ?>">
-                  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
-                  <input type="hidden" name="corporate_id" value="<?= (int)$c['id']; ?>">
-                  <textarea class="form-control mb-2" name="note_text" rows="2" placeholder="Add note" required></textarea>
-                  <button class="btn btn-sm btn-primary">Add Note</button>
-                </form>
-                <?php endif; ?>
-              </div>
-              <div class="col-md-6">
-                <h5>Files</h5>
-                <ul class="list-unstyled" id="files-<?= (int)$c['id']; ?>">
-                  <?php
-                  $fstmt = $pdo->prepare('SELECT id, file_name, file_path FROM module_corporate_files WHERE corporate_id = :id ORDER BY date_created DESC');
-                  $fstmt->execute([':id' => $c['id']]);
-                  foreach ($fstmt as $f): ?>
-                  <li data-file-id="<?= (int)$f['id']; ?>" class="d-flex justify-content-between">
-                    <a href="<?= getURLDir() . e($f['file_path']); ?>" target="_blank"><?= e($f['file_name']); ?></a>
-                    <?php if (user_has_permission('corporate','delete')): ?>
-                    <button class="btn btn-sm btn-outline-danger delete-file" data-id="<?= (int)$f['id']; ?>">Delete</button>
-                    <?php endif; ?>
-                  </li>
-                  <?php endforeach; ?>
-                </ul>
-                <?php if (user_has_permission('corporate','create')): ?>
-                <form class="file-form" data-id="<?= (int)$c['id']; ?>" enctype="multipart/form-data">
-                  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
-                  <input type="hidden" name="corporate_id" value="<?= (int)$c['id']; ?>">
-                  <input type="file" name="file" class="form-control form-control-sm mb-2" required>
-                  <button class="btn btn-sm btn-primary">Upload</button>
-                </form>
-                <?php endif; ?>
-              </div>
-            </div>
-          </td>
-        </tr>
-        <?php endforeach; ?>
-      </tbody>
-    </table>
-  </div>
-  <div class="d-flex justify-content-between align-items-center mt-3">
-    <p class="mb-0" data-list-info></p>
-    <ul class="pagination mb-0"></ul>
-  </div>
-</div>
-
-<div class="modal fade" id="corporateModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog">
-    <form class="modal-content" id="corporateForm">
-      <div class="modal-header">
-        <h5 class="modal-title" id="corporateModalLabel">Add Corporate</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+  <div class="col-md-6">
+    <div class="card mb-4">
+      <div class="card-header"><h5 class="mb-0">Files</h5></div>
+      <div class="card-body">
+        <ul class="list-unstyled" id="filesList">
+          <?php
+          $fstmt = $pdo->prepare('SELECT id, file_name, file_path FROM module_corporate_files WHERE corporate_id = :id ORDER BY date_created DESC');
+          $fstmt->execute([':id' => $corporate['id']]);
+          foreach ($fstmt as $f): ?>
+          <li class="d-flex justify-content-between align-items-start mb-2" data-file-id="<?= (int)$f['id']; ?>">
+            <a href="<?= getURLDir() . e($f['file_path']); ?>" target="_blank"><?= e($f['file_name']); ?></a>
+            <?php if (user_has_permission('admin_corporate','delete')): ?><button class="btn btn-sm btn-outline-danger delete-file">Delete</button><?php endif; ?>
+          </li>
+          <?php endforeach; ?>
+        </ul>
+        <?php if (user_has_permission('admin_corporate','create')): ?>
+        <form id="fileForm" class="mt-3" enctype="multipart/form-data">
+          <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+          <input type="hidden" name="corporate_id" value="<?= (int)$corporate['id']; ?>">
+          <input type="file" name="file" class="form-control form-control-sm mb-2" required>
+          <button class="btn btn-sm btn-primary" type="submit">Upload</button>
+        </form>
+        <?php endif; ?>
       </div>
-      <div class="modal-body">
-        <div id="corporateAlert"></div>
-        <input type="hidden" name="csrf_token" value="<?= $token; ?>">
-        <input type="hidden" name="id" id="corporate-id">
-        <div class="mb-3">
-          <label class="form-label">Name</label>
-          <input type="text" name="name" id="corporate-name" class="form-control" required>
-        </div>
-        <div class="mb-3">
-          <label class="form-label">Feature</label>
-          <select name="feature_id" id="corporate-feature" class="form-select">
-            <option value="">--</option>
-            <?php foreach ($features as $f): ?>
-            <option value="<?= $f['id']; ?>"><?= e($f['label']); ?></option>
-            <?php endforeach; ?>
-          </select>
-        </div>
-        <div class="mb-3">
-          <label class="form-label">Memo</label>
-          <textarea name="memo" id="corporate-memo" class="form-control" rows="3"></textarea>
-        </div>
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-        <button type="submit" class="btn btn-primary">Save</button>
-      </div>
-    </form>
+    </div>
   </div>
 </div>
 
 <script>
 document.addEventListener('DOMContentLoaded', () => {
-  const csrfToken = '<?= $token; ?>';
-  const corporateModal = new bootstrap.Modal(document.getElementById('corporateModal'));
-  const corporateForm = document.getElementById('corporateForm');
-  const corporateAlert = document.getElementById('corporateAlert');
-  const corporateModalLabel = document.getElementById('corporateModalLabel');
-  const corporatesTableBody = document.querySelector('#corporates tbody.list');
-  const addCorporateBtn = document.getElementById('addCorporateBtn');
-  const jsonHeaders = {
-    'X-Requested-With': 'XMLHttpRequest',
-    'Accept': 'application/json'
-  };
-  let corpList;
-  const options = JSON.parse(document.getElementById('corporates').dataset.list);
-  if (window.List) {
-    corpList = new window.List('corporates', options);
+  const flash = document.getElementById('flash');
+  function showFlash(msg, type='success'){
+    flash.innerHTML = `<div class="alert alert-${type} alert-dismissible fade show" role="alert">${msg}<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button></div>`;
   }
-
-  function showAlert(message, type = 'danger') {
-    corporateAlert.innerHTML = `<div class="alert alert-${type} alert-dismissible fade show" role="alert">${message}<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button></div>`;
+  function escapeHtml(str){
+    return str.replace(/[&<>'"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[c]));
   }
-
-  function escapeHtml(text = '') {
-    const div = document.createElement('div');
-    div.textContent = text;
-    return div.innerHTML;
-  }
-
-  addCorporateBtn && addCorporateBtn.addEventListener('click', () => {
-    corporateForm.reset();
-    document.getElementById('corporate-id').value = '';
-    corporateAlert.innerHTML = '';
-    corporateModalLabel.textContent = 'Add Corporate';
-    corporateModal.show();
-  });
-
-  document.querySelectorAll('.edit-corporate').forEach(btn => {
-    btn.addEventListener('click', () => {
-      const id = btn.dataset.id;
-      const tr = btn.closest('tr');
-      document.getElementById('corporate-id').value = id;
-      document.getElementById('corporate-name').value = tr.querySelector('.name').textContent.trim();
-      const featureText = tr.querySelector('.feature').textContent.trim();
-      document.getElementById('corporate-feature').value = Array.from(document.getElementById('corporate-feature').options).find(o => o.text === featureText)?.value || '';
-      corporateAlert.innerHTML = '';
-      corporateModalLabel.textContent = 'Edit Corporate';
-      corporateModal.show();
-    });
-  });
-
-  corporateForm.addEventListener('submit', e => {
+  const corpForm = document.getElementById('corporateForm');
+  corpForm && corpForm.addEventListener('submit', e => {
     e.preventDefault();
-    const formData = new FormData(corporateForm);
-    const action = formData.get('id') ? 'update.php' : 'create.php';
-    fetch('functions/' + action, {
-      method: 'POST',
-      body: formData,
-      headers: jsonHeaders
-    })
-    .then(res => res.json())
-    .then(data => {
-      if (data.success && data.corporate) {
-        const c = data.corporate;
-        let tr = corporatesTableBody.querySelector(`tr[data-corporate-id="${c.id}"]`);
-        if (!tr) {
-          tr = document.createElement('tr');
-          tr.dataset.corporateId = c.id;
-          corporatesTableBody.prepend(tr);
-        }
-        let actions = '';
-        <?php if (user_has_permission('corporate','update')): ?>
-        actions += `<button class=\"btn btn-sm btn-warning edit-corporate\" data-id=\"${c.id}\">Edit</button>`;
-        <?php endif; ?>
-        <?php if (user_has_permission('corporate','delete')): ?>
-        actions += `<form method=\"post\" action=\"functions/delete.php\" class=\"d-inline\" onsubmit=\"return confirm('Delete this record?');\"><input type=\"hidden\" name=\"id\" value=\"${c.id}\"><input type=\"hidden\" name=\"csrf_token\" value=\"${csrfToken}\"><button class=\"btn btn-sm btn-danger\">Delete</button></form>`;
-        <?php endif; ?>
-        tr.innerHTML = `<td class=\"id\">${escapeHtml(c.id)}</td><td class=\"name\">${escapeHtml(c.name)}</td><td class=\"feature\">${escapeHtml(c.feature_label || '')}</td><td>${actions}</td>`;
-        if (corpList) { corpList.reIndex(); }
-        corporateModal.hide();
-      } else {
-        showAlert(data.error || 'Error');
-      }
-    })
-    .catch(() => showAlert('Server error'));
+    fetch('functions/update.php', {method:'POST', body:new FormData(corpForm)})
+      .then(r => r.json())
+      .then(d => { d.success ? showFlash('Settings saved') : showFlash(d.error || 'Error','danger'); })
+      .catch(() => showFlash('Server error','danger'));
   });
 
-  document.querySelectorAll('.note-form').forEach(form => {
-    form.addEventListener('submit', e => {
-      e.preventDefault();
-      const list = document.getElementById('notes-' + form.dataset.id);
-      fetch('functions/add_note.php', {
-        method: 'POST',
-        body: new FormData(form),
-        headers: jsonHeaders
-      }).then(r => r.json()).then(d => {
-        if (d.success && d.note) {
+  const noteForm = document.getElementById('noteForm');
+  noteForm && noteForm.addEventListener('submit', e => {
+    e.preventDefault();
+    fetch('functions/add_note.php',{method:'POST',body:new FormData(noteForm)})
+      .then(r=>r.json()).then(d=>{
+        if(d.success && d.note){
           const li = document.createElement('li');
+          li.className='d-flex justify-content-between align-items-start mb-2';
           li.dataset.noteId = d.note.id;
-          li.className = 'd-flex justify-content-between';
-          li.innerHTML = `<span>${escapeHtml(d.note.note_text)}</span><?php if (user_has_permission('corporate','update')): ?> <div><button class=\"btn btn-sm btn-outline-warning edit-note\" data-id=\"${d.note.id}\">Edit</button><?php endif; if (user_has_permission('corporate','delete')): ?> <button class=\"btn btn-sm btn-outline-danger delete-note\" data-id=\"${d.note.id}\">Delete</button></div><?php endif; ?>`;
-          list.prepend(li);
-          form.reset();
+          li.innerHTML = `<span>${escapeHtml(d.note.note_text)}</span><span><?php if (user_has_permission('admin_corporate','update')): ?><button class="btn btn-sm btn-outline-secondary edit-note">Edit</button><?php endif; ?> <?php if (user_has_permission('admin_corporate','delete')): ?><button class="btn btn-sm btn-outline-danger delete-note">Delete</button><?php endif; ?></span>`;
+          document.getElementById('notesList').prepend(li);
+          noteForm.reset();
+          showFlash('Note added');
+        }else{
+          showFlash(d.error || 'Error','danger');
         }
-      });
-    });
+      }).catch(()=>showFlash('Server error','danger'));
   });
 
-  document.querySelectorAll('.file-form').forEach(form => {
-    form.addEventListener('submit', e => {
-      e.preventDefault();
-      const list = document.getElementById('files-' + form.dataset.id);
-      fetch('functions/upload_file.php', {
-        method: 'POST',
-        body: new FormData(form),
-        headers: jsonHeaders
-      }).then(r => r.json()).then(d => {
-        if (d.success && d.file) {
-          const li = document.createElement('li');
-          li.dataset.fileId = d.file.id;
-          li.className = 'd-flex justify-content-between';
-          li.innerHTML = `<a href=\"${escapeHtml(d.file.file_path)}\" target=\"_blank\">${escapeHtml(d.file.file_name)}</a><?php if (user_has_permission('corporate','delete')): ?> <button class=\"btn btn-sm btn-outline-danger delete-file\" data-id=\"${d.file.id}\">Delete</button><?php endif; ?>`;
-          list.prepend(li);
-          form.reset();
-        }
-      });
-    });
-  });
-
-  document.addEventListener('click', e => {
-    if (e.target.classList.contains('delete-note')) {
-      const id = e.target.dataset.id;
-      const li = e.target.closest('li');
+  document.getElementById('notesList').addEventListener('click', e => {
+    const li = e.target.closest('li');
+    if(!li) return;
+    if(e.target.classList.contains('delete-note')){
       const fd = new FormData();
-      fd.append('id', id);
-      fd.append('csrf_token', csrfToken);
-      fetch('functions/delete_note.php', {method:'POST', body:fd, headers: jsonHeaders})
-        .then(r=>r.json()).then(d=>{ if (d.success) { li.remove(); } });
-    } else if (e.target.classList.contains('delete-file')) {
-      const id = e.target.dataset.id;
-      const li = e.target.closest('li');
-      const fd = new FormData();
-      fd.append('id', id);
-      fd.append('csrf_token', csrfToken);
-      fetch('functions/delete_file.php', {method:'POST', body:fd, headers: jsonHeaders})
-        .then(r=>r.json()).then(d=>{ if (d.success) { li.remove(); } });
-    } else if (e.target.classList.contains('edit-note')) {
-      const id = e.target.dataset.id;
-      const li = e.target.closest('li');
+      fd.append('id', li.dataset.noteId);
+      fd.append('csrf_token', '<?= $token; ?>');
+      fetch('functions/delete_note.php',{method:'POST',body:fd})
+        .then(r=>r.json()).then(d=>{
+          if(d.success){ li.remove(); showFlash('Note deleted'); } else { showFlash(d.error || 'Error','danger'); }
+        }).catch(()=>showFlash('Server error','danger'));
+    } else if(e.target.classList.contains('edit-note')){
       const current = li.querySelector('span').textContent.trim();
-      const newText = prompt('Edit note', current);
-      if (newText !== null && newText !== current) {
+      const updated = prompt('Edit note', current);
+      if(updated !== null && updated !== current){
         const fd = new FormData();
-        fd.append('id', id);
-        fd.append('note_text', newText);
-        fd.append('csrf_token', csrfToken);
-        fetch('functions/edit_note.php', {method:'POST', body:fd, headers: jsonHeaders})
-          .then(r=>r.json()).then(d=>{ if (d.success) { li.querySelector('span').textContent = newText; } });
+        fd.append('id', li.dataset.noteId);
+        fd.append('note_text', updated);
+        fd.append('csrf_token', '<?= $token; ?>');
+        fetch('functions/edit_note.php',{method:'POST',body:fd})
+          .then(r=>r.json()).then(d=>{
+            if(d.success){ li.querySelector('span').textContent = updated; showFlash('Note updated'); } else { showFlash(d.error || 'Error','danger'); }
+          }).catch(()=>showFlash('Server error','danger'));
       }
+    }
+  });
+
+  const fileForm = document.getElementById('fileForm');
+  fileForm && fileForm.addEventListener('submit', e => {
+    e.preventDefault();
+    fetch('functions/upload_file.php',{method:'POST',body:new FormData(fileForm)})
+      .then(r=>r.json()).then(d=>{
+        if(d.success && d.file){
+          const li = document.createElement('li');
+          li.className='d-flex justify-content-between align-items-start mb-2';
+          li.dataset.fileId = d.file.id;
+          li.innerHTML = `<a href="${escapeHtml(d.file.file_path)}" target="_blank">${escapeHtml(d.file.file_name)}</a><?php if (user_has_permission('admin_corporate','delete')): ?> <button class="btn btn-sm btn-outline-danger delete-file">Delete</button><?php endif; ?>`;
+          document.getElementById('filesList').prepend(li);
+          fileForm.reset();
+          showFlash('File uploaded');
+        }else{
+          showFlash(d.error || 'Upload failed','danger');
+        }
+      }).catch(()=>showFlash('Server error','danger'));
+  });
+
+  document.getElementById('filesList').addEventListener('click', e => {
+    if(e.target.classList.contains('delete-file')){
+      const li = e.target.closest('li');
+      const fd = new FormData();
+      fd.append('id', li.dataset.fileId);
+      fd.append('csrf_token', '<?= $token; ?>');
+      fetch('functions/delete_file.php',{method:'POST',body:fd})
+        .then(r=>r.json()).then(d=>{
+          if(d.success){ li.remove(); showFlash('File deleted'); } else { showFlash(d.error || 'Error','danger'); }
+        }).catch(()=>showFlash('Server error','danger'));
     }
   });
 });


### PR DESCRIPTION
## Summary
- Add Phoenix-based Corporate Settings page with notes and file panels
- Implement AJAX handlers for updating settings, notes, and file uploads/deletes with permission checks

## Testing
- `php -l admin/corporate/index.php`
- `php -l admin/corporate/functions/update.php`
- `php -l admin/corporate/functions/add_note.php`
- `php -l admin/corporate/functions/edit_note.php`
- `php -l admin/corporate/functions/delete_note.php`
- `php -l admin/corporate/functions/upload_file.php`
- `php -l admin/corporate/functions/delete_file.php`


------
https://chatgpt.com/codex/tasks/task_e_68aeaaac756483338d985ffa3d1b7905