### PR TITLE
Use person-based attendee search in meetings

### DIFF
--- a/admin/meetings/functions/search_people.php
+++ b/admin/meetings/functions/search_people.php
@@ -1,0 +1,16 @@
+<?php
+require '../../../includes/php_header.php';
+require_permission('person', 'read');
+
+header('Content-Type: application/json');
+
+$q = trim($_GET['q'] ?? '');
+if ($q === '') {
+    echo json_encode([]);
+    exit;
+}
+
+$stmt = $pdo->prepare('SELECT p.id, COALESCE(CONCAT(p.first_name, " ", p.last_name), u.email) AS name, p.user_id FROM person p LEFT JOIN users u ON p.user_id = u.id WHERE COALESCE(CONCAT(p.first_name, " ", p.last_name), u.email) LIKE :q ORDER BY name LIMIT 10');
+$stmt->execute([':q' => "%" . $q . "%"]);
+
+echo json_encode($stmt->fetchAll(PDO::FETCH_ASSOC));

--- a/admin/meetings/include/create_edit_view.php
+++ b/admin/meetings/include/create_edit_view.php
@@ -278,11 +278,15 @@ document.addEventListener('DOMContentLoaded', function(){
   var attendeeChoices;
   function syncHiddenAttendees(){
     attendeeHiddenInputs.innerHTML = '';
-    attendeeChoices.getValue(true).forEach(function(id){
+    attendeeChoices.getValue().forEach(function(item){
       var input = document.createElement('input');
       input.type = 'hidden';
-      input.name = 'attendee_user_id[]';
-      input.value = id;
+      input.name = 'attendee_person_id[]';
+      input.value = item.value;
+      input.dataset.personId = item.value;
+      if(item.customProperties && item.customProperties.user_id){
+        input.dataset.userId = item.customProperties.user_id;
+      }
       attendeeHiddenInputs.appendChild(input);
     });
   }
@@ -293,12 +297,12 @@ document.addEventListener('DOMContentLoaded', function(){
     attendeeSelect.addEventListener('search', function(event){
       var term = event.detail.value;
       if(!term){ return; }
-      fetch('functions/search_users.php?q=' + encodeURIComponent(term))
+      fetch('functions/search_people.php?q=' + encodeURIComponent(term))
         .then(r => r.ok ? r.json() : [])
         .then(function(users){
           attendeeChoices.clearChoices();
           attendeeChoices.setChoices(users.map(function(u){
-            return { value: u.id, label: u.name };
+            return { value: u.id, label: u.name, customProperties:{ user_id: u.user_id || '' } };
           }), 'value', 'label', true);
         });
     });
@@ -350,7 +354,12 @@ document.addEventListener('DOMContentLoaded', function(){
       .then(function(res){
         if(res.success && res.attendees && attendeeChoices){
           attendeeChoices.setChoices(res.attendees.map(function(a){
-            return { value: a.attendee_user_id, label: a.name, selected: true };
+            return {
+              value: a.attendee_person_id || a.person_id,
+              label: a.name,
+              selected: true,
+              customProperties:{ user_id: a.attendee_user_id || a.user_id || '' }
+            };
           }), 'value', 'label', false);
           syncHiddenAttendees();
         }


### PR DESCRIPTION
## Summary
- Switch meeting attendee lookup to new `search_people.php` endpoint and track custom user IDs
- Rename attendee fields to `attendee_person_id[]` and preload existing attendees with person/user metadata
- Render attendee roster entries with `data-person-id` and send person IDs in add/remove requests

## Testing
- `php -l admin/meetings/include/create_edit_view.php`
- `php -l admin/meetings/include/details_view.php`
- `php -l admin/meetings/functions/search_people.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0e123247c8333b5f26337433c398e