### PR TITLE
Expose event owner in calendar list

### DIFF
--- a/module/calendar/functions/list.php
+++ b/module/calendar/functions/list.php
@@ -128,6 +128,7 @@ try {
             'related_id' => $row['link_record_id'],
             'event_type_id' => $row['event_type_id'],
             'visibility_id' => $visibility,
+            'user_id' => (int)$row['user_id'],
             'calendar_user_id' => (int)$row['calendar_user_id'],
             'is_private' => (int)$row['is_private']
         ];


### PR DESCRIPTION
## Summary
- include `user_id` in each calendar event payload

## Testing
- `php -l module/calendar/functions/list.php`


------
https://chatgpt.com/codex/tasks/task_e_68afea2ba34c8333954215751210f2be