### PR TITLE
Restrict corporate uploads and serve files securely

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,11 @@ includes/config.oauth.php
 !admin/corporate/time-tracking/uploads/.gitkeep
 !admin/corporate/strategy/uploads/
 !admin/corporate/strategy/uploads/.gitkeep
+!admin/corporate/uploads/
+!admin/corporate/uploads/.htaccess
+!admin/corporate/accounting/uploads/
+!admin/corporate/assets/uploads/
+!admin/corporate/human-resources/uploads/
+!admin/corporate/prospecting/uploads/
 # Environment configuration
 .env

--- a/admin/corporate/accounting/uploads/.htaccess
+++ b/admin/corporate/accounting/uploads/.htaccess
@@ -1,0 +1,1 @@
+Deny from all

--- a/admin/corporate/assets/uploads/.htaccess
+++ b/admin/corporate/assets/uploads/.htaccess
@@ -1,0 +1,1 @@
+Deny from all

--- a/admin/corporate/finances/invoices/uploads/.htaccess
+++ b/admin/corporate/finances/invoices/uploads/.htaccess
@@ -1,0 +1,1 @@
+Deny from all

--- a/admin/corporate/finances/statements-of-work/uploads/.htaccess
+++ b/admin/corporate/finances/statements-of-work/uploads/.htaccess
@@ -1,0 +1,1 @@
+Deny from all

--- a/admin/corporate/functions/get_file.php
+++ b/admin/corporate/functions/get_file.php
@@ -1,0 +1,34 @@
+<?php
+require '../../../includes/admin_guard.php';
+require_permission('admin_corporate_files','read');
+
+$id = (int)($_GET['id'] ?? 0);
+if(!$id){
+  http_response_code(400);
+  exit('Invalid file id');
+}
+
+$stmt = $pdo->prepare('SELECT file_name,file_path,file_type FROM admin_corporate_files WHERE id = :id');
+$stmt->execute([':id'=>$id]);
+$file = $stmt->fetch(PDO::FETCH_ASSOC);
+
+if(!$file){
+  http_response_code(404);
+  exit('File not found');
+}
+
+$full = __DIR__ . '/../../' . $file['file_path'];
+if(!file_exists($full)){
+  http_response_code(404);
+  exit('File not found');
+}
+
+admin_audit_log($pdo,$this_user_id,'admin_corporate_files',$id,'DOWNLOAD','',json_encode(['file'=>$file['file_name']]));
+
+header('Content-Description: File Transfer');
+header('Content-Type: ' . ($file['file_type'] ?: 'application/octet-stream'));
+header('Content-Disposition: attachment; filename="' . basename($file['file_name']) . '"');
+header('Content-Length: ' . filesize($full));
+
+readfile($full);
+exit;

--- a/admin/corporate/human-resources/uploads/.htaccess
+++ b/admin/corporate/human-resources/uploads/.htaccess
@@ -1,0 +1,1 @@
+Deny from all

--- a/admin/corporate/prospecting/uploads/.htaccess
+++ b/admin/corporate/prospecting/uploads/.htaccess
@@ -1,0 +1,1 @@
+Deny from all

--- a/admin/corporate/strategy/uploads/.htaccess
+++ b/admin/corporate/strategy/uploads/.htaccess
@@ -1,0 +1,1 @@
+Deny from all

--- a/admin/corporate/time-tracking/uploads/.htaccess
+++ b/admin/corporate/time-tracking/uploads/.htaccess
@@ -1,0 +1,1 @@
+Deny from all

--- a/admin/corporate/uploads/.htaccess
+++ b/admin/corporate/uploads/.htaccess
@@ -1,0 +1,1 @@
+Deny from all


### PR DESCRIPTION
## Summary
- Block direct HTTP access to corporate upload folders via `.htaccess`
- Add permission-checked `get_file.php` script for streaming corporate files with access logging
- Whitelist corporate upload directories in `.gitignore`

## Testing
- `php -l admin/corporate/functions/get_file.php`


------
https://chatgpt.com/codex/tasks/task_e_68b11328bf1483338859137bf80fae4d