### PR TITLE
Add CSRF protection for meeting attendee search

### DIFF
--- a/admin/meetings/functions/search_people.php
+++ b/admin/meetings/functions/search_people.php
@@ -4,6 +4,12 @@ require_permission('person', 'read');
 
 header('Content-Type: application/json');
 
+$token = $_GET['csrf_token'] ?? '';
+if (!verify_csrf_token($token)) {
+    echo json_encode(['success' => false, 'message' => 'Invalid CSRF token']);
+    exit;
+}
+
 $q = trim($_GET['q'] ?? '');
 if ($q === '') {
     echo json_encode([]);

--- a/admin/meetings/include/create_edit_view.php
+++ b/admin/meetings/include/create_edit_view.php
@@ -296,13 +296,24 @@ document.addEventListener('DOMContentLoaded', function(){
     attendeeSelect.addEventListener('search', function(event){
       var term = event.detail.value;
       if(!term){ return; }
-      fetch('functions/search_people.php?q=' + encodeURIComponent(term))
-        .then(r => r.ok ? r.json() : [])
+      fetch('functions/search_people.php?q=' + encodeURIComponent(term) + '&csrf_token=' + encodeURIComponent(csrfToken))
+        .then(function(r){
+          if(!r.ok){ throw new Error('Search failed'); }
+          return r.json();
+        })
         .then(function(users){
+          if(!Array.isArray(users)){
+            throw new Error((users && users.message) || 'Search failed');
+          }
           attendeeChoices.clearChoices();
           attendeeChoices.setChoices(users.map(function(u){
             return { value: u.id, label: u.name, customProperties:{ user_id: u.user_id || '' } };
           }), 'value', 'label', true);
+        })
+        .catch(function(err){
+          attendeeChoices.clearChoices();
+          showToast(err.message || 'Error searching people');
+          console.error('Search failed', err);
         });
     });
 

--- a/admin/meetings/include/details_view.php
+++ b/admin/meetings/include/details_view.php
@@ -311,7 +311,7 @@ document.addEventListener('DOMContentLoaded', function(){
   var baseUrl = '<?php echo getURLDir(); ?>';
   var canEdit = <?php echo user_has_permission('meeting','update') ? 'true' : 'false'; ?>;
   var canEditAttendees = <?php echo user_has_permission('meeting','update') ? 'true' : 'false'; ?>;
-  var csrfToken = '<?= $token; ?>';
+  var csrfToken = '<?= h($token); ?>';
   var agendaStatusMap = <?php echo json_encode($agendaStatusMap); ?>;
   var questionStatusMap = <?php echo json_encode($questionStatusMap); ?>;
   var agendaMap = {};
@@ -820,12 +820,17 @@ document.addEventListener('DOMContentLoaded', function(){
         var q = (e.detail.value || '').trim();
         if(q.length < 2){ return; }
         try{
-          var people = await fetchJson('functions/search_people.php?q=' + encodeURIComponent(q) + '&csrf_token=' + csrfToken);
+          var people = await fetchJson('functions/search_people.php?q=' + encodeURIComponent(q) + '&csrf_token=' + encodeURIComponent(csrfToken));
+          if(!Array.isArray(people)){
+            throw new Error((people && people.message) || 'Search failed');
+          }
+          attendeeChoices.clearChoices();
           var opts = people.map(function(p){ return {value:p.id, label:p.name, customProperties:{ user_id: p.user_id || '' }}; });
           attendeeChoices.setChoices(opts, 'value', 'label', true);
         } catch(err){
+          attendeeChoices.clearChoices();
           console.error(err);
-          showToast('Error searching people');
+          showToast(err.message || 'Error searching people');
         }
       });
     }


### PR DESCRIPTION
## Summary
- verify CSRF token in meeting attendee search endpoint
- expose `csrfToken` to meeting views and include token in search requests
- handle failed attendee search requests by clearing options and showing an error toast

## Testing
- `php -l admin/meetings/functions/search_people.php`
- `php -l admin/meetings/include/create_edit_view.php`
- `php -l admin/meetings/include/details_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68b12eeafca48333a0d56568376921dc