### PR TITLE
Show success toast before meeting quick-add redirect

### DIFF
--- a/admin/meetings/include/list_view.php
+++ b/admin/meetings/include/list_view.php
@@ -129,9 +129,14 @@ document.addEventListener('DOMContentLoaded', function(){
           return r.json();
         })
         .then(function(res){
-          if(res.success && (res.id || (res.meeting && res.meeting.id))){
-            var id = res.id || res.meeting.id;
-            window.location = 'index.php?action=edit&id=' + id;
+          if(res.success){
+            showToast('Meeting created','success');
+            var id = res.id || (res.meeting && res.meeting.id);
+            if(id){
+              setTimeout(function(){
+                window.location = 'index.php?action=edit&id=' + id;
+              }, 1000);
+            }
           } else {
             showToast('Creation failed','danger');
           }


### PR DESCRIPTION
## Summary
- show success toast on meeting creation
- delay redirect to edit view to display toast
- keep error toast and button re-enable

## Testing
- `php -l admin/meetings/include/list_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0d6ccf8408333875480e1a819ce00