### PR TITLE
Add timezone selection to calendar events

### DIFF
--- a/_SQL/202502_calendar_event_timezone.sql
+++ b/_SQL/202502_calendar_event_timezone.sql
@@ -1,0 +1,7 @@
+ALTER TABLE module_calendar_events
+  ADD COLUMN timezone_id INT(11) NULL;
+
+ALTER TABLE module_calendar_events
+  ADD CONSTRAINT fk_module_calendar_events_timezone_id
+    FOREIGN KEY (timezone_id) REFERENCES lookup_list_items(id) ON DELETE SET NULL;
+

--- a/module/calendar/functions/create.php
+++ b/module/calendar/functions/create.php
@@ -15,6 +15,7 @@ $calendar_id = (int)($_POST['calendar_id'] ?? 0);
 $location = trim($_POST['location'] ?? '');
 $event_type_id = isset($_POST['event_type_id']) && $_POST['event_type_id'] !== '' && $_POST['event_type_id'] !== 'Select type' ? (int)$_POST['event_type_id'] : null;
 $visibility_id = (int)($_POST['visibility_id'] ?? 198);
+$timezone_id = isset($_POST['timezone_id']) && $_POST['timezone_id'] !== '' ? (int)$_POST['timezone_id'] : null;
 if (!in_array($visibility_id, [198, 199], true)) {
   http_response_code(400);
   echo json_encode(['error' => 'Invalid visibility_id']);
@@ -29,6 +30,16 @@ if ($event_type_id !== null) {
   if (!$etypeStmt->fetchColumn()) {
     http_response_code(400);
     echo json_encode(['error' => 'Invalid event_type_id']);
+    exit;
+  }
+}
+
+if ($timezone_id !== null) {
+  $tzStmt = $pdo->prepare('SELECT li.id FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE li.id = :id AND l.name = "TIMEZONE"');
+  $tzStmt->execute([':id' => $timezone_id]);
+  if (!$tzStmt->fetchColumn()) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid timezone_id']);
     exit;
   }
 }
@@ -52,8 +63,8 @@ if ($title && $start_time && $calendar_id) {
     exit;
   }
 
-  $columns = ['user_id', 'calendar_id', 'title', 'memo', 'location', 'start_time', 'end_time', 'link_module', 'link_record_id', 'visibility_id'];
-  $placeholders = [':uid', ':calendar_id', ':title', ':memo', ':location', ':start_time', ':end_time', ':link_module', ':link_record_id', ':visibility_id'];
+  $columns = ['user_id', 'calendar_id', 'title', 'memo', 'location', 'start_time', 'end_time', 'link_module', 'link_record_id', 'visibility_id', 'timezone_id'];
+  $placeholders = [':uid', ':calendar_id', ':title', ':memo', ':location', ':start_time', ':end_time', ':link_module', ':link_record_id', ':visibility_id', ':timezone_id'];
   $params = [
     ':uid' => $this_user_id,
     ':calendar_id' => $calendar_id,
@@ -64,7 +75,8 @@ if ($title && $start_time && $calendar_id) {
     ':end_time' => $end_time,
     ':link_module' => $link_module,
     ':link_record_id' => $link_record_id,
-    ':visibility_id' => $visibility_id
+    ':visibility_id' => $visibility_id,
+    ':timezone_id' => $timezone_id
   ];
   if ($event_type_id !== null) {
     $columns[] = 'event_type_id';

--- a/module/calendar/functions/update.php
+++ b/module/calendar/functions/update.php
@@ -17,6 +17,7 @@ $calendar_id = (int)($_POST['calendar_id'] ?? 0);
 $location = trim($_POST['location'] ?? '');
 $event_type_id = isset($_POST['event_type_id']) && $_POST['event_type_id'] !== '' && $_POST['event_type_id'] !== 'Select type' ? (int)$_POST['event_type_id'] : null;
 $visibility_id = (int)($_POST['visibility_id'] ?? 198);
+$timezone_id = isset($_POST['timezone_id']) && $_POST['timezone_id'] !== '' ? (int)$_POST['timezone_id'] : null;
 if (!in_array($visibility_id, [198, 199], true)) {
   http_response_code(400);
   echo json_encode(['error' => 'Invalid visibility_id']);
@@ -31,6 +32,16 @@ if ($event_type_id !== null) {
   if (!$etypeStmt->fetchColumn()) {
     http_response_code(400);
     echo json_encode(['error' => 'Invalid event_type_id']);
+    exit;
+  }
+}
+
+if ($timezone_id !== null) {
+  $tzStmt = $pdo->prepare('SELECT li.id FROM lookup_list_items li JOIN lookup_lists l ON li.list_id = l.id WHERE li.id = :id AND l.name = "TIMEZONE"');
+  $tzStmt->execute([':id' => $timezone_id]);
+  if (!$tzStmt->fetchColumn()) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid timezone_id']);
     exit;
   }
 }
@@ -78,7 +89,8 @@ if ($id && $title && $start_time && $calendar_id) {
     'end_time = :end_time',
     'link_module = :link_module',
     'link_record_id = :link_record_id',
-    'visibility_id = :visibility_id'
+    'visibility_id = :visibility_id',
+    'timezone_id = :timezone_id'
   ];
 
   $params = [
@@ -92,6 +104,7 @@ if ($id && $title && $start_time && $calendar_id) {
     ':link_module' => $link_module,
     ':link_record_id' => $link_record_id,
     ':visibility_id' => $visibility_id,
+    ':timezone_id' => $timezone_id,
     ':id' => $id
   ];
 

--- a/module/calendar/include/calendar_view.php
+++ b/module/calendar/include/calendar_view.php
@@ -129,6 +129,16 @@ $default_event_type_id = get_user_default_lookup_item($pdo, $this_user_id, 'CALE
             <label for="addEventType">Event Type</label>
           </div>
 
+          <div class="form-floating mb-3">
+            <select class="form-select" id="addEventTimezone" name="timezone_id">
+              <option value="">Select timezone</option>
+              <?php foreach ($timezoneItems as $tz): ?>
+                <option value="<?= (int)$tz['id']; ?>"<?= (int)$tz['id'] === (int)$userTimezoneId ? ' selected' : ''; ?>><?= h($tz['label']); ?></option>
+              <?php endforeach; ?>
+            </select>
+            <label for="addEventTimezone">Timezone</label>
+          </div>
+
           <?php if ($owns_calendar) { ?>
             <div class="mb-3">
               <label class="form-label d-block mb-2">Calendar</label>
@@ -186,6 +196,16 @@ $default_event_type_id = get_user_default_lookup_item($pdo, $this_user_id, 'CALE
               <?php endforeach; ?>
             </select>
             <label for="editEventType">Event Type</label>
+          </div>
+
+          <div class="form-floating mb-3">
+            <select class="form-select" id="editEventTimezone" name="timezone_id">
+              <option value="">Select timezone</option>
+              <?php foreach ($timezoneItems as $tz): ?>
+                <option value="<?= (int)$tz['id']; ?>"<?= (int)$tz['id'] === (int)$userTimezoneId ? ' selected' : ''; ?>><?= h($tz['label']); ?></option>
+              <?php endforeach; ?>
+            </select>
+            <label for="editEventTimezone">Timezone</label>
           </div>
         </div>
         <div class="modal-footer d-flex justify-content-end align-items-center border-0">
@@ -297,6 +317,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const eventTypes = <?php echo json_encode($event_types); ?>;
     const eventTypeMap = {};
     eventTypes.forEach(et => { eventTypeMap[et.id] = et.label; });
+    const userTimezoneId = <?= (int)$userTimezoneId ?>;
     const createCalendarForm = document.getElementById('createCalendarForm');
     const createCalendarModalEl = document.getElementById('createCalendarModal');
     const detailModalEl = document.getElementById('eventDetailsModal');
@@ -339,6 +360,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
     selectCalendarRadio(addEventForm, cid);
     addEventForm.event_type_id.value = defaultEventTypeId || '';
+    addEventForm.timezone_id.value = userTimezoneId || '';
     bootstrap.Modal.getOrCreateInstance(document.getElementById('addEventModal')).show();
   }
 
@@ -409,6 +431,7 @@ document.addEventListener('DOMContentLoaded', function() {
             form.start_time.value = dayjs(info.event.start).format('YYYY-MM-DD HH:mm');
             form.end_time.value = info.event.end ? dayjs(info.event.end).format('YYYY-MM-DD HH:mm') : '';
             form.event_type_id.value = info.event.extendedProps.event_type_id || defaultEventTypeId || '';
+            form.timezone_id.value = info.event.extendedProps.timezone_id || userTimezoneId || '';
             selectCalendarRadio(form, info.event.extendedProps.calendar_id || getCalendarId());
             modal.hide();
             bootstrap.Modal.getOrCreateInstance(document.getElementById('editEventModal')).show();
@@ -446,6 +469,7 @@ document.addEventListener('DOMContentLoaded', function() {
       form.start_time.value = dayjs(info.date).format('YYYY-MM-DD HH:mm');
       form.end_time.value = '';
       form.event_type_id.value = defaultEventTypeId || '';
+      form.timezone_id.value = userTimezoneId || '';
       selectCalendarRadio(form, getCalendarId());
       bootstrap.Modal.getOrCreateInstance(document.getElementById('addEventModal')).show();
     }
@@ -540,6 +564,7 @@ document.addEventListener('DOMContentLoaded', function() {
     addEventModalEl.addEventListener('show.bs.modal', function() {
       selectCalendarRadio(addEventForm, getCalendarId());
       addEventForm.event_type_id.value = defaultEventTypeId || '';
+      addEventForm.timezone_id.value = userTimezoneId || '';
     });
   }
 

--- a/module/calendar/index.php
+++ b/module/calendar/index.php
@@ -1,6 +1,9 @@
 <?php
 require '../../includes/php_header.php';
 
+$timezoneItems = get_lookup_items($pdo, 'TIMEZONE');
+$userTimezoneId = get_user_default_lookup_item($pdo, $this_user_id, 'TIMEZONE');
+
 $action = $_GET['action'] ?? '';
 if ($action === 'create') {
     require_permission('calendar', 'create');


### PR DESCRIPTION
## Summary
- allow specifying a timezone for calendar events
- surface timezone dropdown in add/edit modals with user default selected
- persist timezone_id in create and update handlers

## Testing
- `php -l module/calendar/index.php`
- `php -l module/calendar/include/calendar_view.php`
- `php -l module/calendar/functions/create.php`
- `php -l module/calendar/functions/update.php`
- `php module/calendar/tests/create_unauthorized_403_test.php`
- `php module/calendar/tests/update_unauthorized_403_test.php`


------
https://chatgpt.com/codex/tasks/task_e_68b15d747bb88333a1a68169f0b5cb2a