### PR TITLE
Add calendar event reference to meetings

### DIFF
--- a/_SQL/2025XX_meetings_calendar_event.sql
+++ b/_SQL/2025XX_meetings_calendar_event.sql
@@ -1,0 +1,2 @@
+ALTER TABLE module_meetings ADD COLUMN calendar_event_id INT(11) NULL AFTER recur_monthly;
+ALTER TABLE module_meetings ADD CONSTRAINT fk_meetings_calendar_event FOREIGN KEY (calendar_event_id) REFERENCES module_calendar_events(id) ON DELETE SET NULL;


### PR DESCRIPTION
## Summary
- link meetings to calendar events by adding calendar_event_id column and foreign key

## Testing
- `mysql --version` (fails: command not found)

------
https://chatgpt.com/codex/tasks/task_e_68afbc8285b88333b5078b0d5542353e