### PR TITLE
Improve meeting project creation endpoint

### DIFF
--- a/admin/meetings/functions/create_project.php
+++ b/admin/meetings/functions/create_project.php
@@ -5,20 +5,32 @@ require_permission('project', 'create');
 header('Content-Type: application/json');
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+        http_response_code(400);
+        echo json_encode(['success' => false, 'message' => 'Invalid CSRF token']);
+        exit;
+    }
+
     $name = trim($_POST['name'] ?? '');
-    $status   = isset($_POST['status']) && $_POST['status'] !== '' ? $_POST['status'] : null;
-    $priority = isset($_POST['priority']) && $_POST['priority'] !== '' ? $_POST['priority'] : null;
-    $type     = isset($_POST['type']) && $_POST['type'] !== '' ? $_POST['type'] : null;
+    $status_id   = isset($_POST['status_id']) && $_POST['status_id'] !== '' ? (int)$_POST['status_id'] : null;
+    $priority_id = isset($_POST['priority_id']) && $_POST['priority_id'] !== '' ? (int)$_POST['priority_id'] : null;
+    $type_id     = isset($_POST['type_id']) && $_POST['type_id'] !== '' ? (int)$_POST['type_id'] : null;
     $description = $_POST['description'] ?? null;
     $requirements = $_POST['requirements'] ?? null;
     $specifications = $_POST['specifications'] ?? null;
     $start_date = $_POST['start_date'] ?? null;
-    $agency_id = isset($_POST['agency_id']) && $_POST['agency_id'] !== '' ? $_POST['agency_id'] : null;
-    $division_id = isset($_POST['division_id']) && $_POST['division_id'] !== '' ? $_POST['division_id'] : null;
+    $agency_id = isset($_POST['agency_id']) && $_POST['agency_id'] !== '' ? (int)$_POST['agency_id'] : null;
+    $division_id = isset($_POST['division_id']) && $_POST['division_id'] !== '' ? (int)$_POST['division_id'] : null;
     $is_private = !empty($_POST['is_private']) ? 1 : 0;
 
-    if ($name !== '') {
-        $stmt = $pdo->prepare('INSERT INTO module_projects (user_id, user_updated, agency_id, division_id, is_private, name, description, requirements, specifications, status, priority, type, start_date) VALUES (:uid,:uid,:agency_id,:division_id,:is_private,:name,:description,:requirements,:specifications,:status,:priority,:type,:start_date)');
+    if ($name === '') {
+        http_response_code(400);
+        echo json_encode(['success' => false, 'message' => 'Project name is required']);
+        exit;
+    }
+
+    try {
+        $stmt = $pdo->prepare('INSERT INTO module_projects (user_id, user_updated, agency_id, division_id, is_private, name, description, requirements, specifications, status, priority, type, start_date) VALUES (:uid,:uid,:agency_id,:division_id,:is_private,:name,:description,:requirements,:specifications,:status_id,:priority_id,:type_id,:start_date)');
         $stmt->execute([
             ':uid' => $this_user_id,
             ':agency_id' => $agency_id,
@@ -28,16 +40,20 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             ':description' => $description,
             ':requirements' => $requirements,
             ':specifications' => $specifications,
-            ':status' => $status,
-            ':priority' => $priority,
-            ':type' => $type,
+            ':status_id' => $status_id,
+            ':priority_id' => $priority_id,
+            ':type_id' => $type_id,
             ':start_date' => $start_date
         ]);
-        $id = $pdo->lastInsertId();
-        admin_audit_log($pdo, $this_user_id, 'module_projects', $id, 'CREATE', null, json_encode(['name' => $name]), 'Created project from meeting');
-        echo json_encode(['success' => true, 'id' => $id]);
-        exit;
+        $project_id = $pdo->lastInsertId();
+        admin_audit_log($pdo, $this_user_id, 'module_projects', $project_id, 'CREATE', null, json_encode(['name' => $name]), 'Created project from meeting');
+        echo json_encode(['success' => true, 'project_id' => $project_id, 'message' => 'Project created']);
+    } catch (Exception $e) {
+        http_response_code(400);
+        echo json_encode(['success' => false, 'message' => $e->getMessage()]);
     }
+    exit;
 }
 
-echo json_encode(['success' => false]);
+http_response_code(400);
+echo json_encode(['success' => false, 'message' => 'Invalid request']);


### PR DESCRIPTION
## Summary
- Validate CSRF token and required project fields when creating a project from a meeting
- Insert project details with status, priority, and type IDs and return structured success message
- Provide clear HTTP 400 error responses for validation or database failures

## Testing
- `php -l admin/meetings/functions/create_project.php`


------
https://chatgpt.com/codex/tasks/task_e_68afd451d070833390d5a16783a961a8