### PR TITLE
Add admin minder notes timeline with AJAX CRUD

### DIFF
--- a/_SQL/202503_minder_notes.sql
+++ b/_SQL/202503_minder_notes.sql
@@ -1,0 +1,26 @@
+CREATE TABLE `admin_minder_note` (
+  `id` INT(11) AUTO_INCREMENT PRIMARY KEY,
+  `user_id` INT(11),
+  `user_updated` INT(11),
+  `date_created` DATETIME DEFAULT CURRENT_TIMESTAMP,
+  `date_updated` DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `memo` TEXT DEFAULT NULL,
+  `title` VARCHAR(255) NOT NULL,
+  `body` TEXT NOT NULL,
+  `category_id` INT(11) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `admin_minder_note_file` (
+  `id` INT(11) AUTO_INCREMENT PRIMARY KEY,
+  `user_id` INT(11),
+  `user_updated` INT(11),
+  `date_created` DATETIME DEFAULT CURRENT_TIMESTAMP,
+  `date_updated` DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `memo` TEXT DEFAULT NULL,
+  `note_id` INT(11) NOT NULL,
+  `file_name` VARCHAR(255) NOT NULL,
+  `file_path` VARCHAR(255) NOT NULL,
+  `file_size` INT DEFAULT NULL,
+  `file_type` VARCHAR(255) DEFAULT NULL,
+  FOREIGN KEY (`note_id`) REFERENCES `admin_minder_note`(`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/admin/minder/notes/functions/create.php
+++ b/admin/minder/notes/functions/create.php
@@ -1,0 +1,115 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/php_header.php';
+require_permission('minder_note','create');
+
+$isAjax = ($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '') === 'XMLHttpRequest'
+    || str_contains($_SERVER['HTTP_ACCEPT'] ?? '', 'application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+  if ($isAjax) {
+    header('Content-Type: application/json');
+    http_response_code(405);
+    echo json_encode(['success'=>false,'error'=>'Method not allowed']);
+  } else {
+    $_SESSION['error_message'] = 'Method not allowed';
+    header('Location: ../index.php');
+  }
+  exit;
+}
+
+if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+  if ($isAjax) {
+    header('Content-Type: application/json');
+    http_response_code(403);
+    echo json_encode(['success'=>false,'error'=>'Invalid CSRF token']);
+  } else {
+    $_SESSION['error_message'] = 'Invalid CSRF token';
+    header('Location: ../index.php');
+  }
+  exit;
+}
+
+$title = trim($_POST['title'] ?? '');
+$body  = trim($_POST['body'] ?? '');
+$category_id = $_POST['category_id'] !== '' ? (int)$_POST['category_id'] : null;
+
+if ($title === '' || $body === '') {
+  if ($isAjax) {
+    header('Content-Type: application/json');
+    http_response_code(400);
+    echo json_encode(['success'=>false,'error'=>'Title and body required']);
+  } else {
+    $_SESSION['error_message'] = 'Title and body required';
+    header('Location: ../note.php');
+  }
+  exit;
+}
+
+$noteId = 0;
+try {
+  $stmt = $pdo->prepare('INSERT INTO admin_minder_note (title, body, category_id, user_id, user_updated) VALUES (:title,:body,:category_id,:uid,:uid)');
+  $stmt->execute([
+    ':title' => $title,
+    ':body' => $body,
+    ':category_id' => $category_id,
+    ':uid' => $this_user_id
+  ]);
+  $noteId = (int)$pdo->lastInsertId();
+  if ($noteId === 0) {
+    throw new PDOException('Insert failed');
+  }
+
+  if (!empty($_FILES['attachments']['name'][0])) {
+    $uploadDir = __DIR__ . '/../uploads/';
+    if (!is_dir($uploadDir)) {
+      mkdir($uploadDir, 0777, true);
+    }
+    foreach ($_FILES['attachments']['name'] as $i => $name) {
+      if ($_FILES['attachments']['error'][$i] === UPLOAD_ERR_OK) {
+        $baseName = basename($name);
+        $safeName = preg_replace('/[^A-Za-z0-9._-]/', '_', $baseName);
+        $targetName = 'note_' . $noteId . '_' . time() . '_' . $safeName;
+        $targetPath = $uploadDir . $targetName;
+        if (move_uploaded_file($_FILES['attachments']['tmp_name'][$i], $targetPath)) {
+          $dbPath = '/admin/minder/notes/uploads/' . $targetName;
+          $pdo->prepare('INSERT INTO admin_minder_note_file (note_id, file_name, file_path, file_size, file_type, user_id, user_updated) VALUES (:nid,:fname,:fpath,:fsize,:ftype,:uid,:uid)')
+            ->execute([
+              ':nid' => $noteId,
+              ':fname' => $baseName,
+              ':fpath' => $dbPath,
+              ':fsize' => $_FILES['attachments']['size'][$i],
+              ':ftype' => $_FILES['attachments']['type'][$i],
+              ':uid' => $this_user_id
+            ]);
+        }
+      }
+    }
+  }
+} catch (PDOException $e) {
+  if ($isAjax) {
+    header('Content-Type: application/json');
+    echo json_encode(['success'=>false,'error'=>$e->getMessage()]);
+  } else {
+    $_SESSION['error_message'] = 'Unable to save note';
+    header('Location: ../note.php');
+  }
+  exit;
+}
+
+admin_audit_log($pdo, $this_user_id, 'minder_note', $noteId, 'CREATE', null, json_encode(['title'=>$title]), 'Created note');
+
+if ($isAjax) {
+  header('Content-Type: application/json');
+  $fetch = $pdo->prepare('SELECT n.id, n.title, n.body, n.category_id, n.date_created, cat.label AS category_label FROM admin_minder_note n LEFT JOIN lookup_list_items cat ON n.category_id = cat.id WHERE n.id = :id');
+  $fetch->execute([':id' => $noteId]);
+  $note = $fetch->fetch(PDO::FETCH_ASSOC);
+  $fileFetch = $pdo->prepare('SELECT id, file_name, file_path FROM admin_minder_note_file WHERE note_id = :id');
+  $fileFetch->execute([':id' => $noteId]);
+  $note['attachments'] = $fileFetch->fetchAll(PDO::FETCH_ASSOC);
+  echo json_encode(['success'=>true,'note'=>$note]);
+} else {
+  $_SESSION['message'] = 'Note saved';
+  header('Location: ../note.php?id=' . $noteId);
+}
+exit;

--- a/admin/minder/notes/functions/delete.php
+++ b/admin/minder/notes/functions/delete.php
@@ -1,0 +1,46 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/php_header.php';
+require_permission('minder_note','delete');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+  $_SESSION['error_message'] = 'Method not allowed';
+  header('Location: ../index.php');
+  exit;
+}
+
+if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+  $_SESSION['error_message'] = 'Invalid CSRF token';
+  header('Location: ../index.php');
+  exit;
+}
+
+$id = (int)($_POST['id'] ?? 0);
+if ($id <= 0) {
+  $_SESSION['error_message'] = 'Invalid ID';
+  header('Location: ../index.php');
+  exit;
+}
+
+try {
+  $fileStmt = $pdo->prepare('SELECT file_path FROM admin_minder_note_file WHERE note_id = :id');
+  $fileStmt->execute([':id' => $id]);
+  $paths = $fileStmt->fetchAll(PDO::FETCH_COLUMN);
+  foreach ($paths as $p) {
+    $full = __DIR__ . '/../uploads/' . basename($p);
+    if (is_file($full)) {
+      @unlink($full);
+    }
+  }
+  $pdo->prepare('DELETE FROM admin_minder_note WHERE id = :id')->execute([':id' => $id]);
+} catch (PDOException $e) {
+  $_SESSION['error_message'] = 'Delete failed';
+  header('Location: ../index.php');
+  exit;
+}
+
+admin_audit_log($pdo, $this_user_id, 'minder_note', $id, 'DELETE', null, null, 'Deleted note');
+
+$_SESSION['message'] = 'Note deleted';
+header('Location: ../index.php');
+exit;

--- a/admin/minder/notes/functions/update.php
+++ b/admin/minder/notes/functions/update.php
@@ -1,0 +1,112 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/php_header.php';
+require_permission('minder_note','update');
+
+$isAjax = ($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '') === 'XMLHttpRequest'
+    || str_contains($_SERVER['HTTP_ACCEPT'] ?? '', 'application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+  if ($isAjax) {
+    header('Content-Type: application/json');
+    http_response_code(405);
+    echo json_encode(['success'=>false,'error'=>'Method not allowed']);
+  } else {
+    $_SESSION['error_message'] = 'Method not allowed';
+    header('Location: ../index.php');
+  }
+  exit;
+}
+
+if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+  if ($isAjax) {
+    header('Content-Type: application/json');
+    http_response_code(403);
+    echo json_encode(['success'=>false,'error'=>'Invalid CSRF token']);
+  } else {
+    $_SESSION['error_message'] = 'Invalid CSRF token';
+    header('Location: ../index.php');
+  }
+  exit;
+}
+
+$id = (int)($_POST['id'] ?? 0);
+$title = trim($_POST['title'] ?? '');
+$body  = trim($_POST['body'] ?? '');
+$category_id = $_POST['category_id'] !== '' ? (int)$_POST['category_id'] : null;
+
+if ($id <= 0 || $title === '' || $body === '') {
+  if ($isAjax) {
+    header('Content-Type: application/json');
+    http_response_code(400);
+    echo json_encode(['success'=>false,'error'=>'Invalid data']);
+  } else {
+    $_SESSION['error_message'] = 'Invalid data';
+    header('Location: ../index.php');
+  }
+  exit;
+}
+
+try {
+  $stmt = $pdo->prepare('UPDATE admin_minder_note SET title = :title, body = :body, category_id = :category_id, user_updated = :uid WHERE id = :id');
+  $stmt->execute([
+    ':title' => $title,
+    ':body' => $body,
+    ':category_id' => $category_id,
+    ':uid' => $this_user_id,
+    ':id' => $id
+  ]);
+
+  if (!empty($_FILES['attachments']['name'][0])) {
+    $uploadDir = __DIR__ . '/../uploads/';
+    if (!is_dir($uploadDir)) {
+      mkdir($uploadDir, 0777, true);
+    }
+    foreach ($_FILES['attachments']['name'] as $i => $name) {
+      if ($_FILES['attachments']['error'][$i] === UPLOAD_ERR_OK) {
+        $baseName = basename($name);
+        $safeName = preg_replace('/[^A-Za-z0-9._-]/', '_', $baseName);
+        $targetName = 'note_' . $id . '_' . time() . '_' . $safeName;
+        $targetPath = $uploadDir . $targetName;
+        if (move_uploaded_file($_FILES['attachments']['tmp_name'][$i], $targetPath)) {
+          $dbPath = '/admin/minder/notes/uploads/' . $targetName;
+          $pdo->prepare('INSERT INTO admin_minder_note_file (note_id, file_name, file_path, file_size, file_type, user_id, user_updated) VALUES (:nid,:fname,:fpath,:fsize,:ftype,:uid,:uid)')
+            ->execute([
+              ':nid' => $id,
+              ':fname' => $baseName,
+              ':fpath' => $dbPath,
+              ':fsize' => $_FILES['attachments']['size'][$i],
+              ':ftype' => $_FILES['attachments']['type'][$i],
+              ':uid' => $this_user_id
+            ]);
+        }
+      }
+    }
+  }
+} catch (PDOException $e) {
+  if ($isAjax) {
+    header('Content-Type: application/json');
+    echo json_encode(['success'=>false,'error'=>$e->getMessage()]);
+  } else {
+    $_SESSION['error_message'] = 'Unable to update note';
+    header('Location: ../note.php?id=' . $id);
+  }
+  exit;
+}
+
+admin_audit_log($pdo, $this_user_id, 'minder_note', $id, 'UPDATE', null, json_encode(['title'=>$title]), 'Updated note');
+
+if ($isAjax) {
+  header('Content-Type: application/json');
+  $fetch = $pdo->prepare('SELECT n.id, n.title, n.body, n.category_id, n.date_created, cat.label AS category_label FROM admin_minder_note n LEFT JOIN lookup_list_items cat ON n.category_id = cat.id WHERE n.id = :id');
+  $fetch->execute([':id' => $id]);
+  $note = $fetch->fetch(PDO::FETCH_ASSOC);
+  $fileFetch = $pdo->prepare('SELECT id, file_name, file_path FROM admin_minder_note_file WHERE note_id = :id');
+  $fileFetch->execute([':id' => $id]);
+  $note['attachments'] = $fileFetch->fetchAll(PDO::FETCH_ASSOC);
+  echo json_encode(['success'=>true,'note'=>$note]);
+} else {
+  $_SESSION['message'] = 'Note updated';
+  header('Location: ../note.php?id=' . $id);
+}
+exit;

--- a/admin/minder/notes/index.php
+++ b/admin/minder/notes/index.php
@@ -1,0 +1,124 @@
+<?php
+require_once __DIR__ . '/../../admin_header.php';
+require_permission('minder_note','read');
+
+$token = generate_csrf_token();
+
+$sql = "SELECT n.id, n.title, n.body, n.category_id, n.date_created, cat.label AS category_label
+        FROM admin_minder_note n
+        LEFT JOIN lookup_list_items cat ON n.category_id = cat.id
+        ORDER BY n.date_created DESC";
+$notes = $pdo->query($sql)->fetchAll(PDO::FETCH_ASSOC);
+
+$fileStmt = $pdo->prepare('SELECT id, file_name, file_path FROM admin_minder_note_file WHERE note_id = :id');
+foreach ($notes as &$n) {
+  $fileStmt->execute([':id' => $n['id']]);
+  $n['attachments'] = $fileStmt->fetchAll(PDO::FETCH_ASSOC);
+}
+unset($n);
+
+$categories = get_lookup_items($pdo, 'ADMIN_NOTE_CATEGORY');
+?>
+<h2 class="mb-4">Notes</h2>
+<?= flash_message($_SESSION['message'] ?? '', 'success'); ?>
+<?= flash_message($_SESSION['error_message'] ?? '', 'danger'); ?>
+<?php unset($_SESSION['message'], $_SESSION['error_message']); ?>
+<?php if (user_has_permission('minder_note','create')): ?>
+<button class="btn btn-sm btn-primary mb-3" id="addNoteBtn">Add Note</button>
+<?php endif; ?>
+<div class="timeline">
+<?php foreach ($notes as $note): ?>
+  <div class="timeline-item mb-4">
+    <div class="timeline-date text-secondary small"><?= e(date('Y-m-d H:i', strtotime($note['date_created']))); ?></div>
+    <h5 class="mb-1"><?= e($note['title']); ?></h5>
+    <?php if ($note['category_label']): ?><span class="badge bg-info mb-2"><?= e($note['category_label']); ?></span><?php endif; ?>
+    <p><?= nl2br(e($note['body'])); ?></p>
+    <?php if (!empty($note['attachments'])): ?>
+    <div class="mb-2">
+      <?php foreach ($note['attachments'] as $f): ?>
+        <a href="<?= e($f['file_path']); ?>" target="_blank"><?= e($f['file_name']); ?></a><br>
+      <?php endforeach; ?>
+    </div>
+    <?php endif; ?>
+    <div>
+      <?php if (user_has_permission('minder_note','update')): ?>
+        <a class="btn btn-sm btn-warning" href="note.php?id=<?= $note['id']; ?>">Edit</a>
+      <?php endif; ?>
+      <?php if (user_has_permission('minder_note','delete')): ?>
+        <form method="post" action="functions/delete.php" class="d-inline" onsubmit="return confirm('Delete this note?');">
+          <input type="hidden" name="id" value="<?= $note['id']; ?>">
+          <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+          <button class="btn btn-sm btn-danger">Delete</button>
+        </form>
+      <?php endif; ?>
+    </div>
+  </div>
+<?php endforeach; ?>
+</div>
+<?php if (user_has_permission('minder_note','create')): ?>
+<div class="modal fade" id="noteModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <form class="modal-content" id="noteForm">
+      <div class="modal-header">
+        <h5 class="modal-title">Add Note</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div id="noteAlert"></div>
+        <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+        <div class="mb-3">
+          <label class="form-label">Title</label>
+          <input type="text" name="title" class="form-control" required>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Body</label>
+          <textarea name="body" class="form-control" rows="4" required></textarea>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Category</label>
+          <select name="category_id" class="form-select">
+            <option value="">--</option>
+            <?php foreach ($categories as $c): ?>
+            <option value="<?= $c['id']; ?>"><?= e($c['label']); ?></option>
+            <?php endforeach; ?>
+          </select>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Attachments</label>
+          <input type="file" name="attachments[]" class="form-control" multiple>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-primary" type="submit">Save</button>
+      </div>
+    </form>
+  </div>
+</div>
+<?php endif; ?>
+<script>
+<?php if (user_has_permission('minder_note','create')): ?>
+const noteModal = new bootstrap.Modal(document.getElementById('noteModal'));
+const noteForm = document.getElementById('noteForm');
+const noteAlert = document.getElementById('noteAlert');
+document.getElementById('addNoteBtn').addEventListener('click', () => {
+  noteAlert.innerHTML = '';
+  noteForm.reset();
+  noteModal.show();
+});
+noteForm.addEventListener('submit', e => {
+  e.preventDefault();
+  const formData = new FormData(noteForm);
+  fetch('functions/create.php', { method: 'POST', body: formData })
+    .then(res => res.json())
+    .then(data => {
+      if (data.success) {
+        window.location.reload();
+      } else {
+        noteAlert.innerHTML = `<div class="alert alert-danger">${data.error || 'Error'}</div>`;
+      }
+    })
+    .catch(() => noteAlert.innerHTML = '<div class="alert alert-danger">Server error</div>');
+});
+<?php endif; ?>
+</script>
+<?php require '../../admin_footer.php'; ?>

--- a/admin/minder/notes/note.php
+++ b/admin/minder/notes/note.php
@@ -1,0 +1,84 @@
+<?php
+require_once __DIR__ . '/../../admin_header.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$editing = $id > 0;
+
+if ($editing) {
+  require_permission('minder_note','update');
+  $stmt = $pdo->prepare('SELECT * FROM admin_minder_note WHERE id = :id');
+  $stmt->execute([':id' => $id]);
+  $note = $stmt->fetch(PDO::FETCH_ASSOC);
+  if (!$note) {
+    echo '<div class="alert alert-danger">Note not found.</div>';
+    require '../../admin_footer.php';
+    exit;
+  }
+  $fileStmt = $pdo->prepare('SELECT id, file_name, file_path FROM admin_minder_note_file WHERE note_id = :id');
+  $fileStmt->execute([':id' => $id]);
+  $files = $fileStmt->fetchAll(PDO::FETCH_ASSOC);
+} else {
+  require_permission('minder_note','create');
+  $note = ['title' => '', 'body' => '', 'category_id' => null];
+  $files = [];
+}
+
+$categories = get_lookup_items($pdo, 'ADMIN_NOTE_CATEGORY');
+$token = generate_csrf_token();
+?>
+<h2 class="mb-4"><?= $editing ? 'Edit Note' : 'Add Note'; ?></h2>
+<div id="noteAlert"></div>
+<form id="noteForm" enctype="multipart/form-data">
+  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+  <?php if ($editing): ?>
+  <input type="hidden" name="id" value="<?= $id; ?>">
+  <?php endif; ?>
+  <div class="mb-3">
+    <label class="form-label">Title</label>
+    <input type="text" name="title" class="form-control" value="<?= e($note['title']); ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Body</label>
+    <textarea name="body" class="form-control" rows="4" required><?= e($note['body']); ?></textarea>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Category</label>
+    <select name="category_id" class="form-select">
+      <option value="">--</option>
+      <?php foreach ($categories as $c): ?>
+      <option value="<?= $c['id']; ?>" <?= $note['category_id'] == $c['id'] ? 'selected' : ''; ?>><?= e($c['label']); ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Attachments</label>
+    <input type="file" name="attachments[]" class="form-control" multiple>
+    <?php if ($editing && $files): ?>
+    <ul class="mt-2">
+      <?php foreach ($files as $f): ?>
+      <li><a href="<?= e($f['file_path']); ?>" target="_blank"><?= e($f['file_name']); ?></a></li>
+      <?php endforeach; ?>
+    </ul>
+    <?php endif; ?>
+  </div>
+  <button class="btn btn-primary" type="submit">Save</button>
+</form>
+<script>
+const noteForm = document.getElementById('noteForm');
+const noteAlert = document.getElementById('noteAlert');
+noteForm.addEventListener('submit', e => {
+  e.preventDefault();
+  const formData = new FormData(noteForm);
+  fetch('functions/<?= $editing ? 'update' : 'create'; ?>.php', { method: 'POST', body: formData })
+    .then(res => res.json())
+    .then(data => {
+      if (data.success) {
+        window.location.href = 'index.php';
+      } else {
+        noteAlert.innerHTML = `<div class="alert alert-danger">${data.error || 'Error'}</div>`;
+      }
+    })
+    .catch(() => noteAlert.innerHTML = '<div class="alert alert-danger">Server error</div>');
+});
+</script>
+<?php require '../../admin_footer.php'; ?>


### PR DESCRIPTION
## Summary
- add admin minder notes listing with timeline UI and modal create form
- implement note editor with AJAX save and attachment uploads
- provide CRUD handlers enforcing minder_note permissions and SQL schema

## Testing
- `php -l admin/minder/notes/index.php admin/minder/notes/note.php admin/minder/notes/functions/create.php admin/minder/notes/functions/update.php admin/minder/notes/functions/delete.php`


------
https://chatgpt.com/codex/tasks/task_e_68b2326b2bd48333ab56b6cfbe71fae9