### PR TITLE
Restrict web access to includes and functions directories

### DIFF
--- a/docs/environment.md
+++ b/docs/environment.md
@@ -25,3 +25,13 @@ SOURCE _SQL/create_atlis_user.sql;
 ```
 
 Replace `change_this_password` with a strong password before running the script.
+
+## Web server
+
+The `includes/` and top-level `functions/` directories are not meant to be served directly. Each contains a `.htaccess` file that denies all HTTP requests. For these protections to work, the web server must allow overrides:
+
+```
+AllowOverride All
+```
+
+If your deployment environment does not support Apache `.htaccess` files, move these directories outside the web root and update any PHP include paths accordingly.

--- a/functions/.htaccess
+++ b/functions/.htaccess
@@ -1,0 +1,7 @@
+# Prevent web access to PHP functions
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+<IfModule !mod_authz_core.c>
+    Deny from all
+</IfModule>

--- a/includes/.htaccess
+++ b/includes/.htaccess
@@ -1,0 +1,7 @@
+# Prevent web access to PHP includes
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+<IfModule !mod_authz_core.c>
+    Deny from all
+</IfModule>


### PR DESCRIPTION
## Summary
- Deny HTTP access to `includes/` and top-level `functions/` through `.htaccess`
- Document required `AllowOverride All` setting and guidance for non-Apache deployments

## Testing
- `composer validate` *(fails: missing package metadata)*

------
https://chatgpt.com/codex/tasks/task_e_68b107c7f7d883339d198351563f4299