### PR TITLE
Add meeting count to meeting search and update list view

### DIFF
--- a/admin/meetings/functions/search.php
+++ b/admin/meetings/functions/search.php
@@ -10,12 +10,20 @@ if ($q === '') {
     echo json_encode(['success' => false, 'message' => 'Query required']);
     exit;
 }
-$stmt = $pdo->prepare('SELECT id, title, start_time FROM module_meetings WHERE title LIKE :q ORDER BY start_time DESC LIMIT 20');
+
+// Fetch up to 20 meetings matching the query and include the total count
+$stmt = $pdo->prepare(
+    'SELECT id, title, start_time, COUNT(*) OVER () AS total FROM module_meetings WHERE title LIKE :q ORDER BY start_time DESC LIMIT 20'
+);
 $stmt->execute([':q' => "%" . $q . "%"]);
 $meetings = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+$count = $meetings[0]['total'] ?? 0;
 foreach ($meetings as &$m) {
     $m['start_time'] = !empty($m['start_time']) ? date('d M, Y g:i A', strtotime($m['start_time'])) : '';
+    unset($m['total']);
 }
 unset($m);
 
-echo json_encode(['success' => true, 'meetings' => $meetings]);
+echo json_encode(['success' => true, 'meetings' => $meetings, 'count' => (int)$count]);
+

--- a/admin/meetings/include/list_view.php
+++ b/admin/meetings/include/list_view.php
@@ -1,7 +1,7 @@
 <?php $token = generate_csrf_token(); ?>
 <div class="toast-container position-fixed top-0 end-0 p-3" id="toastContainer"></div>
 <div class="p-4" id="meetingList">
-  <h2 class="mb-4">Meetings<span class="text-body-tertiary fw-normal">(<?= count($meetings) ?>)</span></h2>
+  <h2 class="mb-4">Meetings<span class="text-body-tertiary fw-normal">(<span id="meetingCount"><?= count($meetings) ?></span>)</span></h2>
   <div class="row g-3 mb-3">
     <div class="col-12">
       <div class="search-box">
@@ -63,6 +63,8 @@ document.addEventListener('DOMContentLoaded', function(){
   var searchTimeout;
   var listContainer = document.getElementById('meetingListContainer');
   var originalListHTML = listContainer ? listContainer.innerHTML : '';
+  var countSpan = document.getElementById('meetingCount');
+  var originalCount = countSpan ? countSpan.textContent : '';
   if(searchInput){
     searchInput.addEventListener('input', function(){
       clearTimeout(searchTimeout);
@@ -70,6 +72,7 @@ document.addEventListener('DOMContentLoaded', function(){
       searchTimeout = setTimeout(function(){
         if(q === ''){
           listContainer.innerHTML = originalListHTML;
+          if(countSpan){ countSpan.textContent = originalCount; }
           return;
         }
         fetch('functions/search.php?q=' + encodeURIComponent(q))
@@ -82,6 +85,7 @@ document.addEventListener('DOMContentLoaded', function(){
           .then(function(res){
             if(res.success){
               listContainer.innerHTML = '';
+              if(countSpan){ countSpan.textContent = res.count || 0; }
               if(res.meetings && res.meetings.length){
                 res.meetings.forEach(function(m){
                   var row = `<div class="row align-items-center border-top py-3 gx-0 meeting-row" data-id="${m.id}">`+


### PR DESCRIPTION
## Summary
- Return total matches from meeting search endpoint
- Display dynamic meeting counts during search and revert on clear

## Testing
- `php -l admin/meetings/functions/search.php`
- `php -l admin/meetings/include/list_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68b12eebece88333929d278480ca3612