### PR TITLE
Add user timezone support

### DIFF
--- a/_SQL/2025XX_user_timezone.sql
+++ b/_SQL/2025XX_user_timezone.sql
@@ -1,0 +1,18 @@
+-- Add TIMEZONE lookup list and user timezone support
+
+INSERT INTO lookup_lists (user_id, user_updated, name, description)
+VALUES (1, 1, 'TIMEZONE', 'User timezone options');
+
+SET @timezone_list_id = (SELECT id FROM lookup_lists WHERE name = 'TIMEZONE');
+
+INSERT INTO lookup_list_items (user_id, user_updated, list_id, label, code, sort_order) VALUES
+  (1, 1, @timezone_list_id, 'America/Denver', 'America/Denver', 1),
+  (1, 1, @timezone_list_id, 'America/Chicago', 'America/Chicago', 2),
+  (1, 1, @timezone_list_id, 'America/New_York', 'America/New_York', 3),
+  (1, 1, @timezone_list_id, 'America/Los_Angeles', 'America/Los_Angeles', 4),
+  (1, 1, @timezone_list_id, 'America/Phoenix', 'America/Phoenix', 5),
+  (1, 1, @timezone_list_id, 'America/Anchorage', 'America/Anchorage', 6),
+  (1, 1, @timezone_list_id, 'America/Honolulu', 'America/Honolulu', 7);
+
+ALTER TABLE users ADD COLUMN timezone_id INT(11) NULL;
+ALTER TABLE users ADD CONSTRAINT fk_users_timezone_id FOREIGN KEY (timezone_id) REFERENCES lookup_list_items(id) ON DELETE SET NULL;

--- a/module/users/functions/save_settings.php
+++ b/module/users/functions/save_settings.php
@@ -8,6 +8,13 @@ if (!isset($this_user_id)) {
   exit;
 }
 
+$timezoneId = $_POST['timezone_id'] ?? null;
+$stmt = $pdo->prepare('UPDATE users SET timezone_id = :tz, user_updated = :uid WHERE id = :uid');
+$stmt->execute([
+  ':tz' => $timezoneId === '' ? null : (int)$timezoneId,
+  ':uid' => $this_user_id,
+]);
+
 $fields = [
   'project_status' => 'PROJECT_STATUS',
   'project_priority' => 'PROJECT_PRIORITY',

--- a/module/users/include/settings.php
+++ b/module/users/include/settings.php
@@ -14,7 +14,18 @@
 <div class="row">
   <div class="col-xl-8">
     <form class="row g-3 mb-6" method="post" action="index.php?action=save-settings">
-      <h5 class="mb-3">Defaults</h5>
+      <div class="col-sm-6 col-md-4">
+        <div class="form-floating">
+          <select class="form-select" id="userTimezone" name="timezone_id">
+            <option value="">Select timezone</option>
+            <?php foreach ($timezoneItems as $item): ?>
+              <option value="<?= $item['id']; ?>" <?= ($userTimezoneId ?? '') == $item['id'] ? 'selected' : ''; ?>><?= h($item['label']); ?></option>
+            <?php endforeach; ?>
+          </select>
+          <label for="userTimezone">Timezone</label>
+        </div>
+      </div>
+      <h5 class="mb-3 mt-3">Defaults</h5>
       <div class="col-12">
         <h6 class="mb-2">Projects</h6>
       </div>

--- a/module/users/index.php
+++ b/module/users/index.php
@@ -41,6 +41,7 @@ if ($action === 'save-settings' && $_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 
 if ($action === 'settings') {
+  $timezoneItems       = get_lookup_items($pdo, 'TIMEZONE');
   $projectStatusItems   = get_lookup_items($pdo, 'PROJECT_STATUS');
   $projectPriorityItems = get_lookup_items($pdo, 'PROJECT_PRIORITY');
   $projectTypeItems     = get_lookup_items($pdo, 'PROJECT_TYPE');
@@ -61,6 +62,10 @@ if ($action === 'settings') {
     'CALENDAR_DEFAULT' => get_user_default_lookup_item($pdo, $this_user_id, 'CALENDAR_DEFAULT'),
     'CALENDAR_EVENT_TYPE_DEFAULT' => get_user_default_lookup_item($pdo, $this_user_id, 'CALENDAR_EVENT_TYPE_DEFAULT'),
   ];
+
+  $tzStmt = $pdo->prepare('SELECT timezone_id FROM users WHERE id = :uid');
+  $tzStmt->execute([':uid' => $this_user_id]);
+  $userTimezoneId = $tzStmt->fetchColumn();
 
   require '../../includes/html_header.php';
   ?>


### PR DESCRIPTION
## Summary
- add TIMEZONE lookup list and timezone_id column for users
- load timezone options in user settings and persist selection

## Testing
- `php -l module/users/index.php`
- `php -l module/users/include/settings.php`
- `php -l module/users/functions/save_settings.php`


------
https://chatgpt.com/codex/tasks/task_e_68b15d7313cc833387a98ad60d190c09