### PR TITLE
Add sidebar calendar filters

### DIFF
--- a/module/calendar/functions/list_calendars.php
+++ b/module/calendar/functions/list_calendars.php
@@ -1,0 +1,12 @@
+<?php
+require '../../../includes/php_header.php';
+header('Content-Type: application/json');
+
+try {
+    $stmt = $pdo->query('SELECT id, name FROM module_calendar WHERE is_private = 0 ORDER BY name');
+    $cals = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    echo json_encode($cals);
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}


### PR DESCRIPTION
## Summary
- Wrap calendar view in a two-column layout with a sidebar for calendar filters
- Load public calendars into sidebar checkboxes from new list_calendars endpoint
- Remove dropdown calendar selector and refactor JS to use checkbox filters

## Testing
- `php -l module/calendar/include/calendar_view.php`
- `php -l module/calendar/functions/list_calendars.php`

------
https://chatgpt.com/codex/tasks/task_e_68afb4fb3f3883339def84859a788c3b