### PR TITLE
Allow owners or admins to delete private calendars

### DIFF
--- a/module/calendar/functions/delete_calendar.php
+++ b/module/calendar/functions/delete_calendar.php
@@ -5,33 +5,36 @@ header('Content-Type: application/json');
 
 $id = (int)($_POST['id'] ?? 0);
 
-if ($id) {
-  $chk = $pdo->prepare('SELECT user_id, is_default, is_private FROM module_calendar WHERE id = ?');
-  $chk->execute([$id]);
-
-  $existing = $chk->fetch(PDO::FETCH_ASSOC);
-  if (!$existing) {
-    http_response_code(404);
-    exit;
-  }
-  if ($existing['user_id'] != $this_user_id && !user_has_role('Admin')) {
-    // Calendar deletions are limited to the owner; Admins may override.
-
-    http_response_code(403);
-    exit;
-  }
-  if (!empty($existing['is_default']) || !empty($existing['is_private'])) {
-    $error = !empty($existing['is_default'])
-      ? 'Cannot delete default calendar'
-      : 'Cannot delete private calendar';
-    echo json_encode(['success' => false, 'error' => $error]);
-    exit;
-  }
-  $stmt = $pdo->prepare('DELETE FROM module_calendar WHERE id = ? AND is_default = 0 AND is_private = 0');
-  $stmt->execute([$id]);
-  echo json_encode(['success' => true]);
+if (!$id) {
+  http_response_code(400);
+  echo json_encode(['success' => false, 'error' => 'Invalid calendar ID']);
   exit;
 }
 
-echo json_encode(['success' => false]);
+$chk = $pdo->prepare('SELECT user_id, is_default FROM module_calendar WHERE id = ?');
+$chk->execute([$id]);
+
+$existing = $chk->fetch(PDO::FETCH_ASSOC);
+if (!$existing) {
+  http_response_code(404);
+  echo json_encode(['success' => false, 'error' => 'Calendar not found']);
+  exit;
+}
+
+if ($existing['user_id'] != $this_user_id && !user_has_role('Admin')) {
+  // Calendar deletions are limited to the owner; Admins may override.
+  http_response_code(403);
+  echo json_encode(['success' => false, 'error' => 'Only the owner or an admin can delete this calendar']);
+  exit;
+}
+
+if (!empty($existing['is_default'])) {
+  http_response_code(400);
+  echo json_encode(['success' => false, 'error' => 'Cannot delete default calendar']);
+  exit;
+}
+
+$stmt = $pdo->prepare('DELETE FROM module_calendar WHERE id = ? AND is_default = 0');
+$stmt->execute([$id]);
+echo json_encode(['success' => true]);
 


### PR DESCRIPTION
## Summary
- Remove `is_private` restriction when deleting a calendar and keep `is_default` safeguard
- Add explicit JSON errors for missing ID, unauthorized access, not found, and default calendars
- Permit deletion only by the calendar owner or an Admin

## Testing
- `php -l module/calendar/functions/delete_calendar.php`
- `php module/calendar/tests/create_unauthorized_403_test.php`

------
https://chatgpt.com/codex/tasks/task_e_68b0d851cf6483338585f001393f5404