### PR TITLE
Link meetings with calendar events

### DIFF
--- a/admin/meetings/functions/create.php
+++ b/admin/meetings/functions/create.php
@@ -17,6 +17,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   $recur_monthly = !empty($_POST['recur_monthly']) ? 1 : 0;
   $meeting_status_id = isset($_POST['status_id']) && $_POST['status_id'] !== '' ? (int)$_POST['status_id'] : null;
   $meeting_type_id   = isset($_POST['type_id']) && $_POST['type_id'] !== '' ? (int)$_POST['type_id'] : null;
+  $calendar_event_id = isset($_POST['calendar_event_id']) && $_POST['calendar_event_id'] !== '' ? (int)$_POST['calendar_event_id'] : null;
 
   $errors = [];
   if ($title === '') {
@@ -42,8 +43,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
       $start_time = $start_dt ? $start_dt->format('Y-m-d H:i:s') : null;
       $end_time = $end_dt ? $end_dt->format('Y-m-d H:i:s') : null;
 
-      $stmt = $pdo->prepare('INSERT INTO module_meetings (user_id, user_updated, title, description, start_time, end_time, recur_daily, recur_weekly, recur_monthly, status_id, type_id) VALUES (?,?,?,?,?,?,?,?,?,?,?)');
-      $stmt->execute([$this_user_id, $this_user_id, $title, $description, $start_time, $end_time, $recur_daily, $recur_weekly, $recur_monthly, $meeting_status_id, $meeting_type_id]);
+      $stmt = $pdo->prepare('INSERT INTO module_meetings (user_id, user_updated, title, description, start_time, end_time, recur_daily, recur_weekly, recur_monthly, calendar_event_id, status_id, type_id) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)');
+      $stmt->execute([$this_user_id, $this_user_id, $title, $description, $start_time, $end_time, $recur_daily, $recur_weekly, $recur_monthly, $calendar_event_id, $meeting_status_id, $meeting_type_id]);
       $id = $pdo->lastInsertId();
       admin_audit_log($pdo, $this_user_id, 'module_meeting', $id, 'CREATE', '', json_encode(['title'=>$title]), 'Created meeting');
 

--- a/admin/meetings/functions/update.php
+++ b/admin/meetings/functions/update.php
@@ -18,6 +18,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   $recur_monthly = !empty($_POST['recur_monthly']) ? 1 : 0;
   $meeting_status_id = isset($_POST['status_id']) && $_POST['status_id'] !== '' ? (int)$_POST['status_id'] : null;
   $meeting_type_id   = isset($_POST['type_id']) && $_POST['type_id'] !== '' ? (int)$_POST['type_id'] : null;
+  $calendar_event_id = isset($_POST['calendar_event_id']) && $_POST['calendar_event_id'] !== '' ? (int)$_POST['calendar_event_id'] : null;
 
   $errors = [];
   if ($title === '') {
@@ -42,8 +43,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
       $pdo->beginTransaction();
       $start_time = $start_dt ? $start_dt->format('Y-m-d H:i:s') : null;
       $end_time = $end_dt ? $end_dt->format('Y-m-d H:i:s') : null;
-      $stmt = $pdo->prepare('UPDATE module_meetings SET user_updated=?, title=?, description=?, start_time=?, end_time=?, recur_daily=?, recur_weekly=?, recur_monthly=?, status_id=?, type_id=? WHERE id=?');
-      $stmt->execute([$this_user_id, $title, $description, $start_time, $end_time, $recur_daily, $recur_weekly, $recur_monthly, $meeting_status_id, $meeting_type_id, $id]);
+      $stmt = $pdo->prepare('UPDATE module_meetings SET user_updated=?, title=?, description=?, start_time=?, end_time=?, recur_daily=?, recur_weekly=?, recur_monthly=?, calendar_event_id=?, status_id=?, type_id=? WHERE id=?');
+      $stmt->execute([$this_user_id, $title, $description, $start_time, $end_time, $recur_daily, $recur_weekly, $recur_monthly, $calendar_event_id, $meeting_status_id, $meeting_type_id, $id]);
       admin_audit_log($pdo, $this_user_id, 'module_meeting', $id, 'UPDATE', '', json_encode(['title'=>$title]), 'Updated meeting');
 
       // Remove existing child records before inserting new data

--- a/admin/meetings/index.php
+++ b/admin/meetings/index.php
@@ -9,7 +9,7 @@ switch ($action) {
     $id = (int)($_GET['id'] ?? 0);
     $meeting = [];
     if ($id) {
-      $stmt = $pdo->prepare('SELECT id, title, description, start_time, end_time, recur_daily, recur_weekly, recur_monthly, status_id, type_id FROM module_meetings WHERE id = ?');
+      $stmt = $pdo->prepare('SELECT m.id, m.title, m.description, m.start_time, m.end_time, m.recur_daily, m.recur_weekly, m.recur_monthly, m.calendar_event_id, ce.title AS calendar_event_title, m.status_id, m.type_id FROM module_meetings m LEFT JOIN module_calendar_events ce ON m.calendar_event_id = ce.id WHERE m.id = ?');
       $stmt->execute([$id]);
       $meeting = $stmt->fetch(PDO::FETCH_ASSOC) ?: [];
     }
@@ -19,7 +19,7 @@ switch ($action) {
   case 'details':
     require_permission('meeting', 'read');
     $id = (int)($_GET['id'] ?? 0);
-    $stmt = $pdo->prepare('SELECT id, title, description, start_time, end_time, recur_daily, recur_weekly, recur_monthly, status_id, type_id FROM module_meetings WHERE id = ?');
+    $stmt = $pdo->prepare('SELECT m.id, m.title, m.description, m.start_time, m.end_time, m.recur_daily, m.recur_weekly, m.recur_monthly, m.calendar_event_id, ce.title AS calendar_event_title, m.status_id, m.type_id FROM module_meetings m LEFT JOIN module_calendar_events ce ON m.calendar_event_id = ce.id WHERE m.id = ?');
     $stmt->execute([$id]);
     $meeting = $stmt->fetch(PDO::FETCH_ASSOC) ?: [];
     require 'include/details_view.php';


### PR DESCRIPTION
## Summary
- Accept optional `calendar_event_id` when creating or updating meetings
- Persist the calendar reference in meeting insert and update statements
- Retrieve linked calendar event details when editing or viewing meeting details

## Testing
- `php -l admin/meetings/functions/create.php`
- `php -l admin/meetings/functions/update.php`
- `php -l admin/meetings/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68afbc8364b08333935c774796477e9b