### PR TITLE
Fix calendar selection logic and event details editing

### DIFF
--- a/module/calendar/include/calendar_view.php
+++ b/module/calendar/include/calendar_view.php
@@ -427,23 +427,21 @@ document.addEventListener('DOMContentLoaded', function() {
         sidebar.appendChild(div);
       });
     }
-    function ensureSelected() {
-      const anyChecked = sidebar.querySelector('.calendar-checkbox:checked');
-      if (!anyChecked) {
-        const firstCb = sidebar.querySelector('.calendar-checkbox');
-        if (firstCb) firstCb.checked = true;
+    function ensureSelected(changed) {
+      if (!sidebar.querySelector('.calendar-checkbox:checked')) {
+        changed.checked = true;
       }
     }
     sidebar.querySelectorAll('.calendar-checkbox').forEach(cb => {
       cb.addEventListener('change', () => {
-        ensureSelected();
+        ensureSelected(cb);
         calendar.refetchEvents();
         if (addEventForm) {
           selectCalendarRadio(addEventForm, getCalendarId());
         }
       });
     });
-    ensureSelected();
+    ensureSelected(sidebar.querySelector('.calendar-checkbox'));
     if (addEventForm) {
       selectCalendarRadio(addEventForm, getCalendarId());
     }


### PR DESCRIPTION
## Summary
- Prevent unchecking all calendars by re-enabling the last toggled checkbox
- Always show event details modal and only allow editing when authorized

## Testing
- `php module/calendar/tests/create_unauthorized_403_test.php`


------
https://chatgpt.com/codex/tasks/task_e_68b004e4682083338d89dd524d9ef381