### PR TITLE
Revamp calendar interface with theme layout

### DIFF
--- a/assets/css/calendar-override.css
+++ b/assets/css/calendar-override.css
@@ -1,0 +1,6 @@
+.fc-event,
+.fc-event-main {
+  background-color: var(--bs-body-bg) !important;
+  border: 1px solid var(--bs-border-color-translucent) !important;
+  color: inherit;
+}


### PR DESCRIPTION
## Summary
- Replace calendar wrapper with Phoenix template markup and new #appCalendar container
- Implement modal-dialog-centered event details modal populated via eventClick
- Customize FullCalendar navigation, headerToolbar false, and soft white event styling

## Testing
- `php -l module/calendar/include/calendar_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0dedb838083339a54fdb0ccc1df21