### PR TITLE
Validate calendar event ownership for meetings

### DIFF
--- a/admin/meetings/functions/create.php
+++ b/admin/meetings/functions/create.php
@@ -26,6 +26,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   }
 
   $errors = [];
+
+  if ($calendar_event_id) {
+    $ceStmt = $pdo->prepare('SELECT e.user_id FROM module_calendar_events e JOIN module_calendar c ON e.calendar_id = c.id WHERE e.id = ?');
+    $ceStmt->execute([$calendar_event_id]);
+    $ownerId = $ceStmt->fetchColumn();
+    if (!$ownerId || (!user_has_role('Admin') && (int)$ownerId !== $this_user_id)) {
+      $errors[] = 'Invalid calendar event';
+      $calendar_event_id = null;
+    }
+  }
+
   if ($title === '') {
     $errors[] = 'Title is required';
   }

--- a/admin/meetings/functions/update.php
+++ b/admin/meetings/functions/update.php
@@ -27,6 +27,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   }
 
   $errors = [];
+
+  if ($calendar_event_id) {
+    $ceStmt = $pdo->prepare('SELECT e.user_id FROM module_calendar_events e JOIN module_calendar c ON e.calendar_id = c.id WHERE e.id = ?');
+    $ceStmt->execute([$calendar_event_id]);
+    $ownerId = $ceStmt->fetchColumn();
+    if (!$ownerId || (!user_has_role('Admin') && (int)$ownerId !== $this_user_id)) {
+      $errors[] = 'Invalid calendar event';
+      $calendar_event_id = null;
+    }
+  }
+
   if ($title === '') {
     $errors[] = 'Title is required';
   }


### PR DESCRIPTION
## Summary
- ensure meetings only link to calendar events owned by the current user unless they are Admin
- query module_calendar_events joined to module_calendar and null out or error on unauthorized events

## Testing
- `php -l admin/meetings/functions/create.php`
- `php -l admin/meetings/functions/update.php`


------
https://chatgpt.com/codex/tasks/task_e_68b12eecd1c4833389ccc11a80e0d8f7