### PR TITLE
Refactor conference option storage

### DIFF
--- a/module/conferences/functions/add_custom_field.php
+++ b/module/conferences/functions/add_custom_field.php
@@ -2,15 +2,15 @@
 require '../../../includes/php_header.php';
 require_permission('conference','update');
 
-$id = (int)($_POST['id'] ?? 0);
-$field = trim($_POST['field'] ?? '');
-$value = trim($_POST['value'] ?? '');
-if ($id && $field !== '') {
-  $stmt = $pdo->prepare('SELECT custom_fields FROM module_conferences WHERE id=?');
-  $stmt->execute([$id]);
-  $fields = $stmt->fetchColumn();
-  $fieldArr = $fields ? json_decode($fields, true) : [];
-  $fieldArr[$field] = $value;
-  $pdo->prepare('UPDATE module_conferences SET custom_fields=? WHERE id=?')->execute([json_encode($fieldArr),$id]);
+$conference_id = (int)($_POST['conference_id'] ?? 0);
+$name = trim($_POST['name'] ?? '');
+$field_type = trim($_POST['field_type'] ?? '');
+$field_options = trim($_POST['field_options'] ?? '');
+
+if ($conference_id && $name !== '' && $field_type !== '') {
+  $stmt = $pdo->prepare('INSERT INTO module_conference_custom_fields (user_id, conference_id, name, field_type, field_options) VALUES (?,?,?,?,?)');
+  $stmt->execute([$this_user_id, $conference_id, $name, $field_type, $field_options]);
+  echo json_encode(['success'=>true,'id'=>$pdo->lastInsertId()]);
+} else {
+  echo json_encode(['success'=>false]);
 }
-echo json_encode(['success'=>true]);

--- a/module/conferences/functions/add_ticket_option.php
+++ b/module/conferences/functions/add_ticket_option.php
@@ -2,14 +2,14 @@
 require '../../../includes/php_header.php';
 require_permission('conference','update');
 
-$id = (int)($_POST['id'] ?? 0);
-$option = trim($_POST['option'] ?? '');
-if ($id && $option !== '') {
-  $stmt = $pdo->prepare('SELECT ticket_options FROM module_conferences WHERE id=?');
-  $stmt->execute([$id]);
-  $opts = $stmt->fetchColumn();
-  $optArr = $opts ? json_decode($opts, true) : [];
-  $optArr[] = $option;
-  $pdo->prepare('UPDATE module_conferences SET ticket_options=? WHERE id=?')->execute([json_encode($optArr),$id]);
+$conference_id = (int)($_POST['conference_id'] ?? 0);
+$option_name = trim($_POST['option_name'] ?? '');
+$price = (float)($_POST['price'] ?? 0);
+
+if ($conference_id && $option_name !== '') {
+  $stmt = $pdo->prepare('INSERT INTO module_conference_ticket_options (user_id, conference_id, option_name, price) VALUES (?,?,?,?)');
+  $stmt->execute([$this_user_id, $conference_id, $option_name, $price]);
+  echo json_encode(['success'=>true,'id'=>$pdo->lastInsertId()]);
+} else {
+  echo json_encode(['success'=>false]);
 }
-echo json_encode(['success'=>true]);

--- a/module/conferences/functions/upload_image.php
+++ b/module/conferences/functions/upload_image.php
@@ -2,26 +2,23 @@
 require '../../../includes/php_header.php';
 require_permission('conference','update');
 
-$id = (int)($_POST['id'] ?? 0);
-if ($id && isset($_FILES['image'])) {
+$conference_id = (int)($_POST['conference_id'] ?? 0);
+if ($conference_id && isset($_FILES['image'])) {
   $uploadDir = '../uploads/';
   if (!is_dir($uploadDir)) { mkdir($uploadDir,0777,true); }
   $file = $_FILES['image'];
   if ($file['error'] === UPLOAD_ERR_OK) {
     $base = basename($file['name']);
     $safe = preg_replace('/[^A-Za-z0-9._-]/','_', $base);
-    $target = 'conf_' . $id . '_' . time() . '_' . $safe;
+    $target = 'conf_' . $conference_id . '_' . time() . '_' . $safe;
     $targetPath = $uploadDir . $target;
     if (move_uploaded_file($file['tmp_name'], $targetPath)) {
       $path = '/module/conferences/uploads/' . $target;
-      $stmt = $pdo->prepare('SELECT images FROM module_conferences WHERE id=?');
-      $stmt->execute([$id]);
-      $imgs = $stmt->fetchColumn();
-      $imgArr = $imgs ? json_decode($imgs, true) : [];
-      $imgArr[] = $path;
-      $pdo->prepare('UPDATE module_conferences SET images=? WHERE id=?')->execute([json_encode($imgArr),$id]);
+      $stmt = $pdo->prepare('INSERT INTO module_conference_images (user_id, conference_id, file_name, file_path, file_size, file_type) VALUES (?,?,?,?,?,?)');
+      $stmt->execute([$this_user_id, $conference_id, $base, $path, (int)$file['size'], $file['type']]);
+      echo json_encode(['success'=>true,'id'=>$pdo->lastInsertId(),'file_name'=>$base,'file_path'=>$path]);
+      exit;
     }
   }
 }
-header('Location: ../index.php?action=details&id=' . $id);
-exit;
+echo json_encode(['success'=>false]);

--- a/module/conferences/include/form.php
+++ b/module/conferences/include/form.php
@@ -1,4 +1,4 @@
-<form method="post" action="<?= $actionUrl ?>" enctype="multipart/form-data">
+<form method="post" action="<?= $actionUrl ?>">
   <?php if ($editing): ?>
     <input type="hidden" name="id" value="<?= (int)$conference['id'] ?>">
   <?php endif; ?>
@@ -44,15 +44,32 @@
   </div>
   <div class="mb-3">
     <label class="form-label">Ticket Options</label>
-    <textarea name="ticket_options" class="form-control" rows="2"><?= h($conference['ticket_options'] ?? '') ?></textarea>
+    <div class="input-group mb-2">
+      <input type="text" id="ticketOptionName" class="form-control" placeholder="Option name">
+      <input type="number" step="0.01" id="ticketOptionPrice" class="form-control" placeholder="Price">
+      <button class="btn btn-outline-secondary" type="button" id="addTicketOptionBtn">Add</button>
+    </div>
+    <ul id="ticketOptionsList" class="list-unstyled"></ul>
   </div>
   <div class="mb-3">
     <label class="form-label">Custom Fields</label>
-    <textarea name="custom_fields" class="form-control" rows="2"><?= h($conference['custom_fields'] ?? '') ?></textarea>
+    <div class="input-group mb-2">
+      <input type="text" id="fieldName" class="form-control" placeholder="Name">
+      <select id="fieldType" class="form-select">
+        <option value="text">Text</option>
+        <option value="number">Number</option>
+        <option value="select">Select</option>
+      </select>
+      <input type="text" id="fieldOptions" class="form-control" placeholder="Options">
+      <button class="btn btn-outline-secondary" type="button" id="addCustomFieldBtn">Add</button>
+    </div>
+    <ul id="customFieldsList" class="list-unstyled"></ul>
   </div>
   <div class="mb-3">
     <label class="form-label">Images</label>
-    <input type="file" name="images[]" class="form-control" multiple>
+    <input type="file" id="conferenceImage" class="form-control">
+    <button class="btn btn-outline-secondary mt-2" type="button" id="uploadImageBtn">Upload</button>
+    <ul id="imageList" class="list-unstyled mt-2"></ul>
   </div>
   <div class="form-check mb-3">
     <input class="form-check-input" type="checkbox" name="privacy" value="1" id="privacyCheck" <?= !empty($conference['privacy']) ? 'checked' : '' ?>>
@@ -60,3 +77,77 @@
   </div>
   <button class="btn btn-success" type="submit"><?= $editing ? 'Update' : 'Create' ?></button>
 </form>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  const confIdField = document.querySelector('input[name="id"]');
+
+  const ticketBtn = document.getElementById('addTicketOptionBtn');
+  if (ticketBtn) {
+    ticketBtn.addEventListener('click', function() {
+      const id = confIdField ? confIdField.value : '';
+      const name = document.getElementById('ticketOptionName').value.trim();
+      const price = document.getElementById('ticketOptionPrice').value.trim();
+      if (!id || !name) return;
+      fetch('functions/add_ticket_option.php', {
+        method: 'POST',
+        headers: {'Content-Type':'application/x-www-form-urlencoded'},
+        body: new URLSearchParams({conference_id:id, option_name:name, price:price})
+      }).then(r=>r.json()).then(res=>{
+        if(res.success){
+          const li = document.createElement('li');
+          li.textContent = name + (price ? ' ($'+price+')' : '');
+          document.getElementById('ticketOptionsList').appendChild(li);
+          document.getElementById('ticketOptionName').value='';
+          document.getElementById('ticketOptionPrice').value='';
+        }
+      });
+    });
+  }
+
+  const fieldBtn = document.getElementById('addCustomFieldBtn');
+  if (fieldBtn) {
+    fieldBtn.addEventListener('click', function() {
+      const id = confIdField ? confIdField.value : '';
+      const name = document.getElementById('fieldName').value.trim();
+      const type = document.getElementById('fieldType').value;
+      const opts = document.getElementById('fieldOptions').value.trim();
+      if (!id || !name) return;
+      fetch('functions/add_custom_field.php', {
+        method:'POST',
+        headers:{'Content-Type':'application/x-www-form-urlencoded'},
+        body:new URLSearchParams({conference_id:id, name:name, field_type:type, field_options:opts})
+      }).then(r=>r.json()).then(res=>{
+        if(res.success){
+          const li = document.createElement('li');
+          li.textContent = name + ' (' + type + ')';
+          document.getElementById('customFieldsList').appendChild(li);
+          document.getElementById('fieldName').value='';
+          document.getElementById('fieldOptions').value='';
+        }
+      });
+    });
+  }
+
+  const imageBtn = document.getElementById('uploadImageBtn');
+  if (imageBtn) {
+    imageBtn.addEventListener('click', function() {
+      const id = confIdField ? confIdField.value : '';
+      const file = document.getElementById('conferenceImage').files[0];
+      if (!id || !file) return;
+      const fd = new FormData();
+      fd.append('conference_id', id);
+      fd.append('image', file);
+      fetch('functions/upload_image.php', {method:'POST', body: fd})
+        .then(r=>r.json())
+        .then(res=>{
+          if(res.success){
+            const li = document.createElement('li');
+            li.textContent = res.file_name;
+            document.getElementById('imageList').appendChild(li);
+            document.getElementById('conferenceImage').value='';
+          }
+        });
+    });
+  }
+});
+</script>


### PR DESCRIPTION
## Summary
- Save conference ticket options in module_conference_ticket_options
- Add conference custom fields into module_conference_custom_fields
- Upload conference images into module_conference_images and wire up AJAX helpers

## Testing
- `php -l module/conferences/functions/add_ticket_option.php`
- `php -l module/conferences/functions/add_custom_field.php`
- `php -l module/conferences/functions/upload_image.php`
- `php -l module/conferences/include/form.php`


------
https://chatgpt.com/codex/tasks/task_e_68aeb181937083338c5efa97e6383ad5