### PR TITLE
Add Add Event button to calendar toolbar

### DIFF
--- a/module/calendar/include/calendar_view.php
+++ b/module/calendar/include/calendar_view.php
@@ -29,6 +29,9 @@ $event_types = get_lookup_items($pdo, 37);
 $default_event_type_id = $event_types[0]['id'] ?? 0;
 
 ?>
+<div class="d-flex justify-content-end mb-3">
+  <button class="btn btn-primary" type="button" id="openAddEvent" <?= $owns_calendar ? '' : 'disabled data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="Create a calendar to add events"'; ?>>Add Event</button>
+</div>
 <div class="row">
   <div class="col-md-3">
     <div id="calendarSidebar"></div>
@@ -175,10 +178,15 @@ document.addEventListener('DOMContentLoaded', function() {
   const calendarEl = document.getElementById('calendar');
   const addEventForm = document.getElementById('addEventForm');
   const addEventModalEl = document.getElementById('addEventModal');
+  const openAddEventBtn = document.getElementById('openAddEvent');
   const listUrl = '<?php echo getURLDir(); ?>module/calendar/functions/list.php';
   const listCalendarsUrl = '<?php echo getURLDir(); ?>module/calendar/functions/list_calendars.php';
   const VISIBILITY_PUBLIC = 198;
   const VISIBILITY_PRIVATE = 199;
+
+  if (openAddEventBtn && openAddEventBtn.disabled) {
+    bootstrap.Tooltip.getOrCreateInstance(openAddEventBtn);
+  }
 
   function isEventPrivate(props) {
     if ('visibility_id' in props) {
@@ -346,6 +354,8 @@ document.addEventListener('DOMContentLoaded', function() {
       });
     });
   }
+
+  document.getElementById('openAddEvent').addEventListener('click', () => { selectCalendarRadio(addEventForm, getCalendarId()); bootstrap.Modal.getOrCreateInstance(document.getElementById('addEventModal')).show(); });
 
   document.getElementById('editEventForm').addEventListener('submit', function(e) {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- Add "Add Event" button to calendar toolbar, disabled with tooltip when no owned calendars
- Initialize tooltip and hook button to show existing Add Event modal

## Testing
- `php -l module/calendar/include/calendar_view.php`
- `php module/calendar/tests/create_unauthorized_403_test.php`


------
https://chatgpt.com/codex/tasks/task_e_68afcc73c9788333b3450237fc13910c