### PR TITLE
Add default meeting lookup items

### DIFF
--- a/_SQL/2025XX_meeting_defaults.sql
+++ b/_SQL/2025XX_meeting_defaults.sql
@@ -1,0 +1,32 @@
+-- Default lookup list items for the Meetings module
+
+-- MEETING_STATUS default value
+SET @meeting_status_list_id := (SELECT id FROM lookup_lists WHERE name = 'MEETING_STATUS');
+INSERT INTO lookup_list_items (user_id, user_updated, list_id, label, code, sort_order, active_from)
+VALUES (1, 1, @meeting_status_list_id, 'Scheduled', 'SCHEDULED', 1, CURDATE());
+SET @meeting_status_item_id := LAST_INSERT_ID();
+INSERT INTO lookup_list_item_attributes (user_id, user_updated, item_id, attr_code, attr_value)
+VALUES
+  (1, 1, @meeting_status_item_id, 'DEFAULT', 'true'),
+  (1, 1, @meeting_status_item_id, 'COLOR-CLASS', 'primary');
+
+-- MEETING_TYPE default value
+SET @meeting_type_list_id := (SELECT id FROM lookup_lists WHERE name = 'MEETING_TYPE');
+INSERT INTO lookup_list_items (user_id, user_updated, list_id, label, code, sort_order, active_from)
+VALUES (1, 1, @meeting_type_list_id, 'General', 'GENERAL', 1, CURDATE());
+SET @meeting_type_item_id := LAST_INSERT_ID();
+INSERT INTO lookup_list_item_attributes (user_id, user_updated, item_id, attr_code, attr_value)
+VALUES
+  (1, 1, @meeting_type_item_id, 'DEFAULT', 'true'),
+  (1, 1, @meeting_type_item_id, 'COLOR-CLASS', 'primary');
+
+-- MEETING_AGENDA_STATUS default value
+SET @agenda_status_list_id := (SELECT id FROM lookup_lists WHERE name = 'MEETING_AGENDA_STATUS');
+INSERT INTO lookup_list_items (user_id, user_updated, list_id, label, code, sort_order, active_from)
+VALUES (1, 1, @agenda_status_list_id, 'Pending', 'PENDING', 1, CURDATE());
+SET @agenda_status_item_id := LAST_INSERT_ID();
+INSERT INTO lookup_list_item_attributes (user_id, user_updated, item_id, attr_code, attr_value)
+VALUES
+  (1, 1, @agenda_status_item_id, 'DEFAULT', 'true'),
+  (1, 1, @agenda_status_item_id, 'COLOR-CLASS', 'warning');
+


### PR DESCRIPTION
## Summary
- add SQL script inserting default meeting status, type, and agenda status lookup items with color classes

## Testing
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_68afd4528ac483339f9d60c7808f8ac1