### PR TITLE
Link strategy key results to tasks and projects

### DIFF
--- a/_SQL/MIGRATION/20250516_strategy_key_results_linking.sql
+++ b/_SQL/MIGRATION/20250516_strategy_key_results_linking.sql
@@ -1,0 +1,9 @@
+ALTER TABLE module_strategy_key_results
+  ADD COLUMN task_id INT(11) DEFAULT NULL,
+  ADD COLUMN project_id INT(11) DEFAULT NULL,
+  ADD CONSTRAINT fk_mskr_task
+    FOREIGN KEY (task_id) REFERENCES module_tasks(id)
+    ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT fk_mskr_project
+    FOREIGN KEY (project_id) REFERENCES module_projects(id)
+    ON DELETE SET NULL ON UPDATE CASCADE;

--- a/functions/link_key_result.php
+++ b/functions/link_key_result.php
@@ -1,0 +1,33 @@
+<?php
+require '../includes/php_header.php';
+require_permission('admin_business_strategy','update');
+header('Content-Type: application/json');
+
+$id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+$taskId = isset($_POST['task_id']) && $_POST['task_id'] !== '' ? (int)$_POST['task_id'] : null;
+$projectId = isset($_POST['project_id']) && $_POST['project_id'] !== '' ? (int)$_POST['project_id'] : null;
+
+if (!$id || ($taskId === null && $projectId === null)) {
+    echo json_encode(['success' => false]);
+    exit;
+}
+
+if ($taskId !== null && !user_has_permission('task', 'read')) {
+    http_response_code(403);
+    echo json_encode(['success' => false]);
+    exit;
+}
+if ($projectId !== null && !user_has_permission('project', 'read')) {
+    http_response_code(403);
+    echo json_encode(['success' => false]);
+    exit;
+}
+
+$stmt = $pdo->prepare('UPDATE module_strategy_key_results SET task_id = :tid, project_id = :pid, user_updated = :uid WHERE id = :id');
+$stmt->bindValue(':tid', $taskId, $taskId !== null ? PDO::PARAM_INT : PDO::PARAM_NULL);
+$stmt->bindValue(':pid', $projectId, $projectId !== null ? PDO::PARAM_INT : PDO::PARAM_NULL);
+$stmt->bindValue(':uid', $this_user_id, PDO::PARAM_INT);
+$stmt->bindValue(':id', $id, PDO::PARAM_INT);
+$success = $stmt->execute();
+
+echo json_encode(['success' => $success]);

--- a/functions/unlink_key_result.php
+++ b/functions/unlink_key_result.php
@@ -1,0 +1,30 @@
+<?php
+require '../includes/php_header.php';
+require_permission('admin_business_strategy','update');
+header('Content-Type: application/json');
+
+$id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+if (!$id) {
+    echo json_encode(['success' => false]);
+    exit;
+}
+
+$target = $_POST['target'] ?? '';
+if ($target === 'task' && !user_has_permission('task','read')) {
+    http_response_code(403);
+    echo json_encode(['success' => false]);
+    exit;
+}
+if ($target === 'project' && !user_has_permission('project','read')) {
+    http_response_code(403);
+    echo json_encode(['success' => false]);
+    exit;
+}
+
+$fieldSql = $target === 'project' ? 'project_id' : 'task_id';
+$stmt = $pdo->prepare("UPDATE module_strategy_key_results SET $fieldSql = NULL, user_updated = :uid WHERE id = :id");
+$stmt->bindValue(':uid', $this_user_id, PDO::PARAM_INT);
+$stmt->bindValue(':id', $id, PDO::PARAM_INT);
+$success = $stmt->execute();
+
+echo json_encode(['success' => $success]);

--- a/module/project/include/details_view.php
+++ b/module/project/include/details_view.php
@@ -284,6 +284,34 @@ if (!empty($current_project)) {
       </div>
     <?php endif; ?>
 
+    <?php if (user_has_permission('admin_business_strategy','update') && user_has_permission('project','read')): ?>
+      <?php
+        $krStmt = $pdo->prepare('SELECT id, name, progress_percent FROM module_strategy_key_results WHERE project_id = :pid');
+        $krStmt->execute([':pid' => $current_project['id']]);
+        $projectKeyResults = $krStmt->fetchAll(PDO::FETCH_ASSOC);
+      ?>
+      <div class="mb-5">
+        <h3 class="text-body-emphasis mb-3">Key Results</h3>
+        <?php if ($projectKeyResults): ?>
+          <ul class="list-group">
+            <?php foreach ($projectKeyResults as $kr): ?>
+              <li class="list-group-item">
+                <div class="d-flex justify-content-between align-items-center">
+                  <span><?= h($kr['name']); ?></span>
+                  <span class="fs-9"><?= (int)($kr['progress_percent'] ?? 0); ?>%</span>
+                </div>
+                <div class="progress mt-2" style="height:4px;">
+                  <div class="progress-bar bg-success" style="width: <?= (int)($kr['progress_percent'] ?? 0); ?>%"></div>
+                </div>
+              </li>
+            <?php endforeach; ?>
+          </ul>
+        <?php else: ?>
+          <p class="text-body-secondary mb-0">No key results linked.</p>
+        <?php endif; ?>
+      </div>
+    <?php endif; ?>
+
     <div class="row">
       <div class="col-6 bg-light border-start border-top border-bottom">
         <div class="p-4" id="taskList" data-list='{"valueNames":["task-name","task-status","task-priority","task-due"],"page":25,"pagination":true}'>

--- a/module/task/include/details_view.php
+++ b/module/task/include/details_view.php
@@ -182,6 +182,31 @@ require_once __DIR__ . '/../../../includes/functions.php';
         <?php else: ?>
           <p class="fs-9 text-body-secondary mb-4">No team members assigned.</p>
         <?php endif; ?>
+        <?php if (user_has_permission('admin_business_strategy','update') && user_has_permission('task','read')): ?>
+          <?php
+            $krStmt = $pdo->prepare('SELECT id, name, progress_percent FROM module_strategy_key_results WHERE task_id = :tid');
+            $krStmt->execute([':tid' => $current_task['id']]);
+            $taskKeyResults = $krStmt->fetchAll(PDO::FETCH_ASSOC);
+          ?>
+          <h5 class="fw-bold mb-2">Key Results</h5>
+          <?php if ($taskKeyResults): ?>
+            <ul class="list-unstyled mb-4">
+              <?php foreach ($taskKeyResults as $kr): ?>
+                <li class="mb-3">
+                  <div class="d-flex justify-content-between mb-1">
+                    <span><?= h($kr['name']); ?></span>
+                    <span class="fs-9"><?= (int)($kr['progress_percent'] ?? 0); ?>%</span>
+                  </div>
+                  <div class="progress" style="height:4px;">
+                    <div class="progress-bar bg-success" role="progressbar" style="width: <?= (int)($kr['progress_percent'] ?? 0); ?>%"></div>
+                  </div>
+                </li>
+              <?php endforeach; ?>
+            </ul>
+          <?php else: ?>
+            <p class="fs-9 text-body-secondary mb-4">No key results linked.</p>
+          <?php endif; ?>
+        <?php endif; ?>
         <div class="modal fade" id="assignUserModal" tabindex="-1" aria-hidden="true">
           <div class="modal-dialog">
             <form class="modal-content" method="post" action="functions/assign_user.php">


### PR DESCRIPTION
## Summary
- allow key results to optionally reference tasks or projects via new foreign keys
- expose related strategy key results and progress on task and project detail views
- provide endpoints for linking and unlinking key results

## Testing
- `php -l functions/link_key_result.php`
- `php -l functions/unlink_key_result.php`
- `php -l module/task/include/details_view.php`
- `php -l module/project/include/details_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68afc4c1637c833395c6720049959256