### PR TITLE
Add minder reminders calendar module

### DIFF
--- a/_SQL/202503_minder_reminder.sql
+++ b/_SQL/202503_minder_reminder.sql
@@ -1,0 +1,45 @@
+-- Table structure for minder_reminder
+CREATE TABLE `minder_reminder` (
+  `id` INT(11) NOT NULL AUTO_INCREMENT,
+  `user_id` INT(11),
+  `user_updated` INT(11),
+  `date_created` DATETIME DEFAULT CURRENT_TIMESTAMP,
+  `date_updated` DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `memo` TEXT DEFAULT NULL,
+  `title` VARCHAR(255) NOT NULL,
+  `description` TEXT,
+  `remind_at` DATETIME NOT NULL,
+  `repeat_type` VARCHAR(20) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Table structure for minder_reminder_assignments
+CREATE TABLE `minder_reminder_assignments` (
+  `id` INT(11) NOT NULL AUTO_INCREMENT,
+  `user_id` INT(11),
+  `user_updated` INT(11),
+  `date_created` DATETIME DEFAULT CURRENT_TIMESTAMP,
+  `date_updated` DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `memo` TEXT DEFAULT NULL,
+  `reminder_id` INT(11) NOT NULL,
+  `assigned_user_id` INT(11) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Indexes and constraints
+ALTER TABLE `minder_reminder`
+  ADD CONSTRAINT `fk_minder_reminder_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  ADD CONSTRAINT `fk_minder_reminder_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`) ON DELETE SET NULL;
+
+ALTER TABLE `minder_reminder_assignments`
+  ADD CONSTRAINT `fk_minder_reminder_assignments_reminder_id` FOREIGN KEY (`reminder_id`) REFERENCES `minder_reminder` (`id`) ON DELETE CASCADE,
+  ADD CONSTRAINT `fk_minder_reminder_assignments_assigned_user_id` FOREIGN KEY (`assigned_user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE,
+  ADD CONSTRAINT `fk_minder_reminder_assignments_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  ADD CONSTRAINT `fk_minder_reminder_assignments_user_updated` FOREIGN KEY (`user_updated`) REFERENCES `users` (`id`) ON DELETE SET NULL;
+
+-- Permissions
+INSERT INTO `admin_permissions` (`user_id`, `user_updated`, `date_created`, `date_updated`, `memo`, `module`, `action`) VALUES
+(1,1,NOW(),NOW(),NULL,'minder_reminder','create'),
+(1,1,NOW(),NOW(),NULL,'minder_reminder','read'),
+(1,1,NOW(),NOW(),NULL,'minder_reminder','update'),
+(1,1,NOW(),NOW(),NULL,'minder_reminder','delete');

--- a/admin/minder/reminders/functions/create.php
+++ b/admin/minder/reminders/functions/create.php
@@ -1,0 +1,85 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../../includes/php_header.php';
+require_permission('minder_reminder', 'create');
+
+$isAjax = ($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '') === 'XMLHttpRequest'
+    || str_contains($_SERVER['HTTP_ACCEPT'] ?? '', 'application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+  if ($isAjax) {
+    header('Content-Type: application/json', true, 405);
+    echo json_encode(['success' => false, 'error' => 'Method not allowed']);
+  } else {
+    $_SESSION['error_message'] = 'Method not allowed';
+    header('Location: ../reminder.php');
+  }
+  exit;
+}
+
+if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+  if ($isAjax) {
+    header('Content-Type: application/json', true, 403);
+    echo json_encode(['success' => false, 'error' => 'Invalid CSRF token']);
+  } else {
+    $_SESSION['error_message'] = 'Invalid CSRF token';
+    header('Location: ../reminder.php');
+  }
+  exit;
+}
+
+$title = trim($_POST['title'] ?? '');
+$remind_at = $_POST['remind_at'] ?? '';
+if ($title === '' || $remind_at === '') {
+  $error = 'Title and Remind At required';
+  if ($isAjax) {
+    header('Content-Type: application/json', true, 400);
+    echo json_encode(['success'=>false,'error'=>$error]);
+  } else {
+    $_SESSION['error_message'] = $error;
+    header('Location: ../reminder.php');
+  }
+  exit;
+}
+$description = $_POST['description'] ?? null;
+$repeat_type = $_POST['repeat_type'] ?? null;
+$memo = $_POST['memo'] ?? null;
+$assigned_user_ids = isset($_POST['assignments']) ? array_map('intval',(array)$_POST['assignments']) : [];
+
+$reminderId = 0;
+try {
+  $stmt = $pdo->prepare('INSERT INTO minder_reminder (title, description, remind_at, repeat_type, memo, user_id, user_updated) VALUES (:title,:description,:remind_at,:repeat_type,:memo,:uid,:uid)');
+  $stmt->execute([
+    ':title'=>$title,
+    ':description'=>$description,
+    ':remind_at'=>$remind_at,
+    ':repeat_type'=>$repeat_type,
+    ':memo'=>$memo,
+    ':uid'=>$this_user_id
+  ]);
+  $reminderId = (int)$pdo->lastInsertId();
+  foreach ($assigned_user_ids as $assigned_user_id) {
+    $pdo->prepare('INSERT INTO minder_reminder_assignments (reminder_id, assigned_user_id, user_id, user_updated) VALUES (:rid,:aid,:uid,:uid)')
+        ->execute([':rid'=>$reminderId, ':aid'=>$assigned_user_id, ':uid'=>$this_user_id]);
+  }
+} catch (PDOException $e) {
+  if ($isAjax) {
+    header('Content-Type: application/json');
+    echo json_encode(['success'=>false,'error'=>$e->getMessage()]);
+  } else {
+    $_SESSION['error_message']='Unable to save reminder';
+    header('Location: ../reminder.php');
+  }
+  exit;
+}
+
+admin_audit_log($pdo, $this_user_id, 'minder_reminder', $reminderId, 'CREATE', null, json_encode(['title'=>$title]), 'Created reminder');
+
+if ($isAjax) {
+  header('Content-Type: application/json');
+  echo json_encode(['success'=>true,'reminder_id'=>$reminderId]);
+} else {
+  $_SESSION['message'] = 'Reminder saved';
+  header('Location: ../reminder.php?id=' . $reminderId);
+}
+exit;

--- a/admin/minder/reminders/functions/delete.php
+++ b/admin/minder/reminders/functions/delete.php
@@ -1,0 +1,65 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../../includes/php_header.php';
+require_permission('minder_reminder', 'delete');
+
+$isAjax = ($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '') === 'XMLHttpRequest'
+    || str_contains($_SERVER['HTTP_ACCEPT'] ?? '', 'application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+  if ($isAjax) {
+    header('Content-Type: application/json', true, 405);
+    echo json_encode(['success'=>false,'error'=>'Method not allowed']);
+  } else {
+    $_SESSION['error_message'] = 'Method not allowed';
+    header('Location: ../index.php');
+  }
+  exit;
+}
+
+if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+  if ($isAjax) {
+    header('Content-Type: application/json', true, 403);
+    echo json_encode(['success'=>false,'error'=>'Invalid CSRF token']);
+  } else {
+    $_SESSION['error_message'] = 'Invalid CSRF token';
+    header('Location: ../index.php');
+  }
+  exit;
+}
+
+$id = (int)($_POST['id'] ?? 0);
+if ($id <= 0) {
+  if ($isAjax) {
+    header('Content-Type: application/json', true, 400);
+    echo json_encode(['success'=>false,'error'=>'Invalid ID']);
+  } else {
+    $_SESSION['error_message'] = 'Invalid ID';
+    header('Location: ../index.php');
+  }
+  exit;
+}
+
+try {
+  $pdo->prepare('DELETE FROM minder_reminder WHERE id=:id')->execute([':id'=>$id]);
+} catch (PDOException $e) {
+  if ($isAjax) {
+    header('Content-Type: application/json');
+    echo json_encode(['success'=>false,'error'=>$e->getMessage()]);
+  } else {
+    $_SESSION['error_message']='Unable to delete reminder';
+    header('Location: ../index.php');
+  }
+  exit;
+}
+
+admin_audit_log($pdo, $this_user_id, 'minder_reminder', $id, 'DELETE', null, null, 'Deleted reminder');
+
+if ($isAjax) {
+  header('Content-Type: application/json');
+  echo json_encode(['success'=>true]);
+} else {
+  $_SESSION['message'] = 'Reminder deleted';
+  header('Location: ../index.php');
+}
+exit;

--- a/admin/minder/reminders/functions/list.php
+++ b/admin/minder/reminders/functions/list.php
@@ -1,0 +1,23 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../../includes/php_header.php';
+require_permission('minder_reminder', 'read');
+
+header('Content-Type: application/json');
+
+$stmt = $pdo->query('SELECT r.id, r.title, r.description, r.remind_at, r.repeat_type, GROUP_CONCAT(ra.assigned_user_id) AS assigned_users FROM minder_reminder r LEFT JOIN minder_reminder_assignments ra ON r.id = ra.reminder_id GROUP BY r.id');
+$events = [];
+while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+  $events[] = [
+    'id' => $row['id'],
+    'title' => $row['title'],
+    'start' => $row['remind_at'],
+    'extendedProps' => [
+      'description' => $row['description'],
+      'repeat_type' => $row['repeat_type'],
+      'assigned_users' => $row['assigned_users'] ? array_map('intval', explode(',', $row['assigned_users'])) : []
+    ]
+  ];
+}
+echo json_encode($events);
+exit;

--- a/admin/minder/reminders/functions/update.php
+++ b/admin/minder/reminders/functions/update.php
@@ -1,0 +1,86 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../../includes/php_header.php';
+require_permission('minder_reminder', 'update');
+
+$isAjax = ($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '') === 'XMLHttpRequest'
+    || str_contains($_SERVER['HTTP_ACCEPT'] ?? '', 'application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+  if ($isAjax) {
+    header('Content-Type: application/json', true, 405);
+    echo json_encode(['success' => false, 'error' => 'Method not allowed']);
+  } else {
+    $_SESSION['error_message'] = 'Method not allowed';
+    header('Location: ../reminder.php');
+  }
+  exit;
+}
+
+if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+  if ($isAjax) {
+    header('Content-Type: application/json', true, 403);
+    echo json_encode(['success' => false, 'error' => 'Invalid CSRF token']);
+  } else {
+    $_SESSION['error_message'] = 'Invalid CSRF token';
+    header('Location: ../reminder.php');
+  }
+  exit;
+}
+
+$id = (int)($_POST['id'] ?? 0);
+$title = trim($_POST['title'] ?? '');
+$remind_at = $_POST['remind_at'] ?? '';
+if ($id <= 0 || $title === '' || $remind_at === '') {
+  $error = 'Invalid data';
+  if ($isAjax) {
+    header('Content-Type: application/json', true, 400);
+    echo json_encode(['success'=>false,'error'=>$error]);
+  } else {
+    $_SESSION['error_message'] = $error;
+    header('Location: ../reminder.php?id='.$id);
+  }
+  exit;
+}
+$description = $_POST['description'] ?? null;
+$repeat_type = $_POST['repeat_type'] ?? null;
+$memo = $_POST['memo'] ?? null;
+$assigned_user_ids = isset($_POST['assignments']) ? array_map('intval',(array)$_POST['assignments']) : [];
+
+try {
+  $stmt = $pdo->prepare('UPDATE minder_reminder SET title=:title, description=:description, remind_at=:remind_at, repeat_type=:repeat_type, memo=:memo, user_updated=:uid WHERE id=:id');
+  $stmt->execute([
+    ':title'=>$title,
+    ':description'=>$description,
+    ':remind_at'=>$remind_at,
+    ':repeat_type'=>$repeat_type,
+    ':memo'=>$memo,
+    ':uid'=>$this_user_id,
+    ':id'=>$id
+  ]);
+  $pdo->prepare('DELETE FROM minder_reminder_assignments WHERE reminder_id=:id')->execute([':id'=>$id]);
+  foreach ($assigned_user_ids as $assigned_user_id) {
+    $pdo->prepare('INSERT INTO minder_reminder_assignments (reminder_id, assigned_user_id, user_id, user_updated) VALUES (:rid,:aid,:uid,:uid)')
+        ->execute([':rid'=>$id, ':aid'=>$assigned_user_id, ':uid'=>$this_user_id]);
+  }
+} catch (PDOException $e) {
+  if ($isAjax) {
+    header('Content-Type: application/json');
+    echo json_encode(['success'=>false,'error'=>$e->getMessage()]);
+  } else {
+    $_SESSION['error_message']='Unable to update reminder';
+    header('Location: ../reminder.php?id='.$id);
+  }
+  exit;
+}
+
+admin_audit_log($pdo, $this_user_id, 'minder_reminder', $id, 'UPDATE', null, json_encode(['title'=>$title]), 'Updated reminder');
+
+if ($isAjax) {
+  header('Content-Type: application/json');
+  echo json_encode(['success'=>true]);
+} else {
+  $_SESSION['message'] = 'Reminder updated';
+  header('Location: ../reminder.php?id=' . $id);
+}
+exit;

--- a/admin/minder/reminders/index.php
+++ b/admin/minder/reminders/index.php
@@ -1,0 +1,149 @@
+<?php
+require_once __DIR__ . '/../../admin_header.php';
+require_permission('minder_reminder','read');
+
+$token = generate_csrf_token();
+$userStmt = $pdo->query('SELECT id, email FROM users ORDER BY email');
+$users = $userStmt->fetchAll(PDO::FETCH_ASSOC);
+?>
+<h2 class="mb-4">Reminders</h2>
+<?= flash_message($_SESSION['message'] ?? '', 'success'); ?>
+<?= flash_message($_SESSION['error_message'] ?? '', 'danger'); ?>
+<?php unset($_SESSION['message'], $_SESSION['error_message']); ?>
+<?php if (user_has_permission('minder_reminder','create')): ?>
+<button class="btn btn-sm btn-primary mb-3" id="addReminderBtn">Add Reminder</button>
+<?php endif; ?>
+<div class="calendar-outline mt-6 mb-9" id="appCalendar"></div>
+<div class="modal fade" id="reminderModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <form class="modal-content" id="reminderForm">
+      <div class="modal-header">
+        <h5 class="modal-title" id="reminderModalLabel">Add Reminder</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div id="reminderAlert"></div>
+        <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+        <input type="hidden" name="id" id="reminder-id">
+        <div class="mb-3">
+          <label class="form-label">Title</label>
+          <input type="text" name="title" id="reminder-title" class="form-control" required>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Description</label>
+          <textarea name="description" id="reminder-description" class="form-control" rows="3"></textarea>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Remind At</label>
+          <input type="text" name="remind_at" id="reminder-remind-at" class="form-control datetimepicker" placeholder="yyyy/mm/dd hh:mm" data-options='{"disableMobile":true,"enableTime":true,"dateFormat":"Y-m-d H:i"}' required>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Repeat</label>
+          <select name="repeat_type" id="reminder-repeat-type" class="form-select">
+            <option value="">None</option>
+            <option value="daily">Daily</option>
+            <option value="weekly">Weekly</option>
+            <option value="monthly">Monthly</option>
+            <option value="yearly">Yearly</option>
+          </select>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Assign Users</label>
+          <select name="assignments[]" id="reminder-assignments" class="form-select" multiple>
+            <?php foreach ($users as $u): ?>
+            <option value="<?= $u['id']; ?>"><?= e($u['email']); ?></option>
+            <?php endforeach; ?>
+          </select>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-danger me-auto d-none" id="deleteReminderBtn">Delete</button>
+        <button type="submit" class="btn btn-primary">Save</button>
+      </div>
+    </form>
+  </div>
+</div>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/main.min.css">
+<script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+<script>
+const canCreate = <?= user_has_permission('minder_reminder','create') ? 'true' : 'false'; ?>;
+const canUpdate = <?= user_has_permission('minder_reminder','update') ? 'true' : 'false'; ?>;
+const canDelete = <?= user_has_permission('minder_reminder','delete') ? 'true' : 'false'; ?>;
+document.addEventListener('DOMContentLoaded', function() {
+  const calendarEl = document.getElementById('appCalendar');
+  const reminderModalEl = document.getElementById('reminderModal');
+  const reminderModal = new bootstrap.Modal(reminderModalEl);
+  const form = document.getElementById('reminderForm');
+  flatpickr('.datetimepicker', JSON.parse(form.querySelector('.datetimepicker').dataset.options));
+  const calendar = new FullCalendar.Calendar(calendarEl, {
+    initialView: 'dayGridMonth',
+    events: 'functions/list.php',
+    eventClick: function(info) {
+      if (!canUpdate) return;
+      const ev = info.event;
+      form.reset();
+      document.getElementById('reminderModalLabel').textContent = 'Edit Reminder';
+      form.id.value = ev.id;
+      form.title.value = ev.title;
+      form.description.value = ev.extendedProps.description || '';
+      form.remind_at.value = ev.start.toISOString().slice(0,16).replace('T',' ');
+      form.repeat_type.value = ev.extendedProps.repeat_type || '';
+      const assigned = ev.extendedProps.assigned_users || [];
+      for (const opt of form['assignments[]'].options) {
+        opt.selected = assigned.includes(parseInt(opt.value));
+      }
+      document.getElementById('deleteReminderBtn').classList.toggle('d-none', !canDelete);
+      reminderModal.show();
+    }
+  });
+  calendar.render();
+  const addBtn = document.getElementById('addReminderBtn');
+  if (addBtn) {
+    addBtn.addEventListener('click', () => {
+      form.reset();
+      document.getElementById('reminderModalLabel').textContent = 'Add Reminder';
+      form.id.value = '';
+      document.getElementById('deleteReminderBtn').classList.add('d-none');
+      reminderModal.show();
+    });
+  }
+  form.addEventListener('submit', function(e) {
+    e.preventDefault();
+    const formData = new FormData(form);
+    const isEdit = formData.get('id');
+    fetch('functions/' + (isEdit ? 'update.php' : 'create.php'), {
+      method: 'POST',
+      body: formData,
+      headers: {'X-Requested-With':'XMLHttpRequest'}
+    }).then(resp => resp.json()).then(data => {
+      if (data.success) {
+        reminderModal.hide();
+        calendar.refetchEvents();
+      } else {
+        document.getElementById('reminderAlert').innerHTML = '<div class="alert alert-danger">'+(data.error||'Error')+'</div>';
+      }
+    });
+  });
+  document.getElementById('deleteReminderBtn').addEventListener('click', function() {
+    const id = form.id.value;
+    if (!id || !confirm('Delete this reminder?')) return;
+    const fd = new FormData();
+    fd.append('id', id);
+    fd.append('csrf_token', form.csrf_token.value);
+    fetch('functions/delete.php', {
+      method:'POST',
+      body: fd,
+      headers: {'X-Requested-With':'XMLHttpRequest'}
+    }).then(resp=>resp.json()).then(data=>{
+      if (data.success) {
+        reminderModal.hide();
+        calendar.refetchEvents();
+      } else {
+        document.getElementById('reminderAlert').innerHTML = '<div class="alert alert-danger">'+(data.error||'Error')+'</div>';
+      }
+    });
+  });
+});
+</script>
+<?php require_once __DIR__ . '/../../admin_footer.php'; ?>

--- a/admin/minder/reminders/reminder.php
+++ b/admin/minder/reminders/reminder.php
@@ -1,0 +1,90 @@
+<?php
+require_once __DIR__ . '/../../admin_header.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$editing = $id > 0;
+
+if ($editing) {
+  require_permission('minder_reminder','update');
+  $stmt = $pdo->prepare('SELECT * FROM minder_reminder WHERE id = :id');
+  $stmt->execute([':id' => $id]);
+  $reminder = $stmt->fetch(PDO::FETCH_ASSOC);
+  if (!$reminder) {
+    echo '<div class="alert alert-danger">Reminder not found.</div>';
+    require_once __DIR__ . '/../../admin_footer.php';
+    exit;
+  }
+} else {
+  require_permission('minder_reminder','create');
+  $reminder = [
+    'title' => '',
+    'description' => '',
+    'remind_at' => '',
+    'repeat_type' => '',
+    'memo' => null
+  ];
+}
+
+$userStmt = $pdo->query('SELECT id, email FROM users ORDER BY email');
+$users = $userStmt->fetchAll(PDO::FETCH_ASSOC);
+
+$assignedUserIds = [];
+if ($editing) {
+  $assStmt = $pdo->prepare('SELECT assigned_user_id FROM minder_reminder_assignments WHERE reminder_id = :id');
+  $assStmt->execute([':id' => $id]);
+  $assignedUserIds = $assStmt->fetchAll(PDO::FETCH_COLUMN);
+}
+
+$token = generate_csrf_token();
+?>
+<h2 class="mb-4"><?= $editing ? 'Edit Reminder' : 'Add Reminder'; ?></h2>
+<?= flash_message($_SESSION['message'] ?? '', 'success'); ?>
+<?= flash_message($_SESSION['error_message'] ?? '', 'danger'); ?>
+<?php unset($_SESSION['message'], $_SESSION['error_message']); ?>
+<form method="post" action="functions/<?= $editing ? 'update' : 'create'; ?>.php">
+  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+  <?php if ($editing): ?>
+  <input type="hidden" name="id" value="<?= $id; ?>">
+  <?php endif; ?>
+  <div class="mb-3">
+    <label class="form-label">Title</label>
+    <input type="text" name="title" class="form-control" value="<?= e($reminder['title']); ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Description</label>
+    <textarea name="description" class="form-control" rows="3"><?= e($reminder['description']); ?></textarea>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Remind At</label>
+    <input type="datetime-local" name="remind_at" class="form-control" value="<?= $reminder['remind_at'] ? e(date('Y-m-d\TH:i', strtotime($reminder['remind_at']))) : ''; ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Repeat</label>
+    <select name="repeat_type" class="form-select">
+      <option value="">None</option>
+      <option value="daily" <?= $reminder['repeat_type']=='daily'?'selected':''; ?>>Daily</option>
+      <option value="weekly" <?= $reminder['repeat_type']=='weekly'?'selected':''; ?>>Weekly</option>
+      <option value="monthly" <?= $reminder['repeat_type']=='monthly'?'selected':''; ?>>Monthly</option>
+      <option value="yearly" <?= $reminder['repeat_type']=='yearly'?'selected':''; ?>>Yearly</option>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Assign Users</label>
+    <select name="assignments[]" class="form-select" multiple>
+      <?php foreach ($users as $u): ?>
+      <option value="<?= $u['id']; ?>" <?= in_array($u['id'], $assignedUserIds) ? 'selected' : ''; ?>><?= e($u['email']); ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Memo</label>
+    <textarea name="memo" class="form-control" rows="2"><?= e($reminder['memo']); ?></textarea>
+  </div>
+  <div class="mb-3">
+    <button class="btn btn-sm btn-primary" type="submit">Save</button>
+    <?php if ($editing && user_has_permission('minder_reminder','delete')): ?>
+    <a href="functions/delete.php?id=<?= $id; ?>&csrf_token=<?= $token; ?>" class="btn btn-sm btn-danger" onclick="return confirm('Delete this reminder?');">Delete</a>
+    <?php endif; ?>
+  </div>
+</form>
+<?php require_once __DIR__ . '/../../admin_footer.php'; ?>


### PR DESCRIPTION
## Summary
- add admin reminders calendar with modal create/edit and AJAX event loading
- implement CRUD endpoints enforcing `minder_reminder` permissions
- seed SQL tables and permissions for reminders and assignments

## Testing
- `php -l admin/minder/reminders/index.php`
- `php -l admin/minder/reminders/reminder.php`
- `php -l admin/minder/reminders/functions/create.php`
- `php -l admin/minder/reminders/functions/update.php`
- `php -l admin/minder/reminders/functions/delete.php`
- `php -l admin/minder/reminders/functions/list.php`


------
https://chatgpt.com/codex/tasks/task_e_68b2326c856c8333ac18d5c690b230a2