### PR TITLE
Add person search endpoint for meetings

### DIFF
--- a/admin/meetings/functions/search_people.php
+++ b/admin/meetings/functions/search_people.php
@@ -1,0 +1,17 @@
+<?php
+require '../../../includes/php_header.php';
+require_permission('person', 'read');
+
+header('Content-Type: application/json');
+
+$q = trim($_GET['q'] ?? '');
+if ($q === '') {
+    echo json_encode([]);
+    exit;
+}
+
+$stmt = $pdo->prepare('SELECT p.id, CONCAT(p.first_name, " ", p.last_name) AS name, p.user_id FROM person p WHERE CONCAT(p.first_name, " ", p.last_name) LIKE :q ORDER BY name LIMIT 10');
+$stmt->execute([':q' => "%" . $q . "%"]);
+
+echo json_encode($stmt->fetchAll(PDO::FETCH_ASSOC));
+


### PR DESCRIPTION
## Summary
- add search_people function to meetings to lookup people by full name

## Testing
- `php -l admin/meetings/functions/search_people.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0e121f22c83338591562dfac84506