### PR TITLE
Use admin_strategy permission for key result links

### DIFF
--- a/_SQL/2024_11_24_add_key_result_links.sql
+++ b/_SQL/2024_11_24_add_key_result_links.sql
@@ -1,0 +1,11 @@
+ALTER TABLE `module_strategy_key_results`
+  ADD COLUMN `task_id` INT(11) NULL AFTER `sort_order`,
+  ADD COLUMN `project_id` INT(11) NULL AFTER `task_id`;
+
+ALTER TABLE `module_strategy_key_results`
+  ADD KEY `fk_mskr_task` (`task_id`),
+  ADD KEY `fk_mskr_project` (`project_id`);
+
+ALTER TABLE `module_strategy_key_results`
+  ADD CONSTRAINT `fk_mskr_task` FOREIGN KEY (`task_id`) REFERENCES `module_tasks` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT `fk_mskr_project` FOREIGN KEY (`project_id`) REFERENCES `module_projects` (`id`) ON DELETE SET NULL ON UPDATE CASCADE;

--- a/admin/corporate/business-strategy/functions/create.php
+++ b/admin/corporate/business-strategy/functions/create.php
@@ -1,6 +1,6 @@
 <?php
 if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
-require_permission('admin_business_strategy', 'create');
+require_permission('admin_strategy', 'create');
 header('Content-Type: application/json');
 echo json_encode(['success' => false, 'error' => 'Not implemented']);

--- a/admin/corporate/business-strategy/functions/delete.php
+++ b/admin/corporate/business-strategy/functions/delete.php
@@ -1,6 +1,6 @@
 <?php
 if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
-require_permission('admin_business_strategy', 'delete');
+require_permission('admin_strategy', 'delete');
 header('Content-Type: application/json');
 echo json_encode(['success' => false, 'error' => 'Not implemented']);

--- a/admin/corporate/business-strategy/functions/read.php
+++ b/admin/corporate/business-strategy/functions/read.php
@@ -1,6 +1,6 @@
 <?php
 if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
-require_permission('admin_business_strategy', 'read');
+require_permission('admin_strategy', 'read');
 header('Content-Type: application/json');
 echo json_encode(['success' => false, 'error' => 'Not implemented']);

--- a/admin/corporate/business-strategy/functions/update.php
+++ b/admin/corporate/business-strategy/functions/update.php
@@ -1,6 +1,6 @@
 <?php
 if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
-require_permission('admin_business_strategy', 'update');
+require_permission('admin_strategy', 'update');
 header('Content-Type: application/json');
 echo json_encode(['success' => false, 'error' => 'Not implemented']);

--- a/admin/corporate/business-strategy/index.php
+++ b/admin/corporate/business-strategy/index.php
@@ -1,6 +1,6 @@
 <?php
 require '../../admin_header.php';
-require_permission('admin_business_strategy','read');
+require_permission('admin_strategy','read');
 ?>
 <h2>Placeholder for business-strategy</h2>
 <?php require '../../admin_footer.php'; ?>

--- a/functions/link_key_result.php
+++ b/functions/link_key_result.php
@@ -1,6 +1,6 @@
 <?php
 require '../includes/php_header.php';
-require_permission('admin_business_strategy','update');
+require_permission('admin_strategy','update');
 header('Content-Type: application/json');
 
 $id = isset($_POST['id']) ? (int)$_POST['id'] : 0;

--- a/functions/unlink_key_result.php
+++ b/functions/unlink_key_result.php
@@ -1,6 +1,6 @@
 <?php
 require '../includes/php_header.php';
-require_permission('admin_business_strategy','update');
+require_permission('admin_strategy','update');
 header('Content-Type: application/json');
 
 $id = isset($_POST['id']) ? (int)$_POST['id'] : 0;

--- a/module/project/include/details_view.php
+++ b/module/project/include/details_view.php
@@ -284,7 +284,7 @@ if (!empty($current_project)) {
       </div>
     <?php endif; ?>
 
-    <?php if (user_has_permission('admin_business_strategy','update') && user_has_permission('project','read')): ?>
+    <?php if (user_has_permission('admin_strategy','update') && user_has_permission('project','read')): ?>
       <?php
         $krStmt = $pdo->prepare('SELECT id, name, progress_percent FROM module_strategy_key_results WHERE project_id = :pid');
         $krStmt->execute([':pid' => $current_project['id']]);

--- a/module/task/include/details_view.php
+++ b/module/task/include/details_view.php
@@ -182,7 +182,7 @@ require_once __DIR__ . '/../../../includes/functions.php';
         <?php else: ?>
           <p class="fs-9 text-body-secondary mb-4">No team members assigned.</p>
         <?php endif; ?>
-        <?php if (user_has_permission('admin_business_strategy','update') && user_has_permission('task','read')): ?>
+        <?php if (user_has_permission('admin_strategy','update') && user_has_permission('task','read')): ?>
           <?php
             $krStmt = $pdo->prepare('SELECT id, name, progress_percent FROM module_strategy_key_results WHERE task_id = :tid');
             $krStmt->execute([':tid' => $current_task['id']]);


### PR DESCRIPTION
## Summary
- migrate strategy key results to support optional task_id and project_id
- require `admin_strategy` permission when linking or unlinking key results
- show key results on task and project detail pages when user has strategy update and module read rights

## Testing
- `php -l functions/link_key_result.php && php -l functions/unlink_key_result.php && php -l module/task/include/details_view.php && php -l module/project/include/details_view.php && php -l admin/corporate/business-strategy/functions/create.php && php -l admin/corporate/business-strategy/functions/update.php && php -l admin/corporate/business-strategy/functions/delete.php && php -l admin/corporate/business-strategy/functions/read.php && php -l admin/corporate/business-strategy/index.php`

------
https://chatgpt.com/codex/tasks/task_e_68afce66880c8333ae12d0695076a575