### PR TITLE
Fetch user and public calendars in listing

### DIFF
--- a/module/calendar/functions/list_calendars.php
+++ b/module/calendar/functions/list_calendars.php
@@ -6,14 +6,17 @@ require_permission('calendar','read');
 header('Content-Type: application/json');
 
 try {
-    $stmt = $pdo->query(
-        "SELECT c.id, c.name, COALESCE(CONCAT(p.first_name, ' ', p.last_name), u.email) AS owner " .
+    $uid = $this_user_id;
+    $stmt = $pdo->prepare(
+        "SELECT c.id, c.name, c.user_id = :uid AS owned, c.is_private, " .
+        "COALESCE(CONCAT(p.first_name, ' ', p.last_name), u.email) AS owner " .
         "FROM module_calendar c " .
         "LEFT JOIN users u ON c.user_id = u.id " .
         "LEFT JOIN person p ON u.id = p.user_id " .
-        "WHERE c.is_private = 0 " .
-        "ORDER BY c.name"
+        "WHERE c.user_id = :uid OR c.is_private = 0 " .
+        "ORDER BY owned DESC, c.name ASC"
     );
+    $stmt->execute(['uid' => $uid]);
     $calendars = $stmt->fetchAll(PDO::FETCH_ASSOC);
     echo json_encode($calendars);
 


### PR DESCRIPTION
## Summary
- Include both personal and public calendars when listing
- Expose `owned` and `is_private` flags along with owner display name
- Sort calendars so personal ones appear first

## Testing
- `php -l module/calendar/functions/list_calendars.php`


------
https://chatgpt.com/codex/tasks/task_e_68afea293de48333948de1e5de88d931