### PR TITLE
Filter calendars via checkboxes when loading events

### DIFF
--- a/module/calendar/include/calendar_view.php
+++ b/module/calendar/include/calendar_view.php
@@ -16,6 +16,14 @@ $default_add_calendar_id = in_array($selected_calendar_id, $owned_calendar_ids, 
     ? $selected_calendar_id
     : ($user_default_calendar_id ?: ($owned_calendar_ids[0] ?? 0));
 
+$user_public_calendar_id = 0;
+foreach ($owned_calendars as $cal) {
+    if ((int)$cal['is_private'] === 0) {
+        $user_public_calendar_id = (int)$cal['id'];
+        break;
+    }
+}
+
 $event_types = get_lookup_items($pdo, 37);
 
 $default_event_type_id = $event_types[0]['id'] ?? 0;
@@ -27,18 +35,15 @@ $default_event_type_id = $event_types[0]['id'] ?? 0;
   </div>
   <div class="col-7 col-md-6 d-flex justify-content-end align-items-center">
     <?php if (!empty($calendars)) { ?>
-      <div class="form-floating form-floating-advance-select me-2">
-        <label for="calendarSelect">Calendars Displayed</label>
-        <select id="calendarSelect"
-                class="form-select"
-                multiple
-                data-choices="data-choices"
-                data-options='{"removeItemButton":true}'>
-          <?php foreach ($calendars as $cal) { ?>
-            <?php $cal_label = $cal['name'] . (!empty($cal['is_private']) ? ' (Private)' : ''); ?>
-            <option value="<?php echo $cal['id']; ?>" selected><?php echo e($cal_label); ?></option>
-          <?php } ?>
-        </select>
+      <div id="calendarSelect" class="me-2">
+        <span class="form-label d-block mb-1">Calendars Displayed</span>
+        <?php foreach ($calendars as $cal) { ?>
+          <?php $cal_label = $cal['name'] . (!empty($cal['is_private']) ? ' (Private)' : ''); ?>
+          <div class="form-check form-check-inline">
+            <input class="form-check-input calendar-check" type="checkbox" id="calendarCheck<?php echo (int)$cal['id']; ?>" value="<?php echo (int)$cal['id']; ?>" checked>
+            <label class="form-check-label" for="calendarCheck<?php echo (int)$cal['id']; ?>"><?php echo e($cal_label); ?></label>
+          </div>
+        <?php } ?>
       </div>
     <?php } ?>
     <?php if ($owns_calendar && user_has_permission('calendar','create')) { ?>
@@ -185,6 +190,7 @@ document.addEventListener('DOMContentLoaded', function() {
   const defaultAddCalendarId = <?php echo (int)$default_add_calendar_id; ?>;
   const defaultEventTypeId = <?php echo (int)$default_event_type_id; ?>;
   const ownedCalendarIds = <?php echo json_encode(array_values(array_map('intval', $owned_calendar_ids))); ?>;
+  const userPublicCalendarId = <?php echo (int)$user_public_calendar_id; ?>;
 
   const calendarEl = document.getElementById('calendar');
   const addEventForm = document.getElementById('addEventForm');
@@ -204,14 +210,20 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   function getCalendarIds() {
+    const boxes = document.querySelectorAll('#calendarSelect input[type="checkbox"]:checked');
+    if (boxes.length) {
+      return Array.from(boxes).map(b => b.value);
+    }
     const sel = document.getElementById('calendarSelect');
-    if (!sel) return [];
-    return Array.from(sel.selectedOptions).map(opt => opt.value);
+    if (sel && sel.tagName === 'SELECT') {
+      return Array.from(sel.selectedOptions).map(opt => opt.value);
+    }
+    return [];
   }
 
   function getCalendarId() {
     const ids = getCalendarIds();
-    const cid = ids.length ? ids[0] : defaultCalendarId;
+    const cid = ids.length ? ids[0] : userPublicCalendarId;
     return ownedCalendarIds.includes(parseInt(cid, 10)) ? cid : defaultAddCalendarId;
   }
 
@@ -235,7 +247,8 @@ document.addEventListener('DOMContentLoaded', function() {
 
     events: function(fetchInfo, successCallback, failureCallback) {
       const ids = getCalendarIds();
-      const url = ids.length ? `${listUrl}?calendar_ids=${ids.join(',')}` : listUrl;
+      const fetchIds = ids.length ? ids : [userPublicCalendarId];
+      const url = `${listUrl}?calendar_ids=${fetchIds.join(',')}`;
       fetch(url)
         .then(r => {
           if (!r.ok) throw new Error('HTTP ' + r.status);
@@ -285,8 +298,10 @@ document.addEventListener('DOMContentLoaded', function() {
 
   const calSelect = document.getElementById('calendarSelect');
   if (calSelect) {
-    calSelect.addEventListener('change', function() {
-      calendar.refetchEvents();
+    calSelect.addEventListener('change', function(e) {
+      if (e.target && e.target.matches('input[type="checkbox"]')) {
+        calendar.refetchEvents();
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- Collect calendar IDs from checked boxes and always send them to event list API
- Fall back to the current user's public calendar when none are checked

## Testing
- `php -l module/calendar/include/calendar_view.php`
- `php -l module/calendar/functions/list.php`


------
https://chatgpt.com/codex/tasks/task_e_68afb4fc7b1483338c9d74b6e99182e9