### PR TITLE
Improve meeting quick-add and search UX

### DIFF
--- a/admin/meetings/functions/search.php
+++ b/admin/meetings/functions/search.php
@@ -5,7 +5,12 @@ require_permission('meeting', 'read');
 header('Content-Type: application/json');
 
 $q = trim($_GET['q'] ?? '');
-$stmt = $pdo->prepare('SELECT id, title, start_time FROM module_meetings WHERE title LIKE :q ORDER BY start_time DESC');
+if ($q === '') {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'message' => 'Query required']);
+    exit;
+}
+$stmt = $pdo->prepare('SELECT id, title, start_time FROM module_meetings WHERE title LIKE :q ORDER BY start_time DESC LIMIT 20');
 $stmt->execute([':q' => "%" . $q . "%"]);
 $meetings = $stmt->fetchAll(PDO::FETCH_ASSOC);
 foreach ($meetings as &$m) {


### PR DESCRIPTION
## Summary
- Debounce meeting search and reset list on empty queries.
- Handle quick-add submission state and error responses.
- Require non-empty search query server-side with limit.

## Testing
- `php -l admin/meetings/include/list_view.php`
- `php -l admin/meetings/functions/search.php`


------
https://chatgpt.com/codex/tasks/task_e_68b075e967548333b01a539736e9101b