### PR TITLE
Implement strategy notes, files, tags, collaborator endpoints

### DIFF
--- a/admin/corporate/strategy/functions/add_note.php
+++ b/admin/corporate/strategy/functions/add_note.php
@@ -3,4 +3,33 @@ if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
 require_permission('admin_strategy_notes', 'create');
 header('Content-Type: application/json');
-echo json_encode(['success' => false, 'error' => 'Not implemented']);
+// Validate input
+$strategyId = (int)($_POST['strategy_id'] ?? 0);
+$note       = trim($_POST['note'] ?? '');
+
+if(!$strategyId || $note === ''){
+  echo json_encode(['success'=>false,'error'=>'Missing data']);
+  exit;
+}
+
+// ensure strategy exists
+$chk = $pdo->prepare('SELECT id FROM module_strategy WHERE id = :id');
+$chk->execute([':id'=>$strategyId]);
+if(!$chk->fetchColumn()){
+  echo json_encode(['success'=>false,'error'=>'Invalid strategy']);
+  exit;
+}
+
+try {
+  $stmt = $pdo->prepare('INSERT INTO module_strategy_notes (user_id,user_updated,strategy_id,note) VALUES (:uid,:uid,:sid,:note)');
+  $stmt->execute([
+    ':uid'=>$this_user_id,
+    ':sid'=>$strategyId,
+    ':note'=>$note
+  ]);
+  $noteId = (int)$pdo->lastInsertId();
+  admin_audit_log($pdo,$this_user_id,'module_strategy_notes',$noteId,'CREATE',null,null,json_encode(['note'=>$note]));
+  echo json_encode(['success'=>true,'note'=>['id'=>$noteId,'note'=>$note]]);
+} catch(PDOException $e){
+  echo json_encode(['success'=>false,'error'=>'Database error']);
+}

--- a/admin/corporate/strategy/functions/add_tag.php
+++ b/admin/corporate/strategy/functions/add_tag.php
@@ -3,4 +3,36 @@ if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
 require_permission('admin_strategy', 'create');
 header('Content-Type: application/json');
-echo json_encode(['success' => false, 'error' => 'Not implemented']);
+$strategyId = (int)($_POST['strategy_id'] ?? 0);
+$tag        = trim($_POST['tag'] ?? '');
+
+if(!$strategyId || $tag === ''){
+  echo json_encode(['success'=>false,'error'=>'Missing data']);
+  exit;
+}
+
+// ensure strategy exists
+$chk = $pdo->prepare('SELECT id FROM module_strategy WHERE id = :id');
+$chk->execute([':id'=>$strategyId]);
+if(!$chk->fetchColumn()){
+  echo json_encode(['success'=>false,'error'=>'Invalid strategy']);
+  exit;
+}
+
+// prevent duplicate tags for same strategy
+$dup = $pdo->prepare('SELECT id FROM module_strategy_tags WHERE strategy_id = :sid AND tag = :tag');
+$dup->execute([':sid'=>$strategyId, ':tag'=>$tag]);
+if($dup->fetchColumn()){
+  echo json_encode(['success'=>false,'error'=>'Tag exists']);
+  exit;
+}
+
+$stmt = $pdo->prepare('INSERT INTO module_strategy_tags (user_id,user_updated,strategy_id,tag) VALUES (:uid,:uid,:sid,:tag)');
+$stmt->execute([
+  ':uid'=>$this_user_id,
+  ':sid'=>$strategyId,
+  ':tag'=>$tag
+]);
+$tagId = (int)$pdo->lastInsertId();
+admin_audit_log($pdo,$this_user_id,'module_strategy_tags',$tagId,'CREATE',null,null,json_encode(['tag'=>$tag]));
+echo json_encode(['success'=>true,'tag'=>['id'=>$tagId,'tag'=>$tag]]);

--- a/admin/corporate/strategy/functions/delete_file.php
+++ b/admin/corporate/strategy/functions/delete_file.php
@@ -3,4 +3,27 @@ if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
 require_permission('admin_strategy_files', 'delete');
 header('Content-Type: application/json');
-echo json_encode(['success' => false, 'error' => 'Not implemented']);
+$fileId     = (int)($_POST['id'] ?? 0);
+$strategyId = (int)($_POST['strategy_id'] ?? 0);
+
+if(!$fileId || !$strategyId){
+  echo json_encode(['success'=>false,'error'=>'Missing data']);
+  exit;
+}
+
+$stmt = $pdo->prepare('SELECT file_path FROM module_strategy_files WHERE id = :id AND strategy_id = :sid');
+$stmt->execute([':id'=>$fileId, ':sid'=>$strategyId]);
+$path = $stmt->fetchColumn();
+if(!$path){
+  echo json_encode(['success'=>false,'error'=>'Invalid file']);
+  exit;
+}
+
+$full = __DIR__ . '/../uploads/' . basename($path);
+if(is_file($full)){
+  unlink($full);
+}
+
+$pdo->prepare('DELETE FROM module_strategy_files WHERE id = :id')->execute([':id'=>$fileId]);
+admin_audit_log($pdo,$this_user_id,'module_strategy_files',$fileId,'DELETE','', '');
+echo json_encode(['success'=>true]);

--- a/admin/corporate/strategy/functions/delete_note.php
+++ b/admin/corporate/strategy/functions/delete_note.php
@@ -3,4 +3,22 @@ if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
 require_permission('admin_strategy_notes', 'delete');
 header('Content-Type: application/json');
-echo json_encode(['success' => false, 'error' => 'Not implemented']);
+$noteId     = (int)($_POST['id'] ?? 0);
+$strategyId = (int)($_POST['strategy_id'] ?? 0);
+
+if(!$noteId || !$strategyId){
+  echo json_encode(['success'=>false,'error'=>'Missing data']);
+  exit;
+}
+
+// verify note belongs to strategy
+$stmt = $pdo->prepare('SELECT id FROM module_strategy_notes WHERE id = :id AND strategy_id = :sid');
+$stmt->execute([':id'=>$noteId, ':sid'=>$strategyId]);
+if(!$stmt->fetchColumn()){
+  echo json_encode(['success'=>false,'error'=>'Invalid note']);
+  exit;
+}
+
+$pdo->prepare('DELETE FROM module_strategy_notes WHERE id = :id')->execute([':id'=>$noteId]);
+admin_audit_log($pdo,$this_user_id,'module_strategy_notes',$noteId,'DELETE','', '');
+echo json_encode(['success'=>true]);

--- a/admin/corporate/strategy/functions/delete_tag.php
+++ b/admin/corporate/strategy/functions/delete_tag.php
@@ -3,4 +3,21 @@ if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
 require_permission('admin_strategy', 'delete');
 header('Content-Type: application/json');
-echo json_encode(['success' => false, 'error' => 'Not implemented']);
+$tagId      = (int)($_POST['id'] ?? 0);
+$strategyId = (int)($_POST['strategy_id'] ?? 0);
+
+if(!$tagId || !$strategyId){
+  echo json_encode(['success'=>false,'error'=>'Missing data']);
+  exit;
+}
+
+$stmt = $pdo->prepare('SELECT id FROM module_strategy_tags WHERE id = :id AND strategy_id = :sid');
+$stmt->execute([':id'=>$tagId, ':sid'=>$strategyId]);
+if(!$stmt->fetchColumn()){
+  echo json_encode(['success'=>false,'error'=>'Invalid tag']);
+  exit;
+}
+
+$pdo->prepare('DELETE FROM module_strategy_tags WHERE id = :id')->execute([':id'=>$tagId]);
+admin_audit_log($pdo,$this_user_id,'module_strategy_tags',$tagId,'DELETE','', '');
+echo json_encode(['success'=>true]);

--- a/admin/corporate/strategy/functions/remove_collaborator.php
+++ b/admin/corporate/strategy/functions/remove_collaborator.php
@@ -3,4 +3,22 @@ if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
 require_permission('admin_strategy', 'delete');
 header('Content-Type: application/json');
-echo json_encode(['success' => false, 'error' => 'Not implemented']);
+$id         = (int)($_POST['id'] ?? 0);
+$strategyId = (int)($_POST['strategy_id'] ?? 0);
+
+if(!$id || !$strategyId){
+  echo json_encode(['success'=>false,'error'=>'Missing data']);
+  exit;
+}
+
+$stmt = $pdo->prepare('SELECT person_id, role_id FROM module_strategy_collaborators WHERE id = :id AND strategy_id = :sid');
+$stmt->execute([':id'=>$id, ':sid'=>$strategyId]);
+$collab = $stmt->fetch(PDO::FETCH_ASSOC);
+if(!$collab){
+  echo json_encode(['success'=>false,'error'=>'Invalid collaborator']);
+  exit;
+}
+
+$pdo->prepare('DELETE FROM module_strategy_collaborators WHERE id = :id')->execute([':id'=>$id]);
+admin_audit_log($pdo,$this_user_id,'module_strategy_collaborators',$id,'DELETE',json_encode($collab),null);
+echo json_encode(['success'=>true]);

--- a/admin/corporate/strategy/functions/update_collaborator.php
+++ b/admin/corporate/strategy/functions/update_collaborator.php
@@ -3,4 +3,68 @@ if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
 require_permission('admin_strategy', 'update');
 header('Content-Type: application/json');
-echo json_encode(['success' => false, 'error' => 'Not implemented']);
+
+$id         = (int)($_POST['id'] ?? 0);
+$strategyId = (int)($_POST['strategy_id'] ?? 0);
+$personId   = isset($_POST['person_id']) && $_POST['person_id'] !== '' ? (int)$_POST['person_id'] : null;
+$roleId     = isset($_POST['role_id']) && $_POST['role_id'] !== '' ? (int)$_POST['role_id'] : null;
+
+if(!$id || !$strategyId){
+  echo json_encode(['success'=>false,'error'=>'Missing data']);
+  exit;
+}
+
+// fetch existing collaborator
+$stmt = $pdo->prepare('SELECT person_id, role_id FROM module_strategy_collaborators WHERE id = :id AND strategy_id = :sid');
+$stmt->execute([':id'=>$id, ':sid'=>$strategyId]);
+$existing = $stmt->fetch(PDO::FETCH_ASSOC);
+if(!$existing){
+  echo json_encode(['success'=>false,'error'=>'Invalid collaborator']);
+  exit;
+}
+
+if($roleId !== null){
+  $checkRole = $pdo->prepare('SELECT li.id FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE l.name = :name AND li.id = :id');
+  $checkRole->execute([':name'=>'CORPORATE_STRATEGY_ROLE',':id'=>$roleId]);
+  if(!$checkRole->fetchColumn()){
+    echo json_encode(['success'=>false,'error'=>'Invalid role']);
+    exit;
+  }
+}
+
+if($personId !== null){
+  $chkPerson = $pdo->prepare('SELECT id FROM person WHERE id = :pid');
+  $chkPerson->execute([':pid'=>$personId]);
+  if(!$chkPerson->fetchColumn()){
+    echo json_encode(['success'=>false,'error'=>'Invalid person']);
+    exit;
+  }
+  // avoid duplicates
+  $dup = $pdo->prepare('SELECT id FROM module_strategy_collaborators WHERE strategy_id = :sid AND person_id = :pid AND id != :id');
+  $dup->execute([':sid'=>$strategyId, ':pid'=>$personId, ':id'=>$id]);
+  if($dup->fetchColumn()){
+    echo json_encode(['success'=>false,'error'=>'Person already collaborator']);
+    exit;
+  }
+}
+
+$fields = [];
+$params = [':uid'=>$this_user_id, ':id'=>$id];
+if($personId !== null){ $fields[] = 'person_id = :pid'; $params[':pid'] = $personId; }
+if($roleId !== null){ $fields[] = 'role_id = :rid'; $params[':rid'] = $roleId; }
+
+if(empty($fields)){
+  echo json_encode(['success'=>false,'error'=>'Nothing to update']);
+  exit;
+}
+
+$sql = 'UPDATE module_strategy_collaborators SET user_updated = :uid, ' . implode(',', $fields) . ' WHERE id = :id';
+$pdo->prepare($sql)->execute($params);
+
+$newData = [
+  'person_id'=>$personId !== null ? $personId : $existing['person_id'],
+  'role_id'=>$roleId !== null ? $roleId : $existing['role_id']
+];
+admin_audit_log($pdo,$this_user_id,'module_strategy_collaborators',$id,'UPDATE',json_encode($existing),json_encode($newData));
+
+echo json_encode(['success'=>true]);

--- a/admin/corporate/strategy/functions/upload_file.php
+++ b/admin/corporate/strategy/functions/upload_file.php
@@ -3,4 +3,45 @@ if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
 require_permission('admin_strategy_files', 'create');
 header('Content-Type: application/json');
-echo json_encode(['success' => false, 'error' => 'Not implemented']);
+
+$strategyId = (int)($_POST['strategy_id'] ?? 0);
+if(!$strategyId || empty($_FILES['file']) || $_FILES['file']['error'] !== UPLOAD_ERR_OK){
+  echo json_encode(['success'=>false,'error'=>'Invalid data']);
+  exit;
+}
+
+// ensure strategy exists
+$chk = $pdo->prepare('SELECT id FROM module_strategy WHERE id = :id');
+$chk->execute([':id'=>$strategyId]);
+if(!$chk->fetchColumn()){
+  echo json_encode(['success'=>false,'error'=>'Invalid strategy']);
+  exit;
+}
+
+$uploadDir = __DIR__ . '/../uploads/';
+if(!is_dir($uploadDir)){
+  mkdir($uploadDir,0777,true);
+}
+
+$orig = $_FILES['file']['name'];
+$safe = preg_replace('/[^A-Za-z0-9._-]/','_', basename($orig));
+$targetName = 'strategy_' . $strategyId . '_' . time() . '_' . $safe;
+$targetPath = $uploadDir . $targetName;
+
+if(!move_uploaded_file($_FILES['file']['tmp_name'],$targetPath)){
+  echo json_encode(['success'=>false,'error'=>'Upload failed']);
+  exit;
+}
+
+$dbPath = 'admin/corporate/strategy/uploads/' . $targetName;
+
+$stmt = $pdo->prepare('INSERT INTO module_strategy_files (user_id,user_updated,strategy_id,file_name,file_path) VALUES (:uid,:uid,:sid,:name,:path)');
+$stmt->execute([
+  ':uid'=>$this_user_id,
+  ':sid'=>$strategyId,
+  ':name'=>$orig,
+  ':path'=>$dbPath
+]);
+$fileId = (int)$pdo->lastInsertId();
+admin_audit_log($pdo,$this_user_id,'module_strategy_files',$fileId,'UPLOAD','',json_encode(['file'=>$orig]));
+echo json_encode(['success'=>true,'file'=>['id'=>$fileId,'file_name'=>$orig,'file_path'=>getURLDir() . $dbPath]]);


### PR DESCRIPTION
## Summary
- add strategy note creation/deletion using prepared statements and audit logging
- implement file upload and deletion for strategies with sanitized filenames
- add tag creation/deletion endpoints with validation
- enable updating and removing strategy collaborators with permission checks

## Testing
- `php -l admin/corporate/strategy/functions/add_note.php`
- `php -l admin/corporate/strategy/functions/delete_note.php`
- `php -l admin/corporate/strategy/functions/upload_file.php`
- `php -l admin/corporate/strategy/functions/delete_file.php`
- `php -l admin/corporate/strategy/functions/add_tag.php`
- `php -l admin/corporate/strategy/functions/delete_tag.php`
- `php -l admin/corporate/strategy/functions/update_collaborator.php`
- `php -l admin/corporate/strategy/functions/remove_collaborator.php`


------
https://chatgpt.com/codex/tasks/task_e_68b075f81ef48333af8e7629eb18c991