### PR TITLE
Gracefully handle DB connection errors and document .env usage

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -12,6 +12,12 @@ $env = [];
 if (file_exists($envFile)) {
     $env = parse_ini_file($envFile);
 }
+// Example .env entry (do not leave credentials blank):
+// DB_HOST=localhost
+// DB_USER=atlis_user
+// DB_PASSWORD=your_password
+// DB_NAME=atlis
+// DB_PORT=3306
 
 // DB Credentials
 define('DB_HOST', $env['DB_HOST'] ?? getenv('DB_HOST') ?? 'localhost');
@@ -29,8 +35,8 @@ $pdo = "";
 try{
         $pdo = new PDO($dsn, DB_USER, DB_PASSWORD, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
 }catch (PDOException $e) {
-        error_log($e->getMessage());
-        echo "Connection failed: " . $e->getMessage();
+        error_log('Database connection failed: ' . $e->getMessage());
+        exit('Database connection error.');
 }
 
 


### PR DESCRIPTION
## Summary
- Add example .env snippet to discourage empty database credentials
- Hide detailed PDO errors from users and abort on connection failure

## Testing
- `php -l includes/config.php`


------
https://chatgpt.com/codex/tasks/task_e_68b107d2dac08333b95a0a8ed314792a