### PR TITLE
Use environment variables for database config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+DB_HOST=localhost
+DB_PORT=3306
+DB_NAME=atlis
+DB_USER=atlis_app
+DB_PASSWORD=change_this_password

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ includes/config.oauth.php
 !admin/corporate/time-tracking/uploads/.gitkeep
 !admin/corporate/strategy/uploads/
 !admin/corporate/strategy/uploads/.gitkeep
+# Environment configuration
+.env

--- a/_SQL/create_atlis_user.sql
+++ b/_SQL/create_atlis_user.sql
@@ -1,0 +1,8 @@
+-- Create application-specific MySQL user for Atlisware
+CREATE USER 'atlis_app'@'localhost' IDENTIFIED BY 'change_this_password';
+
+-- Grant minimal privileges required for application operations
+GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, INDEX, ALTER, CREATE TEMPORARY TABLES
+ON atlis.* TO 'atlis_app'@'localhost';
+
+FLUSH PRIVILEGES;

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -1,0 +1,27 @@
+# Environment Configuration
+
+Atlisware reads its database settings from environment variables or an optional `.env` file at the project root.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and update the values for your environment.
+2. The `.env` file is ignored by Git; do not commit it.
+3. In production, set the variables in the server's environment instead of using a `.env` file.
+
+### Required variables
+
+- `DB_HOST`
+- `DB_PORT`
+- `DB_NAME`
+- `DB_USER`
+- `DB_PASSWORD`
+
+## Database user
+
+Use `_SQL/create_atlis_user.sql` to provision a dedicated MySQL user with only the privileges needed by Atlisware:
+
+```sql
+SOURCE _SQL/create_atlis_user.sql;
+```
+
+Replace `change_this_password` with a strong password before running the script.

--- a/includes/config.php
+++ b/includes/config.php
@@ -6,12 +6,19 @@ require 'functions.php';
 // Add IDs here to restrict specific admin accounts
 $restricted_admin_ids = [];
 
+// Load environment variables from optional .env file
+$envFile = __DIR__ . '/../.env';
+$env = [];
+if (file_exists($envFile)) {
+    $env = parse_ini_file($envFile);
+}
+
 // DB Credentials
-define('DB_HOST', 'localhost');
-define('DB_USER', 'root');
-define('DB_NAME', 'atlis');
-define('DB_PASSWORD', '');
-define('DB_PORT', '3306');
+define('DB_HOST', $env['DB_HOST'] ?? getenv('DB_HOST') ?? 'localhost');
+define('DB_USER', $env['DB_USER'] ?? getenv('DB_USER') ?? '');
+define('DB_NAME', $env['DB_NAME'] ?? getenv('DB_NAME') ?? 'atlis');
+define('DB_PASSWORD', $env['DB_PASSWORD'] ?? getenv('DB_PASSWORD') ?? '');
+define('DB_PORT', $env['DB_PORT'] ?? getenv('DB_PORT') ?? '3306');
 
 // Contractors module upload configuration
 define('CONTRACTOR_UPLOAD_DIR', __DIR__ . '/../admin/contractors/uploads/');


### PR DESCRIPTION
## Summary
- Load database credentials from environment or optional `.env`
- Ignore `.env` and provide example file for local setup
- Add SQL script to create restricted MySQL user
- Document environment configuration and user provisioning

## Testing
- `php -l includes/config.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0deaf0df083339e3923b8a645253c