### PR TITLE
Add memo support to calendar events

### DIFF
--- a/module/calendar/functions/create.php
+++ b/module/calendar/functions/create.php
@@ -5,6 +5,7 @@ require_permission('calendar','create');
 header('Content-Type: application/json');
 
 $title = trim($_POST['title'] ?? '');
+$memo = trim($_POST['memo'] ?? '');
 
 $start_time = $_POST['start_time'] ?? null;
 $end_time = $_POST['end_time'] ?? null;
@@ -31,12 +32,13 @@ if ($title && $start_time && $calendar_id) {
     exit;
   }
 
-  $columns = ['user_id', 'calendar_id', 'title', 'start_time', 'end_time', 'link_module', 'link_record_id', 'visibility_id'];
-  $placeholders = [':uid', ':calendar_id', ':title', ':start_time', ':end_time', ':link_module', ':link_record_id', ':visibility_id'];
+  $columns = ['user_id', 'calendar_id', 'title', 'memo', 'start_time', 'end_time', 'link_module', 'link_record_id', 'visibility_id'];
+  $placeholders = [':uid', ':calendar_id', ':title', ':memo', ':start_time', ':end_time', ':link_module', ':link_record_id', ':visibility_id'];
   $params = [
     ':uid' => $this_user_id,
     ':calendar_id' => $calendar_id,
     ':title' => $title,
+    ':memo' => $memo,
     ':start_time' => $start_time,
     ':end_time' => $end_time,
     ':link_module' => $link_module,
@@ -71,6 +73,7 @@ if ($title && $start_time && $calendar_id) {
     'id' => $eventId,
     'calendar_id' => $calendar_id,
     'title' => $title,
+    'description' => $memo,
     'start' => $start_time,
     'end' => $end_time,
     'visibility_id' => $visibility_id,

--- a/module/calendar/functions/list.php
+++ b/module/calendar/functions/list.php
@@ -33,7 +33,7 @@ try {
     if (user_has_role('Admin')) {
         if (!empty($calendar_ids)) {
             $placeholders = implode(',', array_fill(0, count($calendar_ids), '?'));
-            $sql = "SELECT e.id, e.calendar_id, e.title, e.start_time, e.end_time, e.link_module, e.link_record_id, e.user_id, e.event_type_id, e.visibility_id, c.is_private, c.user_id AS calendar_user_id FROM module_calendar_events e JOIN module_calendar c ON e.calendar_id = c.id WHERE e.calendar_id IN ($placeholders)";
+            $sql = "SELECT e.id, e.calendar_id, e.title, e.memo, e.start_time, e.end_time, e.link_module, e.link_record_id, e.user_id, e.event_type_id, e.visibility_id, c.user_id AS calendar_user_id FROM module_calendar_events e JOIN module_calendar c ON e.calendar_id = c.id WHERE e.calendar_id IN ($placeholders)";
             if ($filterTime) {
                 $sql .= ' AND e.start_time < :end AND e.end_time > :start';
             }
@@ -48,7 +48,7 @@ try {
             }
             $stmt->execute();
         } else {
-            $sql = 'SELECT e.id, e.calendar_id, e.title, e.start_time, e.end_time, e.link_module, e.link_record_id, e.user_id, e.event_type_id, e.visibility_id, c.is_private, c.user_id AS calendar_user_id FROM module_calendar_events e JOIN module_calendar c ON e.calendar_id = c.id';
+            $sql = 'SELECT e.id, e.calendar_id, e.title, e.memo, e.start_time, e.end_time, e.link_module, e.link_record_id, e.user_id, e.event_type_id, e.visibility_id, c.user_id AS calendar_user_id FROM module_calendar_events e JOIN module_calendar c ON e.calendar_id = c.id';
             if ($filterTime) {
                 $sql .= ' WHERE e.start_time < :end AND e.end_time > :start';
                 $stmt = $pdo->prepare($sql);
@@ -75,7 +75,7 @@ try {
                 echo json_encode(['error' => 'Access denied']);
                 exit;
             }
-            $sql = "SELECT e.id, e.calendar_id, e.title, e.start_time, e.end_time, e.link_module, e.link_record_id, e.user_id, e.event_type_id, e.visibility_id, c.is_private, c.user_id AS calendar_user_id FROM module_calendar_events e JOIN module_calendar c ON e.calendar_id = c.id WHERE (e.visibility_id = 198 OR e.user_id = ?) AND (c.is_private = 0 OR c.user_id = ?) AND e.calendar_id IN ($placeholders)";
+            $sql = "SELECT e.id, e.calendar_id, e.title, e.memo, e.start_time, e.end_time, e.link_module, e.link_record_id, e.user_id, e.event_type_id, e.visibility_id, c.user_id AS calendar_user_id FROM module_calendar_events e JOIN module_calendar c ON e.calendar_id = c.id WHERE (e.visibility_id = 198 OR e.user_id = ?) AND (c.is_private = 0 OR c.user_id = ?) AND e.calendar_id IN ($placeholders)";
             if ($filterTime) {
                 $sql .= ' AND e.start_time < :end AND e.end_time > :start';
             }
@@ -92,7 +92,7 @@ try {
             }
             $stmt->execute();
         } else {
-            $sql = 'SELECT e.id, e.calendar_id, e.title, e.start_time, e.end_time, e.link_module, e.link_record_id, e.user_id, e.event_type_id, e.visibility_id, c.is_private, c.user_id AS calendar_user_id FROM module_calendar_events e JOIN module_calendar c ON e.calendar_id = c.id WHERE (e.visibility_id = 198 OR e.user_id = ?) AND (c.is_private = 0 OR c.user_id = ?)';
+            $sql = 'SELECT e.id, e.calendar_id, e.title, e.memo, e.start_time, e.end_time, e.link_module, e.link_record_id, e.user_id, e.event_type_id, e.visibility_id, c.user_id AS calendar_user_id FROM module_calendar_events e JOIN module_calendar c ON e.calendar_id = c.id WHERE (e.visibility_id = 198 OR e.user_id = ?) AND (c.is_private = 0 OR c.user_id = ?)';
             if ($filterTime) {
                 $sql .= ' AND e.start_time < :end AND e.end_time > :start';
             }
@@ -122,6 +122,7 @@ try {
             'id' => (int)$row['id'],
             'calendar_id' => (int)$row['calendar_id'],
             'title' => $row['title'],
+            'description' => $row['memo'],
             'start' => $row['start_time'],
             'end' => $row['end_time'],
             'related_module' => $row['link_module'],
@@ -130,7 +131,7 @@ try {
             'visibility_id' => $visibility,
             'user_id' => (int)$row['user_id'],
             'calendar_user_id' => (int)$row['calendar_user_id'],
-            'is_private' => (int)$row['is_private']
+            'is_private' => $visibility === 199 ? 1 : 0
         ];
     }
 } catch (Exception $e) {

--- a/module/calendar/functions/update.php
+++ b/module/calendar/functions/update.php
@@ -7,6 +7,7 @@ header('Content-Type: application/json');
 
 $id = (int)($_POST['id'] ?? 0);
 $title = trim($_POST['title'] ?? '');
+$memo = trim($_POST['memo'] ?? '');
 
 $start_time = $_POST['start_time'] ?? null;
 $end_time = $_POST['end_time'] ?? null;
@@ -55,6 +56,7 @@ if ($id && $title && $start_time && $calendar_id) {
     'user_updated = :user_updated',
     'calendar_id = :calendar_id',
     'title = :title',
+    'memo = :memo',
     'start_time = :start_time',
     'end_time = :end_time',
     'link_module = :link_module',
@@ -66,6 +68,7 @@ if ($id && $title && $start_time && $calendar_id) {
     ':user_updated' => $this_user_id,
     ':calendar_id' => $calendar_id,
     ':title' => $title,
+    ':memo' => $memo,
     ':start_time' => $start_time,
     ':end_time' => $end_time,
     ':link_module' => $link_module,
@@ -101,6 +104,7 @@ if ($id && $title && $start_time && $calendar_id) {
     'id' => $id,
     'calendar_id' => $calendar_id,
     'title' => $title,
+    'description' => $memo,
     'start' => $start_time,
     'end' => $end_time,
     'visibility_id' => $visibility_id,


### PR DESCRIPTION
## Summary
- Handle memo field in calendar event create and update functions
- Return memo in calendar list API and compute privacy from visibility

## Testing
- `php -l module/calendar/functions/create.php`
- `php -l module/calendar/functions/update.php`
- `php -l module/calendar/functions/list.php`
- `php module/calendar/tests/create_unauthorized_403_test.php`


------
https://chatgpt.com/codex/tasks/task_e_68aff952786c8333902457bcccf55f49