### PR TITLE
Implement strategy CRUD backend and client updates

### DIFF
--- a/admin/corporate/strategy/functions/add_collaborator.php
+++ b/admin/corporate/strategy/functions/add_collaborator.php
@@ -3,4 +3,37 @@ if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
 require_permission('admin_strategy', 'create');
 header('Content-Type: application/json');
-echo json_encode(['success' => false, 'error' => 'Not implemented']);
+
+$strategyId = (int)($_POST['strategy_id'] ?? 0);
+$personId = (int)($_POST['person_id'] ?? 0);
+$roleId = $_POST['role_id'] !== '' ? (int)$_POST['role_id'] : null;
+
+if(!$strategyId || !$personId){
+  echo json_encode(['success'=>false,'error'=>'Missing data']);
+  exit;
+}
+
+// validate role against lookup list CORPORATE_STRATEGY_ROLE
+if($roleId !== null){
+  $checkRole = $pdo->prepare('SELECT li.id FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = :name AND li.id = :id');
+  $checkRole->execute([':name'=>'CORPORATE_STRATEGY_ROLE', ':id'=>$roleId]);
+  if(!$checkRole->fetchColumn()){
+    echo json_encode(['success'=>false,'error'=>'Invalid role']);
+    exit;
+  }
+}
+
+try {
+  $stmt = $pdo->prepare('INSERT INTO module_strategy_collaborators (user_id,user_updated,strategy_id,person_id,role_id) VALUES (:uid,:uid,:sid,:pid,:rid)');
+  $stmt->execute([
+    ':uid'=>$this_user_id,
+    ':sid'=>$strategyId,
+    ':pid'=>$personId,
+    ':rid'=>$roleId
+  ]);
+  $id = (int)$pdo->lastInsertId();
+  admin_audit_log($pdo,$this_user_id,'module_strategy_collaborators',$id,'CREATE',null,null,json_encode(['person_id'=>$personId]));
+  echo json_encode(['success'=>true,'id'=>$id]);
+} catch (PDOException $e){
+  echo json_encode(['success'=>false,'error'=>'Database error']);
+}

--- a/admin/corporate/strategy/functions/add_objective.php
+++ b/admin/corporate/strategy/functions/add_objective.php
@@ -3,4 +3,42 @@ if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
 require_permission('admin_strategy', 'create');
 header('Content-Type: application/json');
-echo json_encode(['success' => false, 'error' => 'Not implemented']);
+
+$strategyId = (int)($_POST['strategy_id'] ?? 0);
+$parentId = $_POST['parent_id'] !== '' ? (int)$_POST['parent_id'] : null;
+$objective = trim($_POST['objective'] ?? '');
+$ownerId = $_POST['owner_id'] !== '' ? (int)$_POST['owner_id'] : null;
+
+if(!$strategyId || $objective === ''){
+  echo json_encode(['success'=>false,'error'=>'Missing data']);
+  exit;
+}
+
+// ensure parent belongs to same strategy if provided
+if ($parentId) {
+  $chk = $pdo->prepare('SELECT id FROM module_strategy_objectives WHERE id = :pid AND strategy_id = :sid');
+  $chk->execute([':pid'=>$parentId, ':sid'=>$strategyId]);
+  if(!$chk->fetchColumn()){
+    echo json_encode(['success'=>false,'error'=>'Invalid parent objective']);
+    exit;
+  }
+}
+
+// determine sort order
+$sortStmt = $pdo->prepare('SELECT COALESCE(MAX(sort_order),0)+1 FROM module_strategy_objectives WHERE strategy_id = :sid AND ((parent_id IS NULL AND :pid IS NULL) OR parent_id = :pid)');
+$sortStmt->execute([':sid'=>$strategyId, ':pid'=>$parentId]);
+$sort = (int)$sortStmt->fetchColumn();
+
+$stmt = $pdo->prepare('INSERT INTO module_strategy_objectives (user_id,user_updated,strategy_id,parent_id,objective,owner_id,sort_order) VALUES (:uid,:uid,:sid,:pid,:obj,:owner,:sort)');
+$stmt->execute([
+  ':uid'=>$this_user_id,
+  ':sid'=>$strategyId,
+  ':pid'=>$parentId,
+  ':obj'=>$objective,
+  ':owner'=>$ownerId,
+  ':sort'=>$sort
+]);
+$objectiveId = (int)$pdo->lastInsertId();
+admin_audit_log($pdo,$this_user_id,'module_strategy_objectives',$objectiveId,'CREATE',null,null,json_encode(['objective'=>$objective]));
+
+echo json_encode(['success'=>true,'id'=>$objectiveId,'sort_order'=>$sort]);

--- a/admin/corporate/strategy/functions/create_strategy.php
+++ b/admin/corporate/strategy/functions/create_strategy.php
@@ -3,4 +3,49 @@ if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
 require_permission('admin_strategy', 'create');
 header('Content-Type: application/json');
-echo json_encode(['success' => false, 'error' => 'Not implemented']);
+
+$title = trim($_POST['title'] ?? '');
+$corporateId = (int)($_POST['corporate_id'] ?? 1);
+$statusId = $_POST['status'] !== '' ? (int)$_POST['status'] : null;
+$priorityId = $_POST['priority'] !== '' ? (int)$_POST['priority'] : null;
+$description = trim($_POST['description'] ?? '');
+$targetStart = $_POST['target_start'] ?? null;
+$targetEnd = $_POST['target_end'] ?? null;
+$tags = trim($_POST['tags'] ?? '');
+
+if ($title === '') {
+  echo json_encode(['success' => false, 'error' => 'Title is required']);
+  exit;
+}
+
+try {
+  $stmt = $pdo->prepare('INSERT INTO module_strategy (user_id,user_updated,corporate_id,title,description,status_id,priority_id,target_start,target_end) VALUES (:uid,:uid,:cid,:title,:description,:status,:priority,:tstart,:tend)');
+  $stmt->execute([
+    ':uid' => $this_user_id,
+    ':cid' => $corporateId,
+    ':title' => $title,
+    ':description' => $description !== '' ? $description : null,
+    ':status' => $statusId,
+    ':priority' => $priorityId,
+    ':tstart' => $targetStart,
+    ':tend' => $targetEnd
+  ]);
+  $strategyId = (int)$pdo->lastInsertId();
+  admin_audit_log($pdo,$this_user_id,'module_strategy',$strategyId,'CREATE',null,null,json_encode(['title'=>$title]));
+
+  if ($tags !== '') {
+    $insTag = $pdo->prepare('INSERT INTO module_strategy_tags (user_id,user_updated,strategy_id,tag) VALUES (:uid,:uid,:sid,:tag)');
+    foreach (array_filter(array_map('trim', explode(',', $tags))) as $tag) {
+      if ($tag === '') continue;
+      $insTag->execute([
+        ':uid' => $this_user_id,
+        ':sid' => $strategyId,
+        ':tag' => $tag
+      ]);
+    }
+  }
+
+  echo json_encode(['success' => true, 'id' => $strategyId]);
+} catch (PDOException $e) {
+  echo json_encode(['success' => false, 'error' => 'Database error']);
+}

--- a/admin/corporate/strategy/functions/read_objectives.php
+++ b/admin/corporate/strategy/functions/read_objectives.php
@@ -3,4 +3,15 @@ if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
 require_permission('admin_strategy', 'read');
 header('Content-Type: application/json');
-echo json_encode(['success' => true, 'objectives' => []]);
+
+$strategyId = (int)($_GET['strategy_id'] ?? 0);
+if(!$strategyId){
+  echo json_encode(['success'=>false,'error'=>'Missing strategy']);
+  exit;
+}
+
+$stmt = $pdo->prepare('SELECT id,parent_id,objective AS title, progress_percent AS progress FROM module_strategy_objectives WHERE strategy_id = :sid ORDER BY parent_id, sort_order');
+$stmt->execute([':sid'=>$strategyId]);
+$objectives = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+echo json_encode(['success'=>true,'objectives'=>$objectives]);

--- a/admin/corporate/strategy/functions/read_strategies.php
+++ b/admin/corporate/strategy/functions/read_strategies.php
@@ -3,4 +3,33 @@ if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
 require_permission('admin_strategy', 'read');
 header('Content-Type: application/json');
-echo json_encode(['success' => true, 'html' => '']);
+
+$status = trim($_GET['status'] ?? '');
+$priority = trim($_GET['priority'] ?? '');
+$tags = trim($_GET['tags'] ?? '');
+
+$sql = 'SELECT s.id, s.title, s.status_id, s.priority_id, GROUP_CONCAT(t.tag) AS tags
+        FROM module_strategy s
+        LEFT JOIN module_strategy_tags t ON t.strategy_id = s.id
+        WHERE 1=1';
+$params = [];
+if ($status !== '') {
+  $sql .= ' AND s.status_id = :status';
+  $params[':status'] = $status;
+}
+if ($priority !== '') {
+  $sql .= ' AND s.priority_id = :priority';
+  $params[':priority'] = $priority;
+}
+$sql .= ' GROUP BY s.id';
+if ($tags !== '') {
+  $sql .= ' HAVING tags LIKE :tags';
+  $params[':tags'] = "%$tags%";
+}
+$sql .= ' ORDER BY s.date_created DESC';
+
+$stmt = $pdo->prepare($sql);
+$stmt->execute($params);
+$strategies = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+echo json_encode(['success' => true, 'strategies' => $strategies]);

--- a/admin/corporate/strategy/functions/reorder_objectives.php
+++ b/admin/corporate/strategy/functions/reorder_objectives.php
@@ -3,4 +3,28 @@ if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
 require_permission('admin_strategy', 'update');
 header('Content-Type: application/json');
-echo json_encode(['success' => false, 'error' => 'Not implemented']);
+
+$data = json_decode($_POST['hierarchy'] ?? '[]', true);
+if(!is_array($data)){
+  echo json_encode(['success'=>false,'error'=>'Invalid data']);
+  exit;
+}
+
+try {
+  $update = $pdo->prepare('UPDATE module_strategy_objectives SET parent_id = :pid, sort_order = :sort, user_updated = :uid WHERE id = :id');
+  $fn = function(array $items, $parent) use (&$fn, $update, $this_user_id){
+    $sort = 0;
+    foreach($items as $item){
+      $pid = $parent ?: null;
+      $update->execute([':pid'=>$pid, ':sort'=>$sort, ':uid'=>$this_user_id, ':id'=>$item['id']]);
+      if(!empty($item['children'])){
+        $fn($item['children'], (int)$item['id']);
+      }
+      $sort++;
+    }
+  };
+  $fn($data, 0);
+  echo json_encode(['success'=>true]);
+} catch (PDOException $e){
+  echo json_encode(['success'=>false,'error'=>'Database error']);
+}


### PR DESCRIPTION
## Summary
- Implement create, read, objective CRUD endpoints for corporate strategy module with RBAC checks
- Support nested objectives with drag-and-drop reordering
- Validate collaborator roles and refresh strategy sections via updated AJAX handlers

## Testing
- `php -l admin/corporate/strategy/functions/create_strategy.php`
- `php -l admin/corporate/strategy/functions/read_strategies.php`
- `php -l admin/corporate/strategy/functions/add_objective.php`
- `php -l admin/corporate/strategy/functions/read_objectives.php`
- `php -l admin/corporate/strategy/functions/reorder_objectives.php`
- `php -l admin/corporate/strategy/functions/add_collaborator.php`
- `php -l admin/corporate/strategy/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68afe49080f08333ba62156aca42cb3b