### PR TITLE
Refresh OAuth tokens for calendar events

### DIFF
--- a/module/calendar/functions/google_events.php
+++ b/module/calendar/functions/google_events.php
@@ -6,11 +6,61 @@ function fetch_google_events(PDO $pdo, int $userId): array {
         return $_SESSION[$cacheKey]['data'];
     }
 
-    $stmt = $pdo->prepare('SELECT access_token FROM module_calendar_external_accounts WHERE user_id = ? AND provider = ?');
+    $stmt = $pdo->prepare('SELECT access_token, refresh_token, token_expires FROM module_calendar_external_accounts WHERE user_id = ? AND provider = ?');
     $stmt->execute([$userId, 'google']);
-    $token = $stmt->fetchColumn();
-    if (!$token) {
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
+    if (!$row) {
         return [];
+    }
+    $token = $row['access_token'] ?? '';
+    $refreshToken = $row['refresh_token'] ?? '';
+    $tokenExpires = $row['token_expires'] ?? '';
+
+    if ($refreshToken && $tokenExpires && strtotime($tokenExpires) <= time()) {
+        global $oauthConfig;
+        $conf = $oauthConfig['google'] ?? [];
+        if (!empty($conf['client_id']) && !empty($conf['client_secret'])) {
+            try {
+                $ch = curl_init('https://oauth2.googleapis.com/token');
+                if ($ch === false) {
+                    throw new Exception('Failed to initialize cURL');
+                }
+                $postFields = http_build_query([
+                    'client_id' => $conf['client_id'],
+                    'client_secret' => $conf['client_secret'],
+                    'refresh_token' => $refreshToken,
+                    'grant_type' => 'refresh_token'
+                ]);
+                curl_setopt_array($ch, [
+                    CURLOPT_POST => true,
+                    CURLOPT_POSTFIELDS => $postFields,
+                    CURLOPT_RETURNTRANSFER => true,
+                ]);
+                $resp = curl_exec($ch);
+                if ($resp === false) {
+                    throw new Exception(curl_error($ch));
+                }
+                curl_close($ch);
+            } catch (Exception $e) {
+                if (isset($ch) && is_resource($ch)) {
+                    curl_close($ch);
+                }
+                error_log($e->getMessage());
+                return [];
+            }
+            $tokenData = json_decode($resp, true);
+            if (!empty($tokenData['access_token'])) {
+                $token = $tokenData['access_token'];
+                $refreshToken = $tokenData['refresh_token'] ?? $refreshToken;
+                $expires = date('Y-m-d H:i:s', time() + (int)($tokenData['expires_in'] ?? 0));
+                $upd = $pdo->prepare('UPDATE module_calendar_external_accounts SET access_token = ?, refresh_token = ?, token_expires = ? WHERE user_id = ? AND provider = ?');
+                $upd->execute([$token, $refreshToken, $expires, $userId, 'google']);
+            } else {
+                return [];
+            }
+        } else {
+            return [];
+        }
     }
 
     try {

--- a/module/calendar/functions/microsoft_events.php
+++ b/module/calendar/functions/microsoft_events.php
@@ -6,11 +6,61 @@ function fetch_microsoft_events(PDO $pdo, int $userId): array {
         return $_SESSION[$cacheKey]['data'];
     }
 
-    $stmt = $pdo->prepare('SELECT access_token FROM module_calendar_external_accounts WHERE user_id = ? AND provider = ?');
+    $stmt = $pdo->prepare('SELECT access_token, refresh_token, token_expires FROM module_calendar_external_accounts WHERE user_id = ? AND provider = ?');
     $stmt->execute([$userId, 'microsoft']);
-    $token = $stmt->fetchColumn();
-    if (!$token) {
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
+    if (!$row) {
         return [];
+    }
+    $token = $row['access_token'] ?? '';
+    $refreshToken = $row['refresh_token'] ?? '';
+    $tokenExpires = $row['token_expires'] ?? '';
+
+    if ($refreshToken && $tokenExpires && strtotime($tokenExpires) <= time()) {
+        global $oauthConfig;
+        $conf = $oauthConfig['microsoft'] ?? [];
+        if (!empty($conf['client_id']) && !empty($conf['client_secret'])) {
+            try {
+                $ch = curl_init('https://login.microsoftonline.com/common/oauth2/v2.0/token');
+                if ($ch === false) {
+                    throw new Exception('Failed to initialize cURL');
+                }
+                $postFields = http_build_query([
+                    'client_id' => $conf['client_id'],
+                    'client_secret' => $conf['client_secret'],
+                    'refresh_token' => $refreshToken,
+                    'grant_type' => 'refresh_token'
+                ]);
+                curl_setopt_array($ch, [
+                    CURLOPT_POST => true,
+                    CURLOPT_POSTFIELDS => $postFields,
+                    CURLOPT_RETURNTRANSFER => true,
+                ]);
+                $resp = curl_exec($ch);
+                if ($resp === false) {
+                    throw new Exception(curl_error($ch));
+                }
+                curl_close($ch);
+            } catch (Exception $e) {
+                if (isset($ch) && is_resource($ch)) {
+                    curl_close($ch);
+                }
+                error_log($e->getMessage());
+                return [];
+            }
+            $tokenData = json_decode($resp, true);
+            if (!empty($tokenData['access_token'])) {
+                $token = $tokenData['access_token'];
+                $refreshToken = $tokenData['refresh_token'] ?? $refreshToken;
+                $expires = date('Y-m-d H:i:s', time() + (int)($tokenData['expires_in'] ?? 0));
+                $upd = $pdo->prepare('UPDATE module_calendar_external_accounts SET access_token = ?, refresh_token = ?, token_expires = ? WHERE user_id = ? AND provider = ?');
+                $upd->execute([$token, $refreshToken, $expires, $userId, 'microsoft']);
+            } else {
+                return [];
+            }
+        } else {
+            return [];
+        }
     }
 
     try {


### PR DESCRIPTION
## Summary
- Refresh Google Calendar tokens when expired and update cache
- Refresh Microsoft Calendar tokens when expired and update cache

## Testing
- `php -l module/calendar/functions/google_events.php`
- `php -l module/calendar/functions/microsoft_events.php`


------
https://chatgpt.com/codex/tasks/task_e_68aff954bb948333a3712da3e99c97c1