### PR TITLE
Secure session handling and auth redirects

### DIFF
--- a/module/users/functions/login.php
+++ b/module/users/functions/login.php
@@ -1,7 +1,4 @@
 <?php
-if (session_status() !== PHP_SESSION_ACTIVE) {
-  session_start();
-}
 require_once '../../../includes/php_header.php';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {

--- a/module/users/functions/logout.php
+++ b/module/users/functions/logout.php
@@ -16,10 +16,10 @@ if ($userId) {
   audit_log($pdo, $userId, 'users', $userId, 'LOGOUT', 'User logged out');
 }
 
-// Clear session and destroy
+// Rotate session ID then clear session and destroy
+session_regenerate_id(true);
 $_SESSION = [];
 session_unset();
 session_destroy();
-//session_regenerate_id(true);
 
 ?>

--- a/module/users/functions/verify_2fa.php
+++ b/module/users/functions/verify_2fa.php
@@ -1,8 +1,5 @@
 <?php
-if (session_status() !== PHP_SESSION_ACTIVE) {
-  session_start();
-}
-require_once '../../../includes/config.php';
+require_once '../../../includes/php_header.php';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   $code = $_POST['code'] ?? '';


### PR DESCRIPTION
## Summary
- Gate display errors behind `ATLIS_ENV` flag and configure secure session cookies
- Redirect unauthenticated users to login except for login and 2FA endpoints
- Regenerate session ID on logout and streamline login/2FA session handling

## Testing
- `php -l includes/php_header.php module/users/functions/logout.php module/users/functions/login.php module/users/functions/verify_2fa.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0deafc6408333963a7f2bed17f9df