### PR TITLE
Use person-based attendee identification

### DIFF
--- a/admin/meetings/functions/get_attendees.php
+++ b/admin/meetings/functions/get_attendees.php
@@ -20,11 +20,12 @@ if (!verify_csrf_token($data['csrf_token'] ?? '')) {
 if ($meeting_id) {
     $stmt = $pdo->prepare(
         'SELECT a.id,
+                a.attendee_person_id,
                 a.attendee_user_id,
                 COALESCE(CONCAT(p.first_name, " ", p.last_name), u.email) AS name
          FROM module_meeting_attendees a
-         LEFT JOIN users u ON a.attendee_user_id = u.id
-         LEFT JOIN person p ON u.id = p.user_id
+         JOIN person p ON a.attendee_person_id = p.id
+         LEFT JOIN users u ON p.user_id = u.id
          WHERE a.meeting_id = ?
          ORDER BY name'
     );

--- a/admin/meetings/functions/remove_attendee.php
+++ b/admin/meetings/functions/remove_attendee.php
@@ -27,11 +27,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         $rosterStmt = $pdo->prepare(
             'SELECT a.id,
+                    a.attendee_person_id,
                     a.attendee_user_id,
                     COALESCE(CONCAT(p.first_name, " ", p.last_name), u.email) AS name
              FROM module_meeting_attendees a
-             LEFT JOIN users u ON a.attendee_user_id = u.id
-             LEFT JOIN person p ON u.id = p.user_id
+             JOIN person p ON a.attendee_person_id = p.id
+             LEFT JOIN users u ON p.user_id = u.id
              WHERE a.meeting_id = ?
              ORDER BY name'
         );


### PR DESCRIPTION
## Summary
- Accept `attendee_person_id` in meeting attendee APIs and derive the user's ID
- Join `person` and `users` when listing attendees and return `{id, attendee_person_id, attendee_user_id, name}` ordered by name
- Prevent duplicate attendees per meeting by checking `(meeting_id, attendee_person_id)`

## Testing
- `php -l admin/meetings/functions/add_attendee.php`
- `php -l admin/meetings/functions/remove_attendee.php`
- `php -l admin/meetings/functions/get_attendees.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0e120cc888333a8836b57f563f490