### PR TITLE
Use lookup_default_id for meetings and validate linked records

### DIFF
--- a/admin/meetings/functions/update.php
+++ b/admin/meetings/functions/update.php
@@ -19,6 +19,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   $meeting_status_id = isset($_POST['status_id']) && $_POST['status_id'] !== '' ? (int)$_POST['status_id'] : null;
   $meeting_type_id   = isset($_POST['type_id']) && $_POST['type_id'] !== '' ? (int)$_POST['type_id'] : null;
   $calendar_event_id = isset($_POST['calendar_event_id']) && $_POST['calendar_event_id'] !== '' ? (int)$_POST['calendar_event_id'] : null;
+  if (!$meeting_status_id) {
+    $meeting_status_id = lookup_default_id($pdo, 'MEETING_STATUS');
+  }
+  if (!$meeting_type_id) {
+    $meeting_type_id = lookup_default_id($pdo, 'MEETING_TYPE');
+  }
 
   $errors = [];
   if ($title === '') {
@@ -61,13 +67,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
       $agendaStmt = $pdo->prepare('INSERT INTO module_meeting_agenda (user_id, user_updated, meeting_id, order_index, title, status_id, linked_task_id, linked_project_id) VALUES (:uid,:uid,:mid,:order_index,:title,:status_id,:task_id,:project_id)');
       $agenda_count = count($agenda_titles);
+      $defaultAgendaStatusId = $agenda_count ? lookup_default_id($pdo, 'MEETING_AGENDA_STATUS') : null;
+      $taskCheckStmt = $pdo->prepare('SELECT id FROM module_tasks WHERE id = ?');
+      $projectCheckStmt = $pdo->prepare('SELECT id FROM module_projects WHERE id = ?');
       for ($i = 0; $i < $agenda_count; $i++) {
         $aTitle = trim($agenda_titles[$i] ?? '');
         if ($aTitle === '') { continue; }
         $order_index = isset($agenda_order_indexes[$i]) && $agenda_order_indexes[$i] !== '' ? (int)$agenda_order_indexes[$i] : $i + 1;
-        $status_id = isset($agenda_status_ids[$i]) && $agenda_status_ids[$i] !== '' ? (int)$agenda_status_ids[$i] : null;
+        $status_id = isset($agenda_status_ids[$i]) && $agenda_status_ids[$i] !== '' ? (int)$agenda_status_ids[$i] : $defaultAgendaStatusId;
         $task_id = isset($agenda_linked_task_ids[$i]) && $agenda_linked_task_ids[$i] !== '' ? (int)$agenda_linked_task_ids[$i] : null;
+        if ($task_id) {
+          $taskCheckStmt->execute([$task_id]);
+          if (!$taskCheckStmt->fetchColumn()) { $task_id = null; }
+        }
         $project_id = isset($agenda_linked_project_ids[$i]) && $agenda_linked_project_ids[$i] !== '' ? (int)$agenda_linked_project_ids[$i] : null;
+        if ($project_id) {
+          $projectCheckStmt->execute([$project_id]);
+          if (!$projectCheckStmt->fetchColumn()) { $project_id = null; }
+        }
         $agendaStmt->execute([
           ':uid' => $this_user_id,
           ':mid' => $id,
@@ -89,12 +106,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
       $questionStmt = $pdo->prepare('INSERT INTO module_meeting_questions (user_id, user_updated, meeting_id, agenda_id, question_text, answer_text, status_id) VALUES (:uid,:uid,:mid,:aid,:q,:a,:status)');
       $question_count = count($question_texts);
+      $defaultQuestionStatusId = $question_count ? lookup_default_id($pdo, 'MEETING_QUESTION_STATUS') : null;
       for ($i = 0; $i < $question_count; $i++) {
         $qText = trim($question_texts[$i] ?? '');
         if ($qText === '') { continue; }
         $aText = trim($answer_texts[$i] ?? '');
         $agenda_id = isset($question_agenda_ids[$i]) && $question_agenda_ids[$i] !== '' ? (int)$question_agenda_ids[$i] : null;
-        $status_id = isset($question_status_ids[$i]) && $question_status_ids[$i] !== '' ? (int)$question_status_ids[$i] : null;
+        $status_id = isset($question_status_ids[$i]) && $question_status_ids[$i] !== '' ? (int)$question_status_ids[$i] : $defaultQuestionStatusId;
         $questionStmt->execute([
           ':uid' => $this_user_id,
           ':mid' => $id,

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -24,4 +24,31 @@ function flash_message(string $message, string $type = 'success'): string {
     return '<div class="alert alert-' . $type . '">' . $msg . '</div>';
 }
 
+/**
+ * Fetch the default lookup list item ID for a given list name.
+ *
+ * A lookup item is considered the default when it has an attribute
+ * `attr_code` of `DEFAULT` with an `attr_value` of `true`.
+ *
+ * @param PDO    $pdo   PDO connection
+ * @param string $name  Lookup list name
+ * @return int|null     ID of the default lookup item or null if none found
+ */
+function lookup_default_id(PDO $pdo, string $name): ?int {
+    $sql = "SELECT li.id
+            FROM lookup_list_items li
+            JOIN lookup_lists l ON li.list_id = l.id
+            JOIN lookup_list_item_attributes a
+              ON a.item_id = li.id AND a.attr_code = 'DEFAULT'
+            WHERE l.name = :name
+              AND a.attr_value = 'true'
+              AND li.active_from <= CURDATE()
+              AND (li.active_to IS NULL OR li.active_to >= CURDATE())
+            LIMIT 1";
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute([':name' => $name]);
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
+    return $row['id'] ?? null;
+}
+
 ?>


### PR DESCRIPTION
## Summary
- add `lookup_default_id` helper to fetch default lookup items
- apply central default lookup logic across meeting creation and updates
- validate linked tasks/projects and agenda ownership when adding items/questions

## Testing
- `php -l includes/helpers.php`
- `php -l admin/meetings/functions/create.php`
- `php -l admin/meetings/functions/update.php`
- `php -l admin/meetings/functions/add_agenda_item.php`
- `php -l admin/meetings/functions/add_question.php`


------
https://chatgpt.com/codex/tasks/task_e_68b075e73a508333ad9a52a05f568019