### PR TITLE
Include event metadata and styling in calendar list

### DIFF
--- a/module/calendar/functions/list.php
+++ b/module/calendar/functions/list.php
@@ -42,7 +42,7 @@ try {
         }
     }
 
-    $sql = 'SELECT e.id, e.calendar_id, e.title, e.memo, e.start_time, e.end_time, e.link_module, e.link_record_id, e.user_id, e.event_type_id, e.visibility_id, c.user_id AS calendar_user_id FROM module_calendar_events e JOIN module_calendar c ON e.calendar_id = c.id';
+    $sql = "SELECT e.id, e.calendar_id, e.title, e.memo, e.start_time, e.end_time, e.location, e.link_module, e.link_record_id, e.user_id, e.event_type_id, e.visibility_id, c.user_id AS calendar_user_id, COALESCE(color_attr.attr_value, 'secondary') AS color_class, COALESCE(icon_attr.attr_value, '') AS icon_class FROM module_calendar_events e JOIN module_calendar c ON e.calendar_id = c.id LEFT JOIN lookup_list_item_attributes color_attr ON e.event_type_id = color_attr.item_id AND color_attr.attr_code = 'COLOR-CLASS' LEFT JOIN lookup_list_item_attributes icon_attr ON e.event_type_id = icon_attr.item_id AND icon_attr.attr_code = 'ICON-CLASS'";
 
     $where = [];
     $params = [];
@@ -90,9 +90,12 @@ try {
             'description' => $row['memo'],
             'start' => $row['start_time'],
             'end' => $row['end_time'],
+            'location' => $row['location'],
             'related_module' => $row['link_module'],
             'related_id' => $row['link_record_id'],
             'event_type_id' => $row['event_type_id'] !== null ? (int)$row['event_type_id'] : null,
+            'color_class' => $row['color_class'],
+            'icon_class' => $row['icon_class'],
             'visibility_id' => $visibility,
             'user_id' => (int)$row['user_id'],
             'calendar_user_id' => (int)$row['calendar_user_id'],


### PR DESCRIPTION
## Summary
- Join lookup list item attributes for event type styling metadata
- Return location and style classes with calendar events

## Testing
- `php -l module/calendar/functions/list.php`
- `php module/calendar/tests/create_unauthorized_403_test.php`
- `php module/calendar/tests/update_unauthorized_403_test.php`


------
https://chatgpt.com/codex/tasks/task_e_68b14653bd60833384190f7ebbe9810e