### PR TITLE
Add calendar listing endpoint for public calendars

### DIFF
--- a/module/calendar/functions/list_calendars.php
+++ b/module/calendar/functions/list_calendars.php
@@ -1,0 +1,24 @@
+<?php
+require '../../../includes/php_header.php';
+require_permission('calendar','read');
+
+header('Content-Type: application/json');
+
+try {
+    $stmt = $pdo->query(
+        "SELECT c.id, c.name, COALESCE(CONCAT(p.first_name, ' ', p.last_name), u.email) AS owner " .
+        "FROM module_calendar c " .
+        "LEFT JOIN users u ON c.user_id = u.id " .
+        "LEFT JOIN person p ON u.id = p.user_id " .
+        "WHERE c.is_private = 0 " .
+        "ORDER BY c.name"
+    );
+    $calendars = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    echo json_encode($calendars);
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}
+
+exit;
+


### PR DESCRIPTION
## Summary
- add `module/calendar/functions/list_calendars.php` endpoint to return public calendars
- protect endpoint with `require_permission('calendar','read')`
- sort calendars alphabetically and include owner display name

## Testing
- `php -l module/calendar/functions/list_calendars.php`


------
https://chatgpt.com/codex/tasks/task_e_68afb4fa78dc8333a18c4ada85f83afa