### PR TITLE
Adjust permissions for strategy notes/files and add uploads folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ includes/config.oauth.php
 !admin/corporate/finances/statements-of-work/uploads/.gitkeep
 !admin/corporate/time-tracking/uploads/
 !admin/corporate/time-tracking/uploads/.gitkeep
+!admin/corporate/strategy/uploads/
+!admin/corporate/strategy/uploads/.gitkeep

--- a/admin/corporate/strategy/functions/add_note.php
+++ b/admin/corporate/strategy/functions/add_note.php
@@ -1,6 +1,6 @@
 <?php
 if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
-require_permission('admin_strategy', 'create');
+require_permission('admin_strategy_notes', 'create');
 header('Content-Type: application/json');
 echo json_encode(['success' => false, 'error' => 'Not implemented']);

--- a/admin/corporate/strategy/functions/delete_file.php
+++ b/admin/corporate/strategy/functions/delete_file.php
@@ -1,6 +1,6 @@
 <?php
 if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
-require_permission('admin_strategy', 'delete');
+require_permission('admin_strategy_files', 'delete');
 header('Content-Type: application/json');
 echo json_encode(['success' => false, 'error' => 'Not implemented']);

--- a/admin/corporate/strategy/functions/delete_note.php
+++ b/admin/corporate/strategy/functions/delete_note.php
@@ -1,6 +1,6 @@
 <?php
 if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
-require_permission('admin_strategy', 'delete');
+require_permission('admin_strategy_notes', 'delete');
 header('Content-Type: application/json');
 echo json_encode(['success' => false, 'error' => 'Not implemented']);

--- a/admin/corporate/strategy/functions/upload_file.php
+++ b/admin/corporate/strategy/functions/upload_file.php
@@ -1,6 +1,6 @@
 <?php
 if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
-require_permission('admin_strategy', 'create');
+require_permission('admin_strategy_files', 'create');
 header('Content-Type: application/json');
 echo json_encode(['success' => false, 'error' => 'Not implemented']);


### PR DESCRIPTION
## Summary
- use dedicated admin strategy permissions for notes and files
- track strategy uploads directory

## Testing
- `php -l admin/corporate/strategy/functions/add_note.php`
- `php -l admin/corporate/strategy/functions/delete_note.php`
- `php -l admin/corporate/strategy/functions/upload_file.php`
- `php -l admin/corporate/strategy/functions/delete_file.php`


------
https://chatgpt.com/codex/tasks/task_e_68afce671f948333ba4c530a314a0974