### PR TITLE
Protect default and private calendars from deletion

### DIFF
--- a/module/calendar/functions/delete_calendar.php
+++ b/module/calendar/functions/delete_calendar.php
@@ -6,7 +6,7 @@ header('Content-Type: application/json');
 $id = (int)($_POST['id'] ?? 0);
 
 if ($id) {
-  $chk = $pdo->prepare('SELECT user_id, is_default FROM module_calendar WHERE id = ?');
+  $chk = $pdo->prepare('SELECT user_id, is_default, is_private FROM module_calendar WHERE id = ?');
   $chk->execute([$id]);
 
   $existing = $chk->fetch(PDO::FETCH_ASSOC);
@@ -20,11 +20,14 @@ if ($id) {
     http_response_code(403);
     exit;
   }
-  if (!empty($existing['is_default'])) {
-    echo json_encode(['success' => false, 'error' => 'Cannot delete default calendar']);
+  if (!empty($existing['is_default']) || !empty($existing['is_private'])) {
+    $error = !empty($existing['is_default'])
+      ? 'Cannot delete default calendar'
+      : 'Cannot delete private calendar';
+    echo json_encode(['success' => false, 'error' => $error]);
     exit;
   }
-  $stmt = $pdo->prepare('DELETE FROM module_calendar WHERE id = ?');
+  $stmt = $pdo->prepare('DELETE FROM module_calendar WHERE id = ? AND is_default = 0 AND is_private = 0');
   $stmt->execute([$id]);
   echo json_encode(['success' => true]);
   exit;

--- a/module/calendar/include/calendar_view.php
+++ b/module/calendar/include/calendar_view.php
@@ -367,5 +367,29 @@ document.addEventListener('DOMContentLoaded', function() {
       alert('Failed to update event: ' + err.message);
     });
   });
+
+  window.deleteCalendar = function(id) {
+    const fd = new FormData();
+    fd.append('id', id);
+    fetch('<?php echo getURLDir(); ?>module/calendar/functions/delete_calendar.php', {
+      method: 'POST',
+      body: fd
+    })
+    .then(r => {
+      if (!r.ok) throw new Error('HTTP ' + r.status);
+      return r.json();
+    })
+    .then(data => {
+      if (data.success) {
+        calendar.refetchEvents();
+      } else {
+        alert(data.error || 'Unable to delete calendar.');
+      }
+    })
+    .catch(err => {
+      console.error('Failed to delete calendar', err);
+      alert('Failed to delete calendar: ' + err.message);
+    });
+  };
 });
 </script>


### PR DESCRIPTION
## Summary
- Prevent deletion of calendars that are default or marked private
- Surface deletion failures to the UI with a new helper that displays server errors

## Testing
- `php -l module/calendar/functions/delete_calendar.php`
- `php -l module/calendar/include/calendar_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68afb4fd3abc8333953429764031b8a5