### PR TITLE
Handle meeting attendees without linked users

### DIFF
--- a/admin/meetings/functions/get_attendees.php
+++ b/admin/meetings/functions/get_attendees.php
@@ -23,8 +23,8 @@ try {
                 a.attendee_user_id,
                 COALESCE(CONCAT(p.first_name, " ", p.last_name), u.email) AS name
          FROM module_meeting_attendees a
-         LEFT JOIN person p ON a.attendee_user_id = p.user_id
-         LEFT JOIN users u ON a.attendee_user_id = u.id
+         LEFT JOIN person p ON a.attendee_person_id = p.id
+         LEFT JOIN users u ON p.user_id = u.id
          WHERE a.meeting_id = ?
          ORDER BY name'
     );

--- a/admin/meetings/functions/remove_attendee.php
+++ b/admin/meetings/functions/remove_attendee.php
@@ -27,8 +27,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     a.attendee_user_id,
                     COALESCE(CONCAT(p.first_name, " ", p.last_name), u.email) AS name
              FROM module_meeting_attendees a
-             LEFT JOIN person p ON a.attendee_user_id = p.user_id
-             LEFT JOIN users u ON a.attendee_user_id = u.id
+             LEFT JOIN person p ON a.attendee_person_id = p.id
+             LEFT JOIN users u ON p.user_id = u.id
              WHERE a.meeting_id = ?
              ORDER BY name'
         );


### PR DESCRIPTION
## Summary
- Allow meeting attendees without user accounts by looking up person.user_id and letting it be null
- Avoid duplicate attendees using (meeting_id, attendee_person_id)
- Always return updated attendee roster with names from person or user email

## Testing
- `php -l admin/meetings/functions/add_attendee.php`
- `php -l admin/meetings/functions/get_attendees.php`
- `php -l admin/meetings/functions/remove_attendee.php`


------
https://chatgpt.com/codex/tasks/task_e_68b1611398808333ae89630b4bfc90b7