### PR TITLE
Link meetings to calendar events

### DIFF
--- a/admin/meetings/functions/search_events.php
+++ b/admin/meetings/functions/search_events.php
@@ -1,0 +1,21 @@
+<?php
+require '../../../includes/php_header.php';
+require_permission('calendar', 'read');
+
+header('Content-Type: application/json');
+
+$q = trim($_GET['q'] ?? '');
+if ($q === '') {
+    echo json_encode([]);
+    exit;
+}
+
+if (user_has_role('Admin')) {
+    $stmt = $pdo->prepare('SELECT e.id, e.title, e.start_time FROM module_calendar_events e JOIN module_calendar c ON e.calendar_id = c.id WHERE e.title LIKE :q ORDER BY e.start_time DESC LIMIT 10');
+    $stmt->execute([':q' => "%" . $q . "%"]);
+} else {
+    $stmt = $pdo->prepare('SELECT e.id, e.title, e.start_time FROM module_calendar_events e JOIN module_calendar c ON e.calendar_id = c.id WHERE (e.visibility_id = 198 OR e.user_id = :uid) AND (c.is_private = 0 OR c.user_id = :uid) AND e.title LIKE :q ORDER BY e.start_time DESC LIMIT 10');
+    $stmt->execute([':uid' => $this_user_id, ':q' => "%" . $q . "%"]);
+}
+
+echo json_encode($stmt->fetchAll(PDO::FETCH_ASSOC));

--- a/admin/meetings/include/create_edit_view.php
+++ b/admin/meetings/include/create_edit_view.php
@@ -57,6 +57,13 @@ $token = generate_csrf_token();
         </select>
       </div>
     </div>
+    <div class="row mb-3">
+      <div class="col-md-6">
+        <label class="form-label" for="calendar_event_search">Event</label>
+        <input type="text" id="calendar_event_search" class="form-control" placeholder="Search event">
+        <input type="hidden" name="calendar_event_id" id="calendar_event_id" value="<?php echo h($meeting['calendar_event_id'] ?? ''); ?>">
+      </div>
+    </div>
     <div class="mb-3">
       <label class="form-label">Recurrence</label>
       <div class="form-check form-check-inline">
@@ -103,6 +110,12 @@ document.addEventListener('DOMContentLoaded', function(){
   var questionStatusMap = <?php echo json_encode($questionStatusMap); ?>;
   var agendaList = document.getElementById('agendaList');
   var attendeesContainer = document.getElementById('attendeesContainer');
+  var eventSearchInput = document.getElementById('calendar_event_search');
+  var eventIdInput = document.getElementById('calendar_event_id');
+  if(eventSearchInput && eventIdInput){
+    initTypeahead(eventSearchInput, eventIdInput, 'functions/search_events.php');
+  }
+
 
   function showToast(msg, type = 'danger'){
     var container = document.getElementById('toastContainer');


### PR DESCRIPTION
## Summary
- allow meetings to link to calendar events with a typeahead search
- add event search endpoint with visibility filtering

## Testing
- `php -l admin/meetings/include/create_edit_view.php`
- `php -l admin/meetings/functions/search_events.php`


------
https://chatgpt.com/codex/tasks/task_e_68afbc84388c8333bd7fc1f4033a1db5