### PR TITLE
Close cURL handles reliably in calendar event fetchers

### DIFF
--- a/module/calendar/functions/google_events.php
+++ b/module/calendar/functions/google_events.php
@@ -42,7 +42,7 @@ function fetch_google_events(PDO $pdo, int $userId): array {
                 }
                 curl_close($ch);
             } catch (Exception $e) {
-                if (isset($ch) && is_resource($ch)) {
+                if (isset($ch)) {
                     curl_close($ch);
                 }
                 error_log($e->getMessage());
@@ -78,7 +78,7 @@ function fetch_google_events(PDO $pdo, int $userId): array {
         }
         curl_close($ch);
     } catch (Exception $e) {
-        if (isset($ch) && is_resource($ch)) {
+        if (isset($ch)) {
             curl_close($ch);
         }
         error_log($e->getMessage());

--- a/module/calendar/functions/microsoft_events.php
+++ b/module/calendar/functions/microsoft_events.php
@@ -42,7 +42,7 @@ function fetch_microsoft_events(PDO $pdo, int $userId): array {
                 }
                 curl_close($ch);
             } catch (Exception $e) {
-                if (isset($ch) && is_resource($ch)) {
+                if (isset($ch)) {
                     curl_close($ch);
                 }
                 error_log($e->getMessage());
@@ -78,7 +78,7 @@ function fetch_microsoft_events(PDO $pdo, int $userId): array {
         }
         curl_close($ch);
     } catch (Exception $e) {
-        if (isset($ch) && is_resource($ch)) {
+        if (isset($ch)) {
             curl_close($ch);
         }
         error_log($e->getMessage());


### PR DESCRIPTION
## Summary
- Simplify cURL cleanup in Google and Microsoft calendar event fetchers so handles always close on errors

## Testing
- `php -l module/calendar/functions/google_events.php`
- `php -l module/calendar/functions/microsoft_events.php`


------
https://chatgpt.com/codex/tasks/task_e_68b002104b04833399425d2c24f651b9