### PR TITLE
Refactor calendar event listing query

### DIFF
--- a/module/calendar/functions/list.php
+++ b/module/calendar/functions/list.php
@@ -30,82 +30,52 @@ $end = $_GET['end'] ?? null;
 $filterTime = $start !== null && $end !== null;
 
 try {
-    if (user_has_role('Admin')) {
-        if (!empty($calendar_ids)) {
-            $placeholders = implode(',', array_fill(0, count($calendar_ids), '?'));
-            $sql = "SELECT e.id, e.calendar_id, e.title, e.memo, e.start_time, e.end_time, e.link_module, e.link_record_id, e.user_id, e.event_type_id, e.visibility_id, c.user_id AS calendar_user_id FROM module_calendar_events e JOIN module_calendar c ON e.calendar_id = c.id WHERE e.calendar_id IN ($placeholders)";
-            if ($filterTime) {
-                $sql .= ' AND e.start_time < :end AND e.end_time > :start';
-            }
-            $stmt = $pdo->prepare($sql);
-            $index = 1;
-            foreach ($calendar_ids as $id) {
-                $stmt->bindValue($index++, $id, PDO::PARAM_INT);
-            }
-            if ($filterTime) {
-                $stmt->bindValue(':start', $start, PDO::PARAM_STR);
-                $stmt->bindValue(':end', $end, PDO::PARAM_STR);
-            }
-            $stmt->execute();
-        } else {
-            $sql = 'SELECT e.id, e.calendar_id, e.title, e.memo, e.start_time, e.end_time, e.link_module, e.link_record_id, e.user_id, e.event_type_id, e.visibility_id, c.user_id AS calendar_user_id FROM module_calendar_events e JOIN module_calendar c ON e.calendar_id = c.id';
-            if ($filterTime) {
-                $sql .= ' WHERE e.start_time < :end AND e.end_time > :start';
-                $stmt = $pdo->prepare($sql);
-                $stmt->bindValue(':start', $start, PDO::PARAM_STR);
-                $stmt->bindValue(':end', $end, PDO::PARAM_STR);
-                $stmt->execute();
-            } else {
-                $stmt = $pdo->query($sql);
-            }
-        }
-    } else {
-        if (!empty($calendar_ids)) {
-            $placeholders = implode(',', array_fill(0, count($calendar_ids), '?'));
-            $chk = $pdo->prepare("SELECT id FROM module_calendar WHERE id IN ($placeholders) AND is_private = 1 AND user_id <> ?");
-            $chkIndex = 1;
-            foreach ($calendar_ids as $id) {
-                $chk->bindValue($chkIndex++, $id, PDO::PARAM_INT);
-            }
-            $chk->bindValue($chkIndex, $this_user_id, PDO::PARAM_INT);
-            $chk->execute();
-            if ($chk->fetch(PDO::FETCH_ASSOC)) {
-                http_response_code(403);
-                ob_clean();
-                echo json_encode(['error' => 'Access denied']);
-                exit;
-            }
-            $sql = "SELECT e.id, e.calendar_id, e.title, e.memo, e.start_time, e.end_time, e.link_module, e.link_record_id, e.user_id, e.event_type_id, e.visibility_id, c.user_id AS calendar_user_id FROM module_calendar_events e JOIN module_calendar c ON e.calendar_id = c.id WHERE (e.visibility_id = 198 OR e.user_id = ?) AND (c.is_private = 0 OR c.user_id = ?) AND e.calendar_id IN ($placeholders)";
-            if ($filterTime) {
-                $sql .= ' AND e.start_time < :end AND e.end_time > :start';
-            }
-            $stmt = $pdo->prepare($sql);
-            $idx = 1;
-            $stmt->bindValue($idx++, $this_user_id, PDO::PARAM_INT);
-            $stmt->bindValue($idx++, $this_user_id, PDO::PARAM_INT);
-            foreach ($calendar_ids as $id) {
-                $stmt->bindValue($idx++, $id, PDO::PARAM_INT);
-            }
-            if ($filterTime) {
-                $stmt->bindValue(':start', $start, PDO::PARAM_STR);
-                $stmt->bindValue(':end', $end, PDO::PARAM_STR);
-            }
-            $stmt->execute();
-        } else {
-            $sql = 'SELECT e.id, e.calendar_id, e.title, e.memo, e.start_time, e.end_time, e.link_module, e.link_record_id, e.user_id, e.event_type_id, e.visibility_id, c.user_id AS calendar_user_id FROM module_calendar_events e JOIN module_calendar c ON e.calendar_id = c.id WHERE (e.visibility_id = 198 OR e.user_id = ?) AND (c.is_private = 0 OR c.user_id = ?)';
-            if ($filterTime) {
-                $sql .= ' AND e.start_time < :end AND e.end_time > :start';
-            }
-            $stmt = $pdo->prepare($sql);
-            $stmt->bindValue(1, $this_user_id, PDO::PARAM_INT);
-            $stmt->bindValue(2, $this_user_id, PDO::PARAM_INT);
-            if ($filterTime) {
-                $stmt->bindValue(':start', $start, PDO::PARAM_STR);
-                $stmt->bindValue(':end', $end, PDO::PARAM_STR);
-            }
-            $stmt->execute();
+    $isAdmin = user_has_role('Admin');
+
+    if (!$isAdmin && !empty($calendar_ids)) {
+        $placeholders = implode(',', array_fill(0, count($calendar_ids), '?'));
+        $chkSql = "SELECT id FROM module_calendar WHERE id IN ($placeholders) AND is_private = 1 AND user_id <> ?";
+        $chkParams = array_merge($calendar_ids, [$this_user_id]);
+        $chk = $pdo->prepare($chkSql);
+        $chk->execute($chkParams);
+        if ($chk->fetch(PDO::FETCH_ASSOC)) {
+            http_response_code(403);
+            ob_clean();
+            echo json_encode(['error' => 'Access denied']);
+            exit;
         }
     }
+
+    $sql = 'SELECT e.id, e.calendar_id, e.title, e.memo, e.start_time, e.end_time, e.link_module, e.link_record_id, e.user_id, e.event_type_id, e.visibility_id, c.user_id AS calendar_user_id FROM module_calendar_events e JOIN module_calendar c ON e.calendar_id = c.id';
+
+    $where = [];
+    $params = [];
+
+    if (!$isAdmin) {
+        $where[] = '(e.visibility_id = 198 OR e.user_id = ?)';
+        $where[] = '(c.is_private = 0 OR c.user_id = ?)';
+        $params[] = $this_user_id;
+        $params[] = $this_user_id;
+    }
+
+    if (!empty($calendar_ids)) {
+        $placeholders = implode(',', array_fill(0, count($calendar_ids), '?'));
+        $where[] = "e.calendar_id IN ($placeholders)";
+        $params = array_merge($params, $calendar_ids);
+    }
+
+    if ($filterTime) {
+        $where[] = 'e.start_time < ? AND e.end_time > ?';
+        $params[] = $end;
+        $params[] = $start;
+    }
+
+    if ($where) {
+        $sql .= ' WHERE ' . implode(' AND ', $where);
+    }
+
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute($params);
 
     $dbEvents = $stmt->fetchAll(PDO::FETCH_ASSOC);
     if ($filterTime && empty($dbEvents)) {


### PR DESCRIPTION
## Summary
- Simplify event list retrieval by building base SQL and params once
- Consolidate Admin/non-Admin logic into dynamic WHERE clauses
- Maintain RBAC validation and external calendar merging

## Testing
- `php -l module/calendar/functions/list.php`


------
https://chatgpt.com/codex/tasks/task_e_68b075f08bac83338f68e71c532597ef