### PR TITLE
Refactor invoices and time tracking tables

### DIFF
--- a/admin/corporate/finances/invoices/functions/create.php
+++ b/admin/corporate/finances/invoices/functions/create.php
@@ -4,19 +4,29 @@ require_once __DIR__ . '/../../../../../includes/php_header.php';
 require_permission('admin_finances_invoices','create');
 header('Content-Type: application/json');
 
-$title = trim($_POST['title'] ?? '');
-$amount = $_POST['amount'] ?? null;
+$invoice_number = trim($_POST['invoice_number'] ?? '');
+$status_id = $_POST['status_id'] ?? null;
+$bill_to = trim($_POST['bill_to'] ?? '');
+$invoice_date = $_POST['invoice_date'] ?? null;
+$due_date = $_POST['due_date'] ?? null;
+$total_amount = $_POST['total_amount'] ?? null;
+$corporate_id = $_POST['corporate_id'] ?? 1;
 
-if ($title === '') {
-  echo json_encode(['success' => false, 'error' => 'Missing title']);
+if ($invoice_number === '') {
+  echo json_encode(['success' => false, 'error' => 'Missing invoice number']);
   exit;
 }
 
-$stmt = $pdo->prepare('INSERT INTO admin_finances_invoices (user_id, title, amount) VALUES (:uid, :title, :amount)');
+$stmt = $pdo->prepare('INSERT INTO admin_finances_invoices (user_id, corporate_id, invoice_number, status_id, bill_to, invoice_date, due_date, total_amount) VALUES (:uid, :cid, :invoice_number, :status_id, :bill_to, :invoice_date, :due_date, :total_amount)');
 $stmt->execute([
   ':uid' => $this_user_id,
-  ':title' => $title,
-  ':amount' => $amount
+  ':cid' => $corporate_id,
+  ':invoice_number' => $invoice_number,
+  ':status_id' => $status_id,
+  ':bill_to' => $bill_to,
+  ':invoice_date' => $invoice_date,
+  ':due_date' => $due_date,
+  ':total_amount' => $total_amount
 ]);
 
 echo json_encode(['success' => true, 'id' => $pdo->lastInsertId()]);

--- a/admin/corporate/finances/invoices/functions/read.php
+++ b/admin/corporate/finances/invoices/functions/read.php
@@ -6,11 +6,11 @@ header('Content-Type: application/json');
 
 $id = $_GET['id'] ?? null;
 if ($id) {
-  $stmt = $pdo->prepare('SELECT * FROM admin_finances_invoices WHERE id = :id');
+  $stmt = $pdo->prepare('SELECT id, invoice_number, status_id, bill_to, invoice_date, due_date, total_amount FROM admin_finances_invoices WHERE id = :id');
   $stmt->execute([':id' => $id]);
   $data = $stmt->fetch(PDO::FETCH_ASSOC);
 } else {
-  $stmt = $pdo->query('SELECT * FROM admin_finances_invoices');
+  $stmt = $pdo->query('SELECT id, invoice_number, status_id, bill_to, invoice_date, due_date, total_amount FROM admin_finances_invoices');
   $data = $stmt->fetchAll(PDO::FETCH_ASSOC);
 }
 

--- a/admin/corporate/finances/invoices/functions/update.php
+++ b/admin/corporate/finances/invoices/functions/update.php
@@ -5,18 +5,26 @@ require_permission('admin_finances_invoices','update');
 header('Content-Type: application/json');
 
 $id = $_POST['id'] ?? null;
-$title = trim($_POST['title'] ?? '');
-$amount = $_POST['amount'] ?? null;
+$invoice_number = trim($_POST['invoice_number'] ?? '');
+$status_id = $_POST['status_id'] ?? null;
+$bill_to = trim($_POST['bill_to'] ?? '');
+$invoice_date = $_POST['invoice_date'] ?? null;
+$due_date = $_POST['due_date'] ?? null;
+$total_amount = $_POST['total_amount'] ?? null;
 
-if (!$id || $title === '') {
+if (!$id || $invoice_number === '') {
   echo json_encode(['success' => false, 'error' => 'Invalid input']);
   exit;
 }
 
-$stmt = $pdo->prepare('UPDATE admin_finances_invoices SET title = :title, amount = :amount, user_updated = :uid WHERE id = :id');
+$stmt = $pdo->prepare('UPDATE admin_finances_invoices SET invoice_number = :invoice_number, status_id = :status_id, bill_to = :bill_to, invoice_date = :invoice_date, due_date = :due_date, total_amount = :total_amount, user_updated = :uid WHERE id = :id');
 $stmt->execute([
-  ':title' => $title,
-  ':amount' => $amount,
+  ':invoice_number' => $invoice_number,
+  ':status_id' => $status_id,
+  ':bill_to' => $bill_to,
+  ':invoice_date' => $invoice_date,
+  ':due_date' => $due_date,
+  ':total_amount' => $total_amount,
   ':uid' => $this_user_id,
   ':id' => $id
 ]);

--- a/admin/corporate/finances/invoices/index.php
+++ b/admin/corporate/finances/invoices/index.php
@@ -2,11 +2,11 @@
 require '../../../admin_header.php';
 require_permission('admin_finances_invoices','read');
 
-$invoiceStmt = $pdo->query('SELECT id, title, amount FROM admin_finances_invoices ORDER BY date_created DESC');
+$invoiceStmt = $pdo->query('SELECT id, invoice_number, total_amount FROM admin_finances_invoices ORDER BY date_created DESC');
 $invoices = $invoiceStmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <h2 class="mb-4">Invoices</h2>
-<div id="invoiceList" data-list='{"valueNames":["id","title","amount"],"page":25,"pagination":true}'>
+<div id="invoiceList" data-list='{"valueNames":["id","invoice_number","total_amount"],"page":25,"pagination":true}'>
   <div class="row g-3 justify-content-between mb-4">
     <div class="col-auto">
       <?php if (user_has_permission('admin_finances_invoices','create')): ?>
@@ -25,21 +25,21 @@ $invoices = $invoiceStmt->fetchAll(PDO::FETCH_ASSOC);
   <div class="bg-body-emphasis border-top border-bottom border-translucent position-relative top-1 mx-n4 px-4">
     <div class="row g-0 text-body-tertiary fw-bold fs-10 py-2">
       <div class="col px-2 sort" data-sort="id">ID</div>
-      <div class="col px-2 sort" data-sort="title">Title</div>
-      <div class="col px-2 sort" data-sort="amount">Amount</div>
+      <div class="col px-2 sort" data-sort="invoice_number">Invoice #</div>
+      <div class="col px-2 sort" data-sort="total_amount">Total Amount</div>
       <div class="col px-2">Entries</div>
     </div>
     <div class="list">
       <?php foreach($invoices as $inv): ?>
         <?php
-          $timeStmt = $pdo->prepare('SELECT id, description, hours FROM module_time_tracking_entries WHERE invoice_id = :iid');
+          $timeStmt = $pdo->prepare('SELECT id, memo, hours FROM admin_time_tracking_entries WHERE invoice_id = :iid');
           $timeStmt->execute([':iid' => $inv['id']]);
           $timeEntries = $timeStmt->fetchAll(PDO::FETCH_ASSOC);
         ?>
         <div class="row g-0 border-bottom py-2">
           <div class="col px-2 id"><?= h($inv['id']); ?></div>
-          <div class="col px-2 title"><?= h($inv['title']); ?></div>
-          <div class="col px-2 amount"><?= h($inv['amount']); ?></div>
+          <div class="col px-2 invoice_number"><?= h($inv['invoice_number']); ?></div>
+          <div class="col px-2 total_amount"><?= h($inv['total_amount']); ?></div>
           <div class="col px-2">
             <button class="btn btn-sm btn-info" data-bs-toggle="modal" data-bs-target="#timeEntries<?= $inv['id']; ?>">View</button>
           </div>
@@ -56,7 +56,7 @@ $invoices = $invoiceStmt->fetchAll(PDO::FETCH_ASSOC);
                   <ul class="list-group">
                     <?php foreach($timeEntries as $te): ?>
                       <li class="list-group-item d-flex justify-content-between align-items-center">
-                        <span><?= h($te['description']); ?></span>
+                        <span><?= h($te['memo']); ?></span>
                         <span class="badge bg-primary rounded-pill"><?= h($te['hours']); ?>h</span>
                       </li>
                     <?php endforeach; ?>
@@ -93,12 +93,28 @@ $invoices = $invoiceStmt->fetchAll(PDO::FETCH_ASSOC);
       <div class="modal-body">
         <form id="invoiceForm">
           <div class="mb-3">
-            <label class="form-label" for="title">Title</label>
-            <input class="form-control" id="title" name="title" type="text" required />
+            <label class="form-label" for="invoice_number">Invoice #</label>
+            <input class="form-control" id="invoice_number" name="invoice_number" type="text" required />
           </div>
           <div class="mb-3">
-            <label class="form-label" for="amount">Amount</label>
-            <input class="form-control" id="amount" name="amount" type="number" step="0.01" />
+            <label class="form-label" for="status_id">Status ID</label>
+            <input class="form-control" id="status_id" name="status_id" type="number" />
+          </div>
+          <div class="mb-3">
+            <label class="form-label" for="bill_to">Bill To</label>
+            <input class="form-control" id="bill_to" name="bill_to" type="text" />
+          </div>
+          <div class="mb-3">
+            <label class="form-label" for="invoice_date">Invoice Date</label>
+            <input class="form-control" id="invoice_date" name="invoice_date" type="date" />
+          </div>
+          <div class="mb-3">
+            <label class="form-label" for="due_date">Due Date</label>
+            <input class="form-control" id="due_date" name="due_date" type="date" />
+          </div>
+          <div class="mb-3">
+            <label class="form-label" for="total_amount">Total Amount</label>
+            <input class="form-control" id="total_amount" name="total_amount" type="number" step="0.01" />
           </div>
           <button class="btn btn-primary" type="submit">Save</button>
         </form>

--- a/admin/corporate/time-tracking/functions/create.php
+++ b/admin/corporate/time-tracking/functions/create.php
@@ -4,21 +4,29 @@ require_once __DIR__ . '/../../../../includes/php_header.php';
 require_permission('admin_time_tracking','create');
 header('Content-Type: application/json');
 
-$description = trim($_POST['description'] ?? '');
+$memo = trim($_POST['memo'] ?? '');
 $hours = $_POST['hours'] ?? null;
 $invoice_id = $_POST['invoice_id'] ?? null;
+$person_id = $_POST['person_id'] ?? null;
+$work_date = $_POST['work_date'] ?? null;
+$rate = $_POST['rate'] ?? null;
+$corporate_id = $_POST['corporate_id'] ?? 1;
 
-if ($description === '' || $hours === null) {
+if ($memo === '' || $hours === null || !$person_id || !$work_date) {
   echo json_encode(['success' => false, 'error' => 'Missing fields']);
   exit;
 }
 
-$stmt = $pdo->prepare('INSERT INTO module_time_tracking_entries (user_id, description, hours, invoice_id) VALUES (:uid, :description, :hours, :invoice_id)');
+$stmt = $pdo->prepare('INSERT INTO admin_time_tracking_entries (user_id, corporate_id, person_id, work_date, hours, rate, invoice_id, memo) VALUES (:uid, :cid, :person_id, :work_date, :hours, :rate, :invoice_id, :memo)');
 $stmt->execute([
   ':uid' => $this_user_id,
-  ':description' => $description,
+  ':cid' => $corporate_id,
+  ':person_id' => $person_id,
+  ':work_date' => $work_date,
   ':hours' => $hours,
-  ':invoice_id' => $invoice_id ?: null
+  ':rate' => $rate,
+  ':invoice_id' => $invoice_id ?: null,
+  ':memo' => $memo
 ]);
 
 echo json_encode(['success' => true, 'id' => $pdo->lastInsertId()]);

--- a/admin/corporate/time-tracking/functions/delete.php
+++ b/admin/corporate/time-tracking/functions/delete.php
@@ -10,7 +10,7 @@ if (!$id) {
   exit;
 }
 
-$stmt = $pdo->prepare('DELETE FROM module_time_tracking_entries WHERE id = :id');
+$stmt = $pdo->prepare('DELETE FROM admin_time_tracking_entries WHERE id = :id');
 $stmt->execute([':id' => $id]);
 
 echo json_encode(['success' => true]);

--- a/admin/corporate/time-tracking/functions/read.php
+++ b/admin/corporate/time-tracking/functions/read.php
@@ -6,11 +6,11 @@ header('Content-Type: application/json');
 
 $id = $_GET['id'] ?? null;
 if ($id) {
-  $stmt = $pdo->prepare('SELECT t.*, i.title AS invoice_title FROM module_time_tracking_entries t LEFT JOIN admin_finances_invoices i ON t.invoice_id = i.id WHERE t.id = :id');
+  $stmt = $pdo->prepare('SELECT t.*, i.invoice_number AS invoice_number FROM admin_time_tracking_entries t LEFT JOIN admin_finances_invoices i ON t.invoice_id = i.id WHERE t.id = :id');
   $stmt->execute([':id' => $id]);
   $data = $stmt->fetch(PDO::FETCH_ASSOC);
 } else {
-  $stmt = $pdo->query('SELECT t.*, i.title AS invoice_title FROM module_time_tracking_entries t LEFT JOIN admin_finances_invoices i ON t.invoice_id = i.id');
+  $stmt = $pdo->query('SELECT t.*, i.invoice_number AS invoice_number FROM admin_time_tracking_entries t LEFT JOIN admin_finances_invoices i ON t.invoice_id = i.id');
   $data = $stmt->fetchAll(PDO::FETCH_ASSOC);
 }
 

--- a/admin/corporate/time-tracking/functions/update.php
+++ b/admin/corporate/time-tracking/functions/update.php
@@ -5,19 +5,25 @@ require_permission('admin_time_tracking','update');
 header('Content-Type: application/json');
 
 $id = $_POST['id'] ?? null;
-$description = trim($_POST['description'] ?? '');
+$memo = trim($_POST['memo'] ?? '');
 $hours = $_POST['hours'] ?? null;
 $invoice_id = $_POST['invoice_id'] ?? null;
+$person_id = $_POST['person_id'] ?? null;
+$work_date = $_POST['work_date'] ?? null;
+$rate = $_POST['rate'] ?? null;
 
-if (!$id || $description === '' || $hours === null) {
+if (!$id || $memo === '' || $hours === null || !$person_id || !$work_date) {
   echo json_encode(['success' => false, 'error' => 'Invalid input']);
   exit;
 }
 
-$stmt = $pdo->prepare('UPDATE module_time_tracking_entries SET description = :description, hours = :hours, invoice_id = :invoice_id, user_updated = :uid WHERE id = :id');
+$stmt = $pdo->prepare('UPDATE admin_time_tracking_entries SET memo = :memo, person_id = :person_id, work_date = :work_date, hours = :hours, rate = :rate, invoice_id = :invoice_id, user_updated = :uid WHERE id = :id');
 $stmt->execute([
-  ':description' => $description,
+  ':memo' => $memo,
+  ':person_id' => $person_id,
+  ':work_date' => $work_date,
   ':hours' => $hours,
+  ':rate' => $rate,
   ':invoice_id' => $invoice_id ?: null,
   ':uid' => $this_user_id,
   ':id' => $id

--- a/admin/corporate/time-tracking/index.php
+++ b/admin/corporate/time-tracking/index.php
@@ -2,9 +2,9 @@
 require '../../admin_header.php';
 require_permission('admin_time_tracking','read');
 
-$invoiceStmt = $pdo->query('SELECT id, title FROM admin_finances_invoices ORDER BY title');
+$invoiceStmt = $pdo->query('SELECT id, invoice_number FROM admin_finances_invoices ORDER BY invoice_number');
 $invoices = $invoiceStmt->fetchAll(PDO::FETCH_ASSOC);
-$entryStmt = $pdo->query('SELECT t.id, t.description, t.hours, i.title AS invoice_title FROM module_time_tracking_entries t LEFT JOIN admin_finances_invoices i ON t.invoice_id = i.id ORDER BY t.date_created DESC');
+$entryStmt = $pdo->query('SELECT t.id, t.memo, t.hours, i.invoice_number AS invoice_number FROM admin_time_tracking_entries t LEFT JOIN admin_finances_invoices i ON t.invoice_id = i.id ORDER BY t.date_created DESC');
 $entries = $entryStmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <h2 class="mb-4">Time Tracking</h2>
@@ -12,19 +12,31 @@ $entries = $entryStmt->fetchAll(PDO::FETCH_ASSOC);
   <div class="col-lg-4">
     <form id="timeEntryForm">
       <div class="mb-3">
-        <label class="form-label" for="description">Description</label>
-        <input class="form-control" id="description" name="description" type="text" required />
+        <label class="form-label" for="memo">Description</label>
+        <input class="form-control" id="memo" name="memo" type="text" required />
       </div>
       <div class="mb-3">
         <label class="form-label" for="hours">Hours</label>
         <input class="form-control" id="hours" name="hours" type="number" step="0.01" required />
       </div>
       <div class="mb-3">
+        <label class="form-label" for="person_id">Person ID</label>
+        <input class="form-control" id="person_id" name="person_id" type="number" required />
+      </div>
+      <div class="mb-3">
+        <label class="form-label" for="work_date">Work Date</label>
+        <input class="form-control" id="work_date" name="work_date" type="date" required />
+      </div>
+      <div class="mb-3">
+        <label class="form-label" for="rate">Rate</label>
+        <input class="form-control" id="rate" name="rate" type="number" step="0.01" />
+      </div>
+      <div class="mb-3">
         <label class="form-label" for="invoice_id">Invoice</label>
         <select class="form-select" id="invoice_id" name="invoice_id">
           <option value="">-- none --</option>
           <?php foreach($invoices as $i): ?>
-            <option value="<?= $i['id']; ?>"><?= h($i['title']); ?></option>
+            <option value="<?= $i['id']; ?>"><?= h($i['invoice_number']); ?></option>
           <?php endforeach; ?>
         </select>
       </div>
@@ -34,19 +46,19 @@ $entries = $entryStmt->fetchAll(PDO::FETCH_ASSOC);
     </form>
   </div>
   <div class="col-lg-8">
-    <div id="timeEntryList" data-list='{"valueNames":["description","hours","invoice"],"page":25,"pagination":true}'>
+    <div id="timeEntryList" data-list='{"valueNames":["memo","hours","invoice"],"page":25,"pagination":true}'>
       <div class="bg-body-emphasis border-top border-bottom border-translucent position-relative top-1 mx-n4 px-4">
         <div class="row g-0 text-body-tertiary fw-bold fs-10 py-2">
-          <div class="col px-2 sort" data-sort="description">Description</div>
+          <div class="col px-2 sort" data-sort="memo">Description</div>
           <div class="col px-2 sort" data-sort="hours">Hours</div>
           <div class="col px-2 sort" data-sort="invoice">Invoice</div>
         </div>
         <div class="list">
           <?php foreach($entries as $e): ?>
             <div class="row g-0 border-bottom py-2">
-              <div class="col px-2 description"><?= h($e['description']); ?></div>
+              <div class="col px-2 memo"><?= h($e['memo']); ?></div>
               <div class="col px-2 hours"><?= h($e['hours']); ?></div>
-              <div class="col px-2 invoice"><?= h($e['invoice_title'] ?? ''); ?></div>
+              <div class="col px-2 invoice"><?= h($e['invoice_number'] ?? ''); ?></div>
             </div>
           <?php endforeach; ?>
         </div>


### PR DESCRIPTION
## Summary
- show invoice numbers and totals, linking to admin time tracking entries
- expand invoice CRUD to handle number, status, billing, dates and totals
- update time tracking to use admin entries with memo, person, work date and rate

## Testing
- `php -l admin/corporate/finances/invoices/index.php`
- `php -l admin/corporate/finances/invoices/functions/create.php`
- `php -l admin/corporate/finances/invoices/functions/read.php`
- `php -l admin/corporate/finances/invoices/functions/update.php`
- `php -l admin/corporate/time-tracking/index.php`
- `php -l admin/corporate/time-tracking/functions/create.php`
- `php -l admin/corporate/time-tracking/functions/read.php`
- `php -l admin/corporate/time-tracking/functions/update.php`
- `php -l admin/corporate/time-tracking/functions/delete.php`


------
https://chatgpt.com/codex/tasks/task_e_68afe48de71883338841301362549e44