### PR TITLE
fix: sync meeting attendees

### DIFF
--- a/admin/meetings/include/create_edit_view.php
+++ b/admin/meetings/include/create_edit_view.php
@@ -341,7 +341,9 @@ document.addEventListener('DOMContentLoaded', function(){
     });
 
     attendeeSelect.addEventListener('addItem', syncHiddenAttendees);
-    attendeeSelect.addEventListener('removeItem', syncHiddenAttendees);
+    attendeeSelect.addEventListener('removeItem', function(){
+      setTimeout(syncHiddenAttendees,0);
+    });
   }
 
   function addQuestion(data){
@@ -394,8 +396,8 @@ document.addEventListener('DOMContentLoaded', function(){
               customProperties:{ user_id: a.attendee_user_id || a.user_id || '' }
             };
           }), 'value', 'label', false);
-          syncHiddenAttendees();
         }
+        syncHiddenAttendees();
       });
   }
 });


### PR DESCRIPTION
## Summary
- synchronize hidden attendee inputs after Choices updates
- ensure removal events update hidden inputs once DOM settles

## Testing
- `php -l admin/meetings/include/create_edit_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68b1cb9df04c83338153c0500a7a1f57