### PR TITLE
Enforce calendar list permissions

### DIFF
--- a/functions/list.php
+++ b/functions/list.php
@@ -3,6 +3,15 @@ if (!isset($pdo)) {
   require '../includes/php_header.php';
 }
 header('Content-Type: application/json');
+
+if (!user_has_permission('calendar', 'read')) {
+  audit_log($pdo, $this_user_id ?? 0, 'module_calendar_events', 0, 'READ', 'Unauthorized calendar list access');
+  http_response_code(403);
+  echo json_encode(['error' => 'Forbidden']);
+  exit;
+}
+
+require_permission('calendar','read');
 try {
   $scope = $_GET['scope'] ?? 'shared';
 


### PR DESCRIPTION
## Summary
- verify calendar read permission before listing events
- return 403 JSON error and log audit entry on unauthorized access

## Testing
- `php -l functions/list.php`


------
https://chatgpt.com/codex/tasks/task_e_68b107c1eb108333b6953b8f04a9634c