### PR TITLE
Enhance corporate finance invoicing and time tracking

### DIFF
--- a/admin/corporate/finances/invoices/functions/add_item.php
+++ b/admin/corporate/finances/invoices/functions/add_item.php
@@ -2,6 +2,7 @@
 if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../../includes/php_header.php';
 require_permission('admin_finances_invoices','update');
+require_once __DIR__ . '/utils.php';
 header('Content-Type: application/json');
 
 $invoice_id = $_POST['invoice_id'] ?? null;
@@ -26,5 +27,7 @@ $stmt->execute([
   ':amt'=>$amount,
   ':teid'=>$time_entry_id
 ]);
+
+recalc_invoice_total($pdo, (int)$invoice_id, $this_user_id);
 
 echo json_encode(['success'=>true,'id'=>$pdo->lastInsertId()]);

--- a/admin/corporate/finances/invoices/functions/create.php
+++ b/admin/corporate/finances/invoices/functions/create.php
@@ -8,8 +8,12 @@ $invoice_number = trim($_POST['invoice_number'] ?? '');
 $status_id = $_POST['status_id'] ?? null;
 $bill_to = trim($_POST['bill_to'] ?? '');
 $invoice_date = $_POST['invoice_date'] ?? null;
+$period_start = $_POST['period_start'] ?? null;
+$period_end = $_POST['period_end'] ?? null;
 $due_date = $_POST['due_date'] ?? null;
 $total_amount = $_POST['total_amount'] ?? null;
+$agency_id = $_POST['agency_id'] ?? null;
+$division_id = $_POST['division_id'] ?? null;
 $corporate_id = $_POST['corporate_id'] ?? 1;
 
 $file_name = null;
@@ -39,14 +43,18 @@ if(!empty($_FILES['file']) && $_FILES['file']['error'] === UPLOAD_ERR_OK){
   }
 }
 
-$stmt = $pdo->prepare('INSERT INTO admin_finances_invoices (user_id, corporate_id, invoice_number, status_id, bill_to, invoice_date, due_date, total_amount, file_name, file_path, file_size, file_type) VALUES (:uid, :cid, :invoice_number, :status_id, :bill_to, :invoice_date, :due_date, :total_amount, :fname, :fpath, :fsize, :ftype)');
+$stmt = $pdo->prepare('INSERT INTO admin_finances_invoices (user_id, corporate_id, invoice_number, agency_id, division_id, status_id, bill_to, invoice_date, period_start, period_end, due_date, total_amount, file_name, file_path, file_size, file_type) VALUES (:uid, :cid, :invoice_number, :agency_id, :division_id, :status_id, :bill_to, :invoice_date, :period_start, :period_end, :due_date, :total_amount, :fname, :fpath, :fsize, :ftype)');
 $stmt->execute([
   ':uid' => $this_user_id,
   ':cid' => $corporate_id,
   ':invoice_number' => $invoice_number,
+  ':agency_id' => $agency_id,
+  ':division_id' => $division_id,
   ':status_id' => $status_id,
   ':bill_to' => $bill_to,
   ':invoice_date' => $invoice_date,
+  ':period_start' => $period_start,
+  ':period_end' => $period_end,
   ':due_date' => $due_date,
   ':total_amount' => $total_amount,
   ':fname' => $file_name,

--- a/admin/corporate/finances/invoices/functions/delete_item.php
+++ b/admin/corporate/finances/invoices/functions/delete_item.php
@@ -2,6 +2,7 @@
 if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../../includes/php_header.php';
 require_permission('admin_finances_invoices','delete');
+require_once __DIR__ . '/utils.php';
 header('Content-Type: application/json');
 
 $id = $_POST['id'] ?? null;
@@ -10,7 +11,15 @@ if(!$id){
   exit;
 }
 
+$invStmt = $pdo->prepare('SELECT invoice_id FROM admin_finances_invoice_items WHERE id=:id');
+$invStmt->execute([':id'=>$id]);
+$invoice_id = $invStmt->fetchColumn();
+
 $stmt = $pdo->prepare('DELETE FROM admin_finances_invoice_items WHERE id=:id');
 $stmt->execute([':id'=>$id]);
+
+if($invoice_id){
+  recalc_invoice_total($pdo,(int)$invoice_id,$this_user_id);
+}
 
 echo json_encode(['success'=>true]);

--- a/admin/corporate/finances/invoices/functions/link_time.php
+++ b/admin/corporate/finances/invoices/functions/link_time.php
@@ -2,6 +2,7 @@
 if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../../includes/php_header.php';
 require_permission('admin_finances_invoices','update');
+require_once __DIR__ . '/utils.php';
 header('Content-Type: application/json');
 
 $invoice_id = $_POST['invoice_id'] ?? null;
@@ -13,5 +14,7 @@ if(!$invoice_id || !$time_entry_id){
 
 $upd = $pdo->prepare('UPDATE admin_time_tracking_entries SET invoice_id=:iid, user_updated=:uid WHERE id=:tid');
 $upd->execute([':iid'=>$invoice_id,':uid'=>$this_user_id,':tid'=>$time_entry_id]);
+
+recalc_invoice_total($pdo,(int)$invoice_id,$this_user_id);
 
 echo json_encode(['success'=>true]);

--- a/admin/corporate/finances/invoices/functions/unlink_time.php
+++ b/admin/corporate/finances/invoices/functions/unlink_time.php
@@ -2,6 +2,7 @@
 if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../../includes/php_header.php';
 require_permission('admin_finances_invoices','update');
+require_once __DIR__ . '/utils.php';
 header('Content-Type: application/json');
 
 $time_entry_id = $_POST['time_entry_id'] ?? null;
@@ -10,7 +11,15 @@ if(!$time_entry_id){
   exit;
 }
 
+$stmt = $pdo->prepare('SELECT invoice_id FROM admin_time_tracking_entries WHERE id=:tid');
+$stmt->execute([':tid'=>$time_entry_id]);
+$invoice_id = $stmt->fetchColumn();
+
 $upd = $pdo->prepare('UPDATE admin_time_tracking_entries SET invoice_id=NULL, user_updated=:uid WHERE id=:tid');
 $upd->execute([':uid'=>$this_user_id,':tid'=>$time_entry_id]);
+
+if($invoice_id){
+  recalc_invoice_total($pdo,(int)$invoice_id,$this_user_id);
+}
 
 echo json_encode(['success'=>true]);

--- a/admin/corporate/finances/invoices/functions/update.php
+++ b/admin/corporate/finances/invoices/functions/update.php
@@ -9,8 +9,12 @@ $invoice_number = trim($_POST['invoice_number'] ?? '');
 $status_id = $_POST['status_id'] ?? null;
 $bill_to = trim($_POST['bill_to'] ?? '');
 $invoice_date = $_POST['invoice_date'] ?? null;
+$period_start = $_POST['period_start'] ?? null;
+$period_end = $_POST['period_end'] ?? null;
 $due_date = $_POST['due_date'] ?? null;
 $total_amount = $_POST['total_amount'] ?? null;
+$agency_id = $_POST['agency_id'] ?? null;
+$division_id = $_POST['division_id'] ?? null;
 
 if (!$id || $invoice_number === '') {
   echo json_encode(['success' => false, 'error' => 'Invalid input']);
@@ -42,12 +46,16 @@ if(!empty($_FILES['file']) && $_FILES['file']['error'] === UPLOAD_ERR_OK){
   }
 }
 
-$stmt = $pdo->prepare('UPDATE admin_finances_invoices SET invoice_number = :invoice_number, status_id = :status_id, bill_to = :bill_to, invoice_date = :invoice_date, due_date = :due_date, total_amount = :total_amount, file_name=:fname, file_path=:fpath, file_size=:fsize, file_type=:ftype, user_updated = :uid WHERE id = :id');
+$stmt = $pdo->prepare('UPDATE admin_finances_invoices SET invoice_number = :invoice_number, agency_id=:agency_id, division_id=:division_id, status_id = :status_id, bill_to = :bill_to, invoice_date = :invoice_date, period_start=:period_start, period_end=:period_end, due_date = :due_date, total_amount = :total_amount, file_name=:fname, file_path=:fpath, file_size=:fsize, file_type=:ftype, user_updated = :uid WHERE id = :id');
 $stmt->execute([
   ':invoice_number' => $invoice_number,
+  ':agency_id' => $agency_id,
+  ':division_id' => $division_id,
   ':status_id' => $status_id,
   ':bill_to' => $bill_to,
   ':invoice_date' => $invoice_date,
+  ':period_start' => $period_start,
+  ':period_end' => $period_end,
   ':due_date' => $due_date,
   ':total_amount' => $total_amount,
   ':fname'=>$file_name,

--- a/admin/corporate/finances/invoices/functions/update_item.php
+++ b/admin/corporate/finances/invoices/functions/update_item.php
@@ -2,6 +2,7 @@
 if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../../includes/php_header.php';
 require_permission('admin_finances_invoices','update');
+require_once __DIR__ . '/utils.php';
 header('Content-Type: application/json');
 
 $id = $_POST['id'] ?? null;
@@ -10,11 +11,16 @@ $quantity = $_POST['quantity'] ?? null;
 $rate = $_POST['rate'] ?? null;
 $amount = $_POST['amount'] ?? null;
 $time_entry_id = $_POST['time_entry_id'] ?? null;
+$invoice_id = null;
 
 if(!$id || $description===''){
   echo json_encode(['success'=>false,'error'=>'Invalid input']);
   exit;
 }
+
+$invStmt = $pdo->prepare('SELECT invoice_id FROM admin_finances_invoice_items WHERE id=:id');
+$invStmt->execute([':id'=>$id]);
+$invoice_id = $invStmt->fetchColumn();
 
 $stmt = $pdo->prepare('UPDATE admin_finances_invoice_items SET description=:desc, quantity=:qty, rate=:rate, amount=:amt, time_entry_id=:teid, user_updated=:uid WHERE id=:id');
 $stmt->execute([
@@ -26,5 +32,9 @@ $stmt->execute([
   ':uid'=>$this_user_id,
   ':id'=>$id
 ]);
+
+if($invoice_id){
+  recalc_invoice_total($pdo,(int)$invoice_id,$this_user_id);
+}
 
 echo json_encode(['success'=>true]);

--- a/admin/corporate/finances/invoices/functions/utils.php
+++ b/admin/corporate/finances/invoices/functions/utils.php
@@ -1,0 +1,15 @@
+<?php
+function recalc_invoice_total(PDO $pdo, int $invoice_id, int $user_id): void {
+    $stmt = $pdo->prepare('SELECT COALESCE(SUM(amount),0) FROM admin_finances_invoice_items WHERE invoice_id = :id');
+    $stmt->execute([':id'=>$invoice_id]);
+    $itemTotal = (float)$stmt->fetchColumn();
+
+    $stmt = $pdo->prepare('SELECT COALESCE(SUM(hours*rate),0) FROM admin_time_tracking_entries WHERE invoice_id = :id');
+    $stmt->execute([':id'=>$invoice_id]);
+    $timeTotal = (float)$stmt->fetchColumn();
+
+    $total = $itemTotal + $timeTotal;
+    $upd = $pdo->prepare('UPDATE admin_finances_invoices SET total_amount = :total, user_updated = :uid WHERE id = :id');
+    $upd->execute([':total'=>$total, ':uid'=>$user_id, ':id'=>$invoice_id]);
+}
+?>

--- a/admin/corporate/finances/statements-of-work/functions/create.php
+++ b/admin/corporate/finances/statements-of-work/functions/create.php
@@ -5,6 +5,7 @@ require_permission('admin_finances_statements_of_work','create');
 header('Content-Type: application/json');
 
 $title = trim($_POST['title'] ?? '');
+$description = trim($_POST['description'] ?? '');
 $start_date = $_POST['start_date'] ?? null;
 $end_date = $_POST['end_date'] ?? null;
 $status_id = $_POST['status_id'] ?? null;
@@ -37,11 +38,12 @@ if(!empty($_FILES['file']) && $_FILES['file']['error'] === UPLOAD_ERR_OK){
   }
 }
 
-$stmt = $pdo->prepare('INSERT INTO admin_finances_statements_of_work (user_id, corporate_id, title, start_date, end_date, status_id, file_name, file_path, file_size, file_type) VALUES (:uid, :cid, :title, :start_date, :end_date, :status_id, :fname, :fpath, :fsize, :ftype)');
+$stmt = $pdo->prepare('INSERT INTO admin_finances_statements_of_work (user_id, corporate_id, title, description, start_date, end_date, status_id, file_name, file_path, file_size, file_type) VALUES (:uid, :cid, :title, :description, :start_date, :end_date, :status_id, :fname, :fpath, :fsize, :ftype)');
 $stmt->execute([
   ':uid' => $this_user_id,
   ':cid' => $corporate_id,
   ':title' => $title,
+  ':description' => $description,
   ':start_date' => $start_date,
   ':end_date' => $end_date,
   ':status_id' => $status_id,

--- a/admin/corporate/finances/statements-of-work/functions/link_invoice.php
+++ b/admin/corporate/finances/statements-of-work/functions/link_invoice.php
@@ -11,6 +11,17 @@ if(!$statement_id || !$invoice_id){
   exit;
 }
 
+$sCorp = $pdo->prepare('SELECT corporate_id FROM admin_finances_statements_of_work WHERE id=:sid');
+$sCorp->execute([':sid'=>$statement_id]);
+$sowCorp = $sCorp->fetchColumn();
+$iCorp = $pdo->prepare('SELECT corporate_id FROM admin_finances_invoices WHERE id=:iid');
+$iCorp->execute([':iid'=>$invoice_id]);
+$invCorp = $iCorp->fetchColumn();
+if(!$sowCorp || !$invCorp || $sowCorp != $invCorp){
+  echo json_encode(['success'=>false,'error'=>'Corporate mismatch']);
+  exit;
+}
+
 $stmt = $pdo->prepare('SELECT id FROM admin_finances_invoice_sow WHERE invoice_id=:iid AND statement_id=:sid');
 $stmt->execute([':iid'=>$invoice_id,':sid'=>$statement_id]);
 if(!$stmt->fetch()){

--- a/admin/corporate/finances/statements-of-work/functions/unlink_invoice.php
+++ b/admin/corporate/finances/statements-of-work/functions/unlink_invoice.php
@@ -11,6 +11,17 @@ if(!$statement_id || !$invoice_id){
   exit;
 }
 
+$sCorp = $pdo->prepare('SELECT corporate_id FROM admin_finances_statements_of_work WHERE id=:sid');
+$sCorp->execute([':sid'=>$statement_id]);
+$sowCorp = $sCorp->fetchColumn();
+$iCorp = $pdo->prepare('SELECT corporate_id FROM admin_finances_invoices WHERE id=:iid');
+$iCorp->execute([':iid'=>$invoice_id]);
+$invCorp = $iCorp->fetchColumn();
+if(!$sowCorp || !$invCorp || $sowCorp != $invCorp){
+  echo json_encode(['success'=>false,'error'=>'Corporate mismatch']);
+  exit;
+}
+
 $del = $pdo->prepare('DELETE FROM admin_finances_invoice_sow WHERE invoice_id=:iid AND statement_id=:sid');
 $del->execute([':iid'=>$invoice_id,':sid'=>$statement_id]);
 

--- a/admin/corporate/finances/statements-of-work/functions/update.php
+++ b/admin/corporate/finances/statements-of-work/functions/update.php
@@ -6,6 +6,7 @@ header('Content-Type: application/json');
 
 $id = $_POST['id'] ?? null;
 $title = trim($_POST['title'] ?? '');
+$description = trim($_POST['description'] ?? '');
 $start_date = $_POST['start_date'] ?? null;
 $end_date = $_POST['end_date'] ?? null;
 $status_id = $_POST['status_id'] ?? null;
@@ -40,9 +41,10 @@ if(!empty($_FILES['file']) && $_FILES['file']['error'] === UPLOAD_ERR_OK){
   }
 }
 
-$stmt = $pdo->prepare('UPDATE admin_finances_statements_of_work SET title=:title, start_date=:start_date, end_date=:end_date, status_id=:status_id, file_name=:fname, file_path=:fpath, file_size=:fsize, file_type=:ftype, user_updated=:uid WHERE id=:id');
+$stmt = $pdo->prepare('UPDATE admin_finances_statements_of_work SET title=:title, description=:description, start_date=:start_date, end_date=:end_date, status_id=:status_id, file_name=:fname, file_path=:fpath, file_size=:fsize, file_type=:ftype, user_updated=:uid WHERE id=:id');
 $stmt->execute([
   ':title' => $title,
+  ':description' => $description,
   ':start_date' => $start_date,
   ':end_date' => $end_date,
   ':status_id' => $status_id,

--- a/admin/corporate/time-tracking/functions/link_invoice.php
+++ b/admin/corporate/time-tracking/functions/link_invoice.php
@@ -2,20 +2,23 @@
 if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
 require_permission('admin_time_tracking','link_invoice');
+require_once __DIR__ . '/../../finances/invoices/functions/utils.php';
 header('Content-Type: application/json');
 
-$id = $_POST['id'] ?? null;
+$ids = $_POST['ids'] ?? [];
 $invoice_id = $_POST['invoice_id'] ?? null;
-if (!$id || !$invoice_id) {
-  echo json_encode(['success' => false, 'error' => 'Missing fields']);
+if(!is_array($ids)){$ids = [$ids];}
+$ids = array_filter($ids);
+if(!$invoice_id || empty($ids)){
+  echo json_encode(['success'=>false,'error'=>'Missing fields']);
   exit;
 }
 
-$stmt = $pdo->prepare('UPDATE admin_time_tracking_entries SET invoice_id = :invoice_id, user_updated = :uid WHERE id = :id');
-$stmt->execute([
-  ':invoice_id' => $invoice_id,
-  ':uid' => $this_user_id,
-  ':id' => $id
-]);
+$placeholders = implode(',', array_fill(0, count($ids), '?'));
+$params = array_merge([$invoice_id,$this_user_id], $ids);
+$stmt = $pdo->prepare("UPDATE admin_time_tracking_entries SET invoice_id = ?, user_updated = ? WHERE id IN ($placeholders)");
+$stmt->execute($params);
 
-echo json_encode(['success' => true]);
+recalc_invoice_total($pdo,(int)$invoice_id,$this_user_id);
+
+echo json_encode(['success'=>true]);

--- a/admin/corporate/time-tracking/functions/unlink_invoice.php
+++ b/admin/corporate/time-tracking/functions/unlink_invoice.php
@@ -2,18 +2,27 @@
 if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
 require_permission('admin_time_tracking','unlink_invoice');
+require_once __DIR__ . '/../../finances/invoices/functions/utils.php';
 header('Content-Type: application/json');
 
-$id = $_POST['id'] ?? null;
-if (!$id) {
-  echo json_encode(['success' => false, 'error' => 'Missing id']);
+$ids = $_POST['ids'] ?? [];
+if(!is_array($ids)){$ids = [$ids];}
+$ids = array_filter($ids);
+if(empty($ids)){
+  echo json_encode(['success'=>false,'error'=>'Missing id']);
   exit;
 }
 
-$stmt = $pdo->prepare('UPDATE admin_time_tracking_entries SET invoice_id = NULL, user_updated = :uid WHERE id = :id');
-$stmt->execute([
-  ':uid' => $this_user_id,
-  ':id' => $id
-]);
+$placeholders = implode(',', array_fill(0, count($ids), '?'));
+$stmt = $pdo->prepare("SELECT DISTINCT invoice_id FROM admin_time_tracking_entries WHERE id IN ($placeholders)");
+$stmt->execute($ids);
+$invIds = $stmt->fetchAll(PDO::FETCH_COLUMN);
 
-echo json_encode(['success' => true]);
+$upd = $pdo->prepare("UPDATE admin_time_tracking_entries SET invoice_id = NULL, user_updated = ? WHERE id IN ($placeholders)");
+$upd->execute(array_merge([$this_user_id], $ids));
+
+foreach($invIds as $iid){
+  if($iid){ recalc_invoice_total($pdo,(int)$iid,$this_user_id); }
+}
+
+echo json_encode(['success'=>true]);


### PR DESCRIPTION
## Summary
- add agency/division selections, period dates, status dropdown, file links, and searchable item linking for invoices
- support descriptions, status dropdown, and corporate-owned invoice linking for Statements of Work
- show rate and amount, filter by invoice, and bulk attach/detach time entries while recalculating invoice totals

## Testing
- `php -l admin/corporate/finances/invoices/functions/utils.php`
- `php -l admin/corporate/finances/invoices/index.php`
- `php -l admin/corporate/finances/statements-of-work/index.php`
- `php -l admin/corporate/time-tracking/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0049895b88333841a1db3efc34c3c