### PR TITLE
Remove feature selection from corporate settings

### DIFF
--- a/admin/corporate/functions/update.php
+++ b/admin/corporate/functions/update.php
@@ -11,14 +11,11 @@ if(!verify_csrf_token($_POST['csrf_token'] ?? '')){
 $id = (int)($_POST['id'] ?? 0);
 $name = trim($_POST['name'] ?? '');
 $description = trim($_POST['description'] ?? '');
-$feature_id = $_POST['feature_id'] !== '' ? (int)$_POST['feature_id'] : null;
-
 if($id && $name !== ''){
-  $stmt = $pdo->prepare('UPDATE admin_corporate SET name = :name, description = :description, feature_id = :feature_id, user_updated = :uid WHERE id = :id');
+  $stmt = $pdo->prepare('UPDATE admin_corporate SET name = :name, description = :description, user_updated = :uid WHERE id = :id');
   $stmt->execute([
     ':name'=>$name,
     ':description'=>$description,
-    ':feature_id'=>$feature_id,
     ':uid'=>$this_user_id,
     ':id'=>$id
   ]);

--- a/admin/corporate/index.php
+++ b/admin/corporate/index.php
@@ -6,8 +6,7 @@ $token = generate_csrf_token();
 
 // Load corporate settings (single row)
 $stmt = $pdo->query('SELECT * FROM admin_corporate LIMIT 1');
-$corporate = $stmt->fetch(PDO::FETCH_ASSOC) ?: ['id'=>0,'name'=>'','description'=>'','feature_id'=>null];
-$features = get_lookup_items($pdo, 'CORPORATE_FEATURE');
+$corporate = $stmt->fetch(PDO::FETCH_ASSOC) ?: ['id'=>0,'name'=>'','description'=>''];
 ?>
 <h2 class="mb-4">Corporate Settings</h2>
 <div id="flash"></div>
@@ -22,15 +21,6 @@ $features = get_lookup_items($pdo, 'CORPORATE_FEATURE');
     <div class="mb-3">
       <label class="form-label" for="description">Description</label>
       <textarea class="form-control" id="description" name="description" rows="3"><?= e($corporate['description']); ?></textarea>
-    </div>
-    <div class="mb-3">
-      <label class="form-label" for="feature_id">Feature</label>
-      <select class="form-select" id="feature_id" name="feature_id">
-        <option value="">Select</option>
-        <?php foreach ($features as $f): ?>
-        <option value="<?= (int)$f['id']; ?>" <?= (int)$corporate['feature_id'] === (int)$f['id'] ? 'selected' : ''; ?>><?= e($f['label']); ?></option>
-        <?php endforeach; ?>
-      </select>
     </div>
     <?php if (user_has_permission('admin_corporate','update')): ?>
     <button class="btn btn-primary" type="submit">Save Settings</button>


### PR DESCRIPTION
## Summary
- drop feature lookup and selector from corporate settings page
- simplify corporate settings update handler by removing obsolete feature_id

## Testing
- `php -l admin/corporate/index.php`
- `php -l admin/corporate/functions/update.php`
- `php -l admin/corporate/functions/add_note.php`
- `php -l admin/corporate/functions/upload_file.php`
- `php admin/corporate/functions/update.php` *(fails: Connection failed: SQLSTATE[HY000] [2002] No such file or directory)*
- `php add_note.php` *(fails: Connection failed: SQLSTATE[HY000] [2002] No such file or directory)*
- `php upload_file.php` *(fails: Connection failed: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68afe48d004883339169df12fb11061e