### PR TITLE
Add calendar event link to meeting details

### DIFF
--- a/admin/meetings/include/details_view.php
+++ b/admin/meetings/include/details_view.php
@@ -31,6 +31,9 @@ $_SESSION['csrf_token'] = $token;
       <?php if (!empty($meeting['end_time'])): ?>
       <p class="mb-0"><strong>End:</strong> <?php echo h(date('l, F j, Y g:i A', strtotime($meeting['end_time']))); ?></p>
       <?php endif; ?>
+      <?php if (!empty($meeting['calendar_event_id'])): ?>
+      <p class="mb-0"><a href="../calendar/index.php?action=details&id=<?= (int)$meeting['calendar_event_id']; ?>">View Calendar Event: <?= h($meeting['calendar_event_title']); ?></a></p>
+      <?php endif; ?>
       <p class="mb-0"><strong>Recurs:</strong> <?php
         $recur = [];
         if (!empty($meeting['recur_daily'])) $recur[] = 'Daily';


### PR DESCRIPTION
## Summary
- Display calendar event link in meeting details when a related calendar event exists.

## Testing
- `php -l admin/meetings/include/details_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68afbc84fea88333a719c448d0cf85b4