### PR TITLE
Expose meeting status and type in admin screens

### DIFF
--- a/admin/meetings/include/create_edit_view.php
+++ b/admin/meetings/include/create_edit_view.php
@@ -40,7 +40,7 @@ $token = generate_csrf_token();
         <select id="status_id" name="status_id" class="form-select">
           <option value="">Select status</option>
           <?php foreach ($meetingStatusList as $s): ?>
-            <option value="<?= (int)$s['id']; ?>" <?php echo (!empty($meeting['status_id']) && (int)$meeting['status_id'] === (int)$s['id']) ? 'selected' : ''; ?>><?= h($s['label']); ?></option>
+            <option value="<?= (int)$s['id']; ?>" <?php echo (isset($meeting['status_id']) && (int)$meeting['status_id'] === (int)$s['id']) ? 'selected' : ''; ?>><?= h($s['label']); ?></option>
           <?php endforeach; ?>
         </select>
       </div>
@@ -49,7 +49,7 @@ $token = generate_csrf_token();
         <select id="type_id" name="type_id" class="form-select">
           <option value="">Select type</option>
           <?php foreach ($meetingTypeList as $t): ?>
-            <option value="<?= (int)$t['id']; ?>" <?php echo (!empty($meeting['type_id']) && (int)$meeting['type_id'] === (int)$t['id']) ? 'selected' : ''; ?>><?= h($t['label']); ?></option>
+            <option value="<?= (int)$t['id']; ?>" <?php echo (isset($meeting['type_id']) && (int)$meeting['type_id'] === (int)$t['id']) ? 'selected' : ''; ?>><?= h($t['label']); ?></option>
           <?php endforeach; ?>
         </select>
       </div>

--- a/admin/meetings/include/details_view.php
+++ b/admin/meetings/include/details_view.php
@@ -2,8 +2,8 @@
 $agendaStatusMap  = array_column(get_lookup_items($pdo, 'MEETING_AGENDA_STATUS'), null, 'id');
 $meetingStatusMap = array_column(get_lookup_items($pdo, 'MEETING_STATUS'), null, 'id');
 $meetingTypeMap   = array_column(get_lookup_items($pdo, 'MEETING_TYPE'), null, 'id');
-$meetingStatusLabel = !empty($meeting['status_id']) && isset($meetingStatusMap[$meeting['status_id']]) ? $meetingStatusMap[$meeting['status_id']]['label'] : null;
-$meetingTypeLabel   = !empty($meeting['type_id']) && isset($meetingTypeMap[$meeting['type_id']]) ? $meetingTypeMap[$meeting['type_id']]['label'] : null;
+$meetingStatusLabel = isset($meeting['status_id'], $meetingStatusMap[$meeting['status_id']]) ? $meetingStatusMap[$meeting['status_id']]['label'] : null;
+$meetingTypeLabel   = isset($meeting['type_id'], $meetingTypeMap[$meeting['type_id']]) ? $meetingTypeMap[$meeting['type_id']]['label'] : null;
 $token = $_SESSION['csrf_token'] ?? bin2hex(random_bytes(32));
 $_SESSION['csrf_token'] = $token;
 ?>

--- a/admin/meetings/index.php
+++ b/admin/meetings/index.php
@@ -9,7 +9,7 @@ switch ($action) {
     $id = (int)($_GET['id'] ?? 0);
     $meeting = [];
     if ($id) {
-      $stmt = $pdo->prepare('SELECT id, title, description, start_time, end_time, recur_daily, recur_weekly, recur_monthly FROM module_meetings WHERE id = ?');
+      $stmt = $pdo->prepare('SELECT id, title, description, start_time, end_time, recur_daily, recur_weekly, recur_monthly, status_id, type_id FROM module_meetings WHERE id = ?');
       $stmt->execute([$id]);
       $meeting = $stmt->fetch(PDO::FETCH_ASSOC) ?: [];
     }
@@ -19,7 +19,7 @@ switch ($action) {
   case 'details':
     require_permission('meeting', 'read');
     $id = (int)($_GET['id'] ?? 0);
-    $stmt = $pdo->prepare('SELECT id, title, description, start_time, end_time, recur_daily, recur_weekly, recur_monthly FROM module_meetings WHERE id = ?');
+    $stmt = $pdo->prepare('SELECT id, title, description, start_time, end_time, recur_daily, recur_weekly, recur_monthly, status_id, type_id FROM module_meetings WHERE id = ?');
     $stmt->execute([$id]);
     $meeting = $stmt->fetch(PDO::FETCH_ASSOC) ?: [];
     require 'include/details_view.php';


### PR DESCRIPTION
## Summary
- Include status and type fields when loading meeting details for edit and detail views
- Preselect meeting status and type in the create/edit form
- Show badges for meeting status and type on the meeting detail page

## Testing
- `php -l admin/meetings/index.php`
- `php -l admin/meetings/include/create_edit_view.php`
- `php -l admin/meetings/include/details_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68aeadafdf948333992d1f92fc8b729f