### PR TITLE
feat(calendar): centralize event caching and handle token refresh failures

### DIFF
--- a/module/calendar/functions/google_events.php
+++ b/module/calendar/functions/google_events.php
@@ -4,40 +4,36 @@ require_once __DIR__ . '/external_helper.php';
 
 function fetch_google_events(PDO $pdo, int $userId): array {
     $cacheKey = 'google_calendar_events_' . $userId;
-    if (isset($_SESSION[$cacheKey]) && $_SESSION[$cacheKey]['time'] > time() - 300) {
-        return $_SESSION[$cacheKey]['data'];
-    }
-
-    $token = refresh_token('google', $pdo, $userId);
-    if (!$token) {
-        return [];
-    }
-
-    $data = fetch_remote_events('google', $token);
-    if (!$data) {
-        return [];
-    }
-
-    $events = [];
-    if (!empty($data['items'])) {
-        foreach ($data['items'] as $item) {
-            $events[] = [
-                'id' => 'google-' . ($item['id'] ?? ''),
-                'calendar_id' => 0,
-                'title' => $item['summary'] ?? '',
-                'start' => $item['start']['dateTime'] ?? $item['start']['date'] ?? '',
-                'end' => $item['end']['dateTime'] ?? $item['end']['date'] ?? '',
-                'related_module' => null,
-                'related_id' => null,
-                'event_type_id' => 0,
-                'is_private' => 0,
-                'source' => 'google'
-            ];
+    return get_cached_events($cacheKey, function () use ($pdo, $userId) {
+        $token = refresh_token('google', $pdo, $userId);
+        if (!$token) {
+            return [];
         }
-    }
 
-    $_SESSION[$cacheKey] = ['time' => time(), 'data' => $events];
-    return $events;
+        $data = fetch_remote_events('google', $token);
+        if (!$data) {
+            return [];
+        }
+
+        $events = [];
+        if (!empty($data['items'])) {
+            foreach ($data['items'] as $item) {
+                $events[] = [
+                    'id' => 'google-' . ($item['id'] ?? ''),
+                    'calendar_id' => 0,
+                    'title' => $item['summary'] ?? '',
+                    'start' => $item['start']['dateTime'] ?? $item['start']['date'] ?? '',
+                    'end' => $item['end']['dateTime'] ?? $item['end']['date'] ?? '',
+                    'related_module' => null,
+                    'related_id' => null,
+                    'event_type_id' => 0,
+                    'is_private' => 0,
+                    'source' => 'google',
+                ];
+            }
+        }
+        return $events;
+    });
 }
 
 if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {

--- a/module/calendar/functions/microsoft_events.php
+++ b/module/calendar/functions/microsoft_events.php
@@ -4,40 +4,36 @@ require_once __DIR__ . '/external_helper.php';
 
 function fetch_microsoft_events(PDO $pdo, int $userId): array {
     $cacheKey = 'microsoft_calendar_events_' . $userId;
-    if (isset($_SESSION[$cacheKey]) && $_SESSION[$cacheKey]['time'] > time() - 300) {
-        return $_SESSION[$cacheKey]['data'];
-    }
-
-    $token = refresh_token('microsoft', $pdo, $userId);
-    if (!$token) {
-        return [];
-    }
-
-    $data = fetch_remote_events('microsoft', $token);
-    if (!$data) {
-        return [];
-    }
-
-    $events = [];
-    if (!empty($data['value'])) {
-        foreach ($data['value'] as $item) {
-            $events[] = [
-                'id' => 'microsoft-' . ($item['id'] ?? ''),
-                'calendar_id' => 0,
-                'title' => $item['subject'] ?? '',
-                'start' => $item['start']['dateTime'] ?? '',
-                'end' => $item['end']['dateTime'] ?? '',
-                'related_module' => null,
-                'related_id' => null,
-                'event_type_id' => 0,
-                'is_private' => 0,
-                'source' => 'microsoft'
-            ];
+    return get_cached_events($cacheKey, function () use ($pdo, $userId) {
+        $token = refresh_token('microsoft', $pdo, $userId);
+        if (!$token) {
+            return [];
         }
-    }
 
-    $_SESSION[$cacheKey] = ['time' => time(), 'data' => $events];
-    return $events;
+        $data = fetch_remote_events('microsoft', $token);
+        if (!$data) {
+            return [];
+        }
+
+        $events = [];
+        if (!empty($data['value'])) {
+            foreach ($data['value'] as $item) {
+                $events[] = [
+                    'id' => 'microsoft-' . ($item['id'] ?? ''),
+                    'calendar_id' => 0,
+                    'title' => $item['subject'] ?? '',
+                    'start' => $item['start']['dateTime'] ?? '',
+                    'end' => $item['end']['dateTime'] ?? '',
+                    'related_module' => null,
+                    'related_id' => null,
+                    'event_type_id' => 0,
+                    'is_private' => 0,
+                    'source' => 'microsoft',
+                ];
+            }
+        }
+        return $events;
+    });
 }
 
 if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {


### PR DESCRIPTION
## Summary
- add `get_cached_events` to reuse session-based caching
- make `refresh_token` log errors and return an empty string on failure
- streamline Google and Microsoft event fetchers to use shared caching and label sources

## Testing
- `php -l module/calendar/functions/external_helper.php`
- `php -l module/calendar/functions/google_events.php`
- `php -l module/calendar/functions/microsoft_events.php`


------
https://chatgpt.com/codex/tasks/task_e_68b12e91f3948333bd76d81f08420f5b