### PR TITLE
Scaffold admin asset management module

### DIFF
--- a/_SQL/202503_module_assets.sql
+++ b/_SQL/202503_module_assets.sql
@@ -1,0 +1,67 @@
+CREATE TABLE `module_assets` (
+  `id` INT(11) AUTO_INCREMENT PRIMARY KEY,
+  `user_id` INT(11),
+  `user_updated` INT(11),
+  `date_created` DATETIME DEFAULT CURRENT_TIMESTAMP,
+  `date_updated` DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `memo` TEXT DEFAULT NULL,
+  `asset_tag` VARCHAR(50) NOT NULL,
+  `type_id` INT(11) NOT NULL,
+  `status_id` INT(11) DEFAULT NULL,
+  `model` VARCHAR(100) DEFAULT NULL,
+  `serial` VARCHAR(100) DEFAULT NULL,
+  `purchase_date` DATE DEFAULT NULL,
+  `warranty_expiration` DATE DEFAULT NULL,
+  `compliance_flags` VARCHAR(255) DEFAULT NULL,
+  `assignee_id` INT(11) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `module_asset_tags` (
+  `id` INT(11) AUTO_INCREMENT PRIMARY KEY,
+  `asset_id` INT(11) NOT NULL,
+  `tag` VARCHAR(100) NOT NULL,
+  `user_id` INT(11),
+  `user_updated` INT(11),
+  `date_created` DATETIME DEFAULT CURRENT_TIMESTAMP,
+  `date_updated` DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `module_asset_files` (
+  `id` INT(11) AUTO_INCREMENT PRIMARY KEY,
+  `asset_id` INT(11) NOT NULL,
+  `file_path` VARCHAR(255) NOT NULL,
+  `user_id` INT(11),
+  `user_updated` INT(11),
+  `date_created` DATETIME DEFAULT CURRENT_TIMESTAMP,
+  `date_updated` DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `module_asset_events` (
+  `id` INT(11) AUTO_INCREMENT PRIMARY KEY,
+  `asset_id` INT(11) NOT NULL,
+  `event_type` VARCHAR(50) NOT NULL,
+  `memo` TEXT DEFAULT NULL,
+  `user_id` INT(11),
+  `user_updated` INT(11),
+  `date_created` DATETIME DEFAULT CURRENT_TIMESTAMP,
+  `date_updated` DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `module_asset_assignments` (
+  `id` INT(11) AUTO_INCREMENT PRIMARY KEY,
+  `asset_id` INT(11) NOT NULL,
+  `contractor_id` INT(11) NOT NULL,
+  `assigned_date` DATETIME DEFAULT CURRENT_TIMESTAMP,
+  `returned_date` DATETIME DEFAULT NULL,
+  `user_id` INT(11),
+  `user_updated` INT(11),
+  `date_created` DATETIME DEFAULT CURRENT_TIMESTAMP,
+  `date_updated` DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `module_asset_tag_seq` (
+  `id` INT(11) AUTO_INCREMENT PRIMARY KEY,
+  `type_id` INT(11) NOT NULL,
+  `year` INT(4) NOT NULL,
+  `seq` INT(11) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/admin/assets/asset.php
+++ b/admin/assets/asset.php
@@ -1,0 +1,141 @@
+<?php
+require '../admin_header.php';
+require_permission('assets','read');
+
+function get_asset_tags(PDO $pdo, int $asset_id): array {
+  $stmt = $pdo->prepare('SELECT tag FROM module_asset_tags WHERE asset_id=:id');
+  $stmt->execute([':id'=>$asset_id]);
+  return array_column($stmt->fetchAll(PDO::FETCH_ASSOC),'tag');
+}
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$editing = $id > 0;
+$token = generate_csrf_token();
+
+$asset = null;
+if ($editing) {
+  $stmt = $pdo->prepare('SELECT * FROM module_assets WHERE id=:id');
+  $stmt->execute([':id'=>$id]);
+  $asset = $stmt->fetch(PDO::FETCH_ASSOC);
+  if (!$asset) {
+    $_SESSION['error_message'] = 'Asset not found';
+    header('Location: index.php');
+    exit;
+  }
+}
+
+$types = get_lookup_items($pdo,'ASSET_TYPE');
+$statuses = get_lookup_items($pdo,'ASSET_STATUS');
+$tags = $editing ? get_asset_tags($pdo,$id) : [];
+?>
+<h2 class="mb-4"><?= $editing ? 'Edit' : 'Add'; ?> Asset</h2>
+<?= flash_message($_SESSION['message'] ?? '', 'success'); ?>
+<?= flash_message($_SESSION['error_message'] ?? '', 'danger'); ?>
+<?php unset($_SESSION['message'], $_SESSION['error_message']); ?>
+<form method="post" action="functions/<?= $editing?'update':'create'; ?>.php" enctype="multipart/form-data" id="assetForm">
+  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+  <?php if ($editing): ?><input type="hidden" name="id" value="<?= $id; ?>"><?php endif; ?>
+  <div class="row mb-3">
+    <div class="col">
+      <label class="form-label">Type</label>
+      <select name="type_id" class="form-select" data-choices data-options='{"removeItemButton":true}'>
+        <option value="">--</option>
+        <?php foreach($types as $t): ?>
+        <option value="<?= $t['id']; ?>" <?= $asset && $asset['type_id']==$t['id']?'selected':''; ?>><?= e($t['label']); ?></option>
+        <?php endforeach; ?>
+      </select>
+    </div>
+    <div class="col">
+      <label class="form-label">Status</label>
+      <select name="status_id" class="form-select" data-choices>
+        <option value="">--</option>
+        <?php foreach($statuses as $s): ?>
+        <option value="<?= $s['id']; ?>" <?= $asset && $asset['status_id']==$s['id']?'selected':''; ?>><?= e($s['label']); ?></option>
+        <?php endforeach; ?>
+      </select>
+    </div>
+  </div>
+  <div class="row mb-3">
+    <div class="col">
+      <label class="form-label">Model</label>
+      <input type="text" name="model" class="form-control" value="<?= e($asset['model'] ?? ''); ?>">
+    </div>
+    <div class="col">
+      <label class="form-label">Serial</label>
+      <input type="text" name="serial" class="form-control" value="<?= e($asset['serial'] ?? ''); ?>">
+    </div>
+  </div>
+  <div class="row mb-3">
+    <div class="col">
+      <label class="form-label">Purchase Date</label>
+      <input type="text" name="purchase_date" class="form-control" data-flatpickr value="<?= e($asset['purchase_date'] ?? ''); ?>">
+    </div>
+    <div class="col">
+      <label class="form-label">Warranty Expiration</label>
+      <input type="text" name="warranty_expiration" class="form-control" data-flatpickr value="<?= e($asset['warranty_expiration'] ?? ''); ?>">
+    </div>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Compliance Flags</label><br>
+    <div class="form-check form-check-inline">
+      <input class="form-check-input" type="checkbox" name="compliance[]" value="gdpr" <?php if($asset && str_contains($asset['compliance_flags'],'gdpr')) echo 'checked'; ?>>
+      <label class="form-check-label">GDPR</label>
+    </div>
+    <div class="form-check form-check-inline">
+      <input class="form-check-input" type="checkbox" name="compliance[]" value="hipaa" <?php if($asset && str_contains($asset['compliance_flags'],'hipaa')) echo 'checked'; ?>>
+      <label class="form-check-label">HIPAA</label>
+    </div>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Tags</label>
+    <select name="tags[]" class="form-select" data-choices data-options='{"removeItemButton":true}' multiple>
+      <?php foreach($tags as $tag): ?>
+      <option value="<?= e($tag); ?>" selected><?= e($tag); ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Attachments</label>
+    <div class="dropzone" id="asset-dropzone"></div>
+  </div>
+  <?php if ($editing && $asset['asset_tag']): ?>
+  <div class="mb-3">
+    <label class="form-label">QR Code</label><br>
+    <img src="functions/label.php?id=<?= $id; ?>" alt="QR">
+  </div>
+  <?php endif; ?>
+  <div class="mb-3">
+    <label class="form-label">Memo</label>
+    <textarea name="memo" class="form-control" rows="3"><?= e($asset['memo'] ?? ''); ?></textarea>
+  </div>
+  <button class="btn btn-primary" type="submit">Save</button>
+</form>
+
+<?php if($editing): ?>
+<hr>
+<h3>History</h3>
+<?php
+$events = $pdo->prepare('SELECT * FROM module_asset_events WHERE asset_id=:id ORDER BY date_created DESC');
+$events->execute([':id'=>$id]);
+foreach ($events->fetchAll(PDO::FETCH_ASSOC) as $ev) {
+  echo '<div class="border rounded p-2 mb-2"><strong>'.e($ev['event_type']).'</strong> '.e($ev['memo']).' <span class="text-muted small">'.e($ev['date_created'])."</span></div>";
+}
+?>
+<?php endif; ?>
+
+<link rel="stylesheet" href="../vendors/dropzone/dropzone.css">
+<link rel="stylesheet" href="../vendors/choices/choices.min.css">
+<link rel="stylesheet" href="../vendors/flatpickr/flatpickr.min.css">
+<script src="../vendors/dropzone/dropzone-min.js"></script>
+<script src="../vendors/choices/choices.min.js"></script>
+<script src="../vendors/flatpickr/flatpickr.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/signature_pad/4.1.5/signature_pad.umd.min.js"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('[data-flatpickr]').forEach(el => flatpickr(el, {}));
+    document.querySelectorAll('[data-choices]').forEach(el => new Choices(el));
+    Dropzone.autoDiscover = false;
+    new Dropzone('#asset-dropzone', { url: 'functions/upload_file.php', params: { csrf_token: '<?= $token; ?>', asset_id: '<?= $id; ?>' } });
+  });
+</script>
+<?php require '../admin_footer.php'; ?>

--- a/admin/assets/functions/assign.php
+++ b/admin/assets/functions/assign.php
@@ -1,0 +1,22 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/php_header.php';
+require_permission('assets','update');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') { http_response_code(405); exit; }
+if (!verify_csrf_token($_POST['csrf_token'] ?? '')) { http_response_code(403); exit; }
+$asset_id = (int)($_POST['asset_id'] ?? 0);
+$contractor_id = (int)($_POST['contractor_id'] ?? 0);
+
+$open = $pdo->prepare('SELECT id FROM module_asset_assignments WHERE asset_id=:id AND returned_date IS NULL');
+$open->execute([':id'=>$asset_id]);
+if ($open->fetch()) { http_response_code(400); echo 'Asset already assigned'; exit; }
+
+$pdo->prepare('INSERT INTO module_asset_assignments (asset_id,contractor_id,assigned_date,user_id,user_updated) VALUES (:aid,:cid,NOW(),:uid,:uid)')->execute([':aid'=>$asset_id,':cid'=>$contractor_id,':uid'=>$this_user_id]);
+$assign_id = (int)$pdo->lastInsertId();
+$pdo->prepare('UPDATE module_assets SET assignee_id=:cid,user_updated=:uid WHERE id=:id')->execute([':cid'=>$contractor_id,':uid'=>$this_user_id,':id'=>$asset_id]);
+$pdo->prepare('INSERT INTO module_asset_events (asset_id,event_type,memo,user_id,user_updated) VALUES (:aid,"assign",NULL,:uid,:uid)')->execute([':aid'=>$asset_id,':uid'=>$this_user_id]);
+admin_audit_log($pdo,$this_user_id,'module_asset_assignments',$assign_id,'asset.assign',null,json_encode(['asset_id'=>$asset_id,'contractor_id'=>$contractor_id]),'Assigned asset');
+
+echo 'ok';
+?>

--- a/admin/assets/functions/create.php
+++ b/admin/assets/functions/create.php
@@ -1,0 +1,58 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/php_header.php';
+require_once __DIR__ . '/helpers.php';
+require_permission('assets','create');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+  $_SESSION['error_message'] = 'Method not allowed';
+  header('Location: ../asset.php');
+  exit;
+}
+if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+  $_SESSION['error_message'] = 'Invalid CSRF token';
+  header('Location: ../asset.php');
+  exit;
+}
+
+$type_id = (int)($_POST['type_id'] ?? 0);
+$status_id = $_POST['status_id'] !== '' ? (int)$_POST['status_id'] : null;
+$model = trim($_POST['model'] ?? '');
+$serial = trim($_POST['serial'] ?? '');
+$purchase_date = $_POST['purchase_date'] ?: null;
+$warranty_expiration = $_POST['warranty_expiration'] ?: null;
+$memo = $_POST['memo'] ?? null;
+$compliance_flags = isset($_POST['compliance']) ? implode(',', (array)$_POST['compliance']) : null;
+$tags = isset($_POST['tags']) ? array_filter(array_map('trim', (array)$_POST['tags'])) : [];
+
+try {
+  $asset_tag = generate_asset_tag($pdo,$type_id);
+  $stmt = $pdo->prepare('INSERT INTO module_assets (asset_tag,type_id,status_id,model,serial,purchase_date,warranty_expiration,compliance_flags,memo,user_id,user_updated) VALUES (:asset_tag,:type_id,:status_id,:model,:serial,:purchase_date,:warranty_expiration,:compliance_flags,:memo,:uid,:uid)');
+  $stmt->execute([
+    ':asset_tag'=>$asset_tag,
+    ':type_id'=>$type_id,
+    ':status_id'=>$status_id,
+    ':model'=>$model,
+    ':serial'=>$serial,
+    ':purchase_date'=>$purchase_date,
+    ':warranty_expiration'=>$warranty_expiration,
+    ':compliance_flags'=>$compliance_flags,
+    ':memo'=>$memo,
+    ':uid'=>$this_user_id
+  ]);
+  $asset_id = (int)$pdo->lastInsertId();
+  foreach ($tags as $tag) {
+    $pdo->prepare('INSERT INTO module_asset_tags (asset_id, tag, user_id, user_updated) VALUES (:aid,:tag,:uid,:uid)')->execute([':aid'=>$asset_id,':tag'=>$tag,':uid'=>$this_user_id]);
+  }
+} catch (Exception $e) {
+  $_SESSION['error_message'] = 'Unable to save asset';
+  header('Location: ../asset.php');
+  exit;
+}
+
+admin_audit_log($pdo,$this_user_id,'module_assets',$asset_id,'asset.create',null,json_encode(['asset_tag'=>$asset_tag,'type_id'=>$type_id,'status_id'=>$status_id,'model'=>$model,'serial'=>$serial]),'Created asset');
+
+$_SESSION['message'] = 'Asset saved';
+header('Location: ../asset.php?id='.$asset_id);
+exit;
+?>

--- a/admin/assets/functions/delete.php
+++ b/admin/assets/functions/delete.php
@@ -1,0 +1,36 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/php_header.php';
+require_permission('assets','delete');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+  $_SESSION['error_message'] = 'Method not allowed';
+  header('Location: ../index.php');
+  exit;
+}
+if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+  $_SESSION['error_message'] = 'Invalid CSRF token';
+  header('Location: ../index.php');
+  exit;
+}
+
+$id = (int)($_POST['id'] ?? 0);
+$stmt = $pdo->prepare('SELECT * FROM module_assets WHERE id=:id');
+$stmt->execute([':id'=>$id]);
+$existing = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$existing) {
+  $_SESSION['error_message'] = 'Asset not found';
+  header('Location: ../index.php');
+  exit;
+}
+
+$pdo->prepare('DELETE FROM module_assets WHERE id=:id')->execute([':id'=>$id]);
+$pdo->prepare('DELETE FROM module_asset_tags WHERE asset_id=:id')->execute([':id'=>$id]);
+$pdo->prepare('DELETE FROM module_asset_files WHERE asset_id=:id')->execute([':id'=>$id]);
+
+admin_audit_log($pdo,$this_user_id,'module_assets',$id,'asset.delete',json_encode($existing),null,'Deleted asset');
+
+$_SESSION['message'] = 'Asset deleted';
+header('Location: ../index.php');
+exit;
+?>

--- a/admin/assets/functions/delete_file.php
+++ b/admin/assets/functions/delete_file.php
@@ -1,0 +1,18 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/php_header.php';
+require_permission('assets','update');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') { http_response_code(405); exit; }
+if (!verify_csrf_token($_POST['csrf_token'] ?? '')) { http_response_code(403); exit; }
+$id = (int)($_POST['id'] ?? 0);
+$stmt = $pdo->prepare('SELECT asset_id,file_path FROM module_asset_files WHERE id=:id');
+$stmt->execute([':id'=>$id]);
+$file = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$file) { http_response_code(404); exit; }
+$path = __DIR__.'/../uploads/'.$file['asset_id'].'/'.$file['file_path'];
+if (is_file($path)) unlink($path);
+$pdo->prepare('DELETE FROM module_asset_files WHERE id=:id')->execute([':id'=>$id]);
+admin_audit_log($pdo,$this_user_id,'module_asset_files',$id,'asset.delete',json_encode($file),null,'Deleted file');
+echo 'ok';
+?>

--- a/admin/assets/functions/helpers.php
+++ b/admin/assets/functions/helpers.php
@@ -1,0 +1,20 @@
+<?php
+function generate_asset_tag(PDO $pdo, int $type_id): string {
+    $stmt = $pdo->prepare('SELECT code FROM lookup_list_items WHERE id=:id');
+    $stmt->execute([':id'=>$type_id]);
+    $code = $stmt->fetchColumn();
+    if (!$code) { throw new Exception('Type code not found'); }
+    $year = date('Y');
+    $seqStmt = $pdo->prepare('SELECT id, seq FROM module_asset_tag_seq WHERE type_id=:type_id AND year=:yr');
+    $seqStmt->execute([':type_id'=>$type_id, ':yr'=>$year]);
+    $row = $seqStmt->fetch(PDO::FETCH_ASSOC);
+    if ($row) {
+        $seq = $row['seq'] + 1;
+        $pdo->prepare('UPDATE module_asset_tag_seq SET seq=:seq WHERE id=:id')->execute([':seq'=>$seq, ':id'=>$row['id']]);
+    } else {
+        $seq = 1;
+        $pdo->prepare('INSERT INTO module_asset_tag_seq (type_id, year, seq) VALUES (:type_id,:yr,1)')->execute([':type_id'=>$type_id, ':yr'=>$year]);
+    }
+    return sprintf('%s-%s-%04d', $code, $year, $seq);
+}
+?>

--- a/admin/assets/functions/label.php
+++ b/admin/assets/functions/label.php
@@ -1,0 +1,16 @@
+<?php
+require_once __DIR__ . '/../../../includes/php_header.php';
+require_permission('assets','read');
+require_once __DIR__ . '/../lib/qrlib.php';
+
+$id = (int)($_GET['id'] ?? 0);
+$stmt = $pdo->prepare('SELECT asset_tag, model FROM module_assets WHERE id=:id');
+$stmt->execute([':id'=>$id]);
+$asset = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$asset) { die('Not found'); }
+
+$qrTempDir = sys_get_temp_dir();
+$data = getURLDir()."admin/assets/view.php?id=".$id;
+header('Content-Type: image/png');
+QRcode::png($data,false,QR_ECLEVEL_L,4);
+?>

--- a/admin/assets/functions/labels.php
+++ b/admin/assets/functions/labels.php
@@ -1,0 +1,10 @@
+<?php
+require_once __DIR__ . '/../../../includes/php_header.php';
+require_permission('assets','read');
+
+$ids = array_filter(array_map('intval', explode(',', $_GET['ids'] ?? '')));
+?><html><head><link rel="stylesheet" href="../labels.css"></head><body>
+<?php foreach ($ids as $id): ?>
+<div class="label"><img src="label.php?id=<?= $id; ?>" alt="QR"></div>
+<?php endforeach; ?>
+</body></html>

--- a/admin/assets/functions/return.php
+++ b/admin/assets/functions/return.php
@@ -1,0 +1,21 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/php_header.php';
+require_permission('assets','update');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') { http_response_code(405); exit; }
+if (!verify_csrf_token($_POST['csrf_token'] ?? '')) { http_response_code(403); exit; }
+$asset_id = (int)($_POST['asset_id'] ?? 0);
+
+$assign = $pdo->prepare('SELECT id FROM module_asset_assignments WHERE asset_id=:id AND returned_date IS NULL');
+$assign->execute([':id'=>$asset_id]);
+$row = $assign->fetch(PDO::FETCH_ASSOC);
+if (!$row) { http_response_code(400); echo 'No active assignment'; exit; }
+
+$pdo->prepare('UPDATE module_asset_assignments SET returned_date=NOW(),user_updated=:uid WHERE id=:id')->execute([':uid'=>$this_user_id,':id'=>$row['id']]);
+$pdo->prepare('UPDATE module_assets SET assignee_id=NULL,user_updated=:uid WHERE id=:id')->execute([':uid'=>$this_user_id,':id'=>$asset_id]);
+$pdo->prepare('INSERT INTO module_asset_events (asset_id,event_type,memo,user_id,user_updated) VALUES (:aid,"return",NULL,:uid,:uid)')->execute([':aid'=>$asset_id,':uid'=>$this_user_id]);
+admin_audit_log($pdo,$this_user_id,'module_asset_assignments',$row['id'],'asset.return',null,null,'Returned asset');
+
+echo 'ok';
+?>

--- a/admin/assets/functions/update.php
+++ b/admin/assets/functions/update.php
@@ -1,0 +1,67 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/php_header.php';
+require_once __DIR__ . '/helpers.php';
+require_permission('assets','update');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+  $_SESSION['error_message'] = 'Method not allowed';
+  header('Location: ../asset.php');
+  exit;
+}
+if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+  $_SESSION['error_message'] = 'Invalid CSRF token';
+  header('Location: ../asset.php');
+  exit;
+}
+
+$id = (int)($_POST['id'] ?? 0);
+$type_id = (int)($_POST['type_id'] ?? 0);
+$status_id = $_POST['status_id'] !== '' ? (int)$_POST['status_id'] : null;
+$model = trim($_POST['model'] ?? '');
+$serial = trim($_POST['serial'] ?? '');
+$purchase_date = $_POST['purchase_date'] ?: null;
+$warranty_expiration = $_POST['warranty_expiration'] ?: null;
+$memo = $_POST['memo'] ?? null;
+$compliance_flags = isset($_POST['compliance']) ? implode(',', (array)$_POST['compliance']) : null;
+$tags = isset($_POST['tags']) ? array_filter(array_map('trim', (array)$_POST['tags'])) : [];
+
+$stmt = $pdo->prepare('SELECT * FROM module_assets WHERE id=:id');
+$stmt->execute([':id'=>$id]);
+$existing = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$existing) {
+  $_SESSION['error_message'] = 'Asset not found';
+  header('Location: ../index.php');
+  exit;
+}
+
+try {
+  $pdo->prepare('UPDATE module_assets SET type_id=:type_id,status_id=:status_id,model=:model,serial=:serial,purchase_date=:purchase_date,warranty_expiration=:warranty_expiration,compliance_flags=:compliance_flags,memo=:memo,user_updated=:uid WHERE id=:id')
+      ->execute([
+        ':type_id'=>$type_id,
+        ':status_id'=>$status_id,
+        ':model'=>$model,
+        ':serial'=>$serial,
+        ':purchase_date'=>$purchase_date,
+        ':warranty_expiration'=>$warranty_expiration,
+        ':compliance_flags'=>$compliance_flags,
+        ':memo'=>$memo,
+        ':uid'=>$this_user_id,
+        ':id'=>$id
+      ]);
+  $pdo->prepare('DELETE FROM module_asset_tags WHERE asset_id=:id')->execute([':id'=>$id]);
+  foreach ($tags as $tag) {
+    $pdo->prepare('INSERT INTO module_asset_tags (asset_id,tag,user_id,user_updated) VALUES (:aid,:tag,:uid,:uid)')->execute([':aid'=>$id,':tag'=>$tag,':uid'=>$this_user_id]);
+  }
+} catch (Exception $e) {
+  $_SESSION['error_message'] = 'Unable to update asset';
+  header('Location: ../asset.php?id='.$id);
+  exit;
+}
+
+admin_audit_log($pdo,$this_user_id,'module_assets',$id,'asset.update',json_encode($existing),json_encode(['type_id'=>$type_id,'status_id'=>$status_id,'model'=>$model,'serial'=>$serial]),'Updated asset');
+
+$_SESSION['message'] = 'Asset updated';
+header('Location: ../asset.php?id='.$id);
+exit;
+?>

--- a/admin/assets/functions/upload_file.php
+++ b/admin/assets/functions/upload_file.php
@@ -1,0 +1,30 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/php_header.php';
+require_permission('assets','update');
+
+$asset_id = (int)($_POST['asset_id'] ?? 0);
+if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+  http_response_code(403);
+  echo 'Invalid token';
+  exit;
+}
+if (!isset($_FILES['file']) || $_FILES['file']['error'] !== UPLOAD_ERR_OK) {
+  http_response_code(400);
+  echo 'Upload error';
+  exit;
+}
+$uploadDir = __DIR__ . '/../uploads/' . $asset_id . '/';
+if (!is_dir($uploadDir)) { mkdir($uploadDir,0775,true); }
+$filename = basename($_FILES['file']['name']);
+$target = $uploadDir . $filename;
+if (!move_uploaded_file($_FILES['file']['tmp_name'],$target)) {
+  http_response_code(500);
+  echo 'Save failed';
+  exit;
+}
+$pdo->prepare('INSERT INTO module_asset_files (asset_id,file_path,user_id,user_updated) VALUES (:aid,:path,:uid,:uid)')->execute([':aid'=>$asset_id,':path'=>$filename,':uid'=>$this_user_id]);
+admin_audit_log($pdo,$this_user_id,'module_asset_files',$pdo->lastInsertId(),'asset.upload',null,$filename,'Uploaded file');
+
+echo 'ok';
+?>

--- a/admin/assets/index.php
+++ b/admin/assets/index.php
@@ -1,0 +1,113 @@
+<?php
+require '../admin_header.php';
+require_permission('assets','read');
+
+$token = generate_csrf_token();
+
+$filters = [
+  'status_id' => isset($_GET['status_id']) ? (int)$_GET['status_id'] : null,
+  'type_id' => isset($_GET['type_id']) ? (int)$_GET['type_id'] : null,
+  'assigned' => isset($_GET['assigned']) ? (int)$_GET['assigned'] : null,
+  'tag' => trim($_GET['tag'] ?? '')
+];
+
+$sql = "SELECT a.id, a.asset_tag, a.model, a.serial, a.warranty_expiration,
+               st.label AS status_label, ty.label AS type_label,
+               CONCAT(u.first_name,' ',u.last_name) AS assignee,
+               (SELECT MAX(date_created) FROM module_asset_events e WHERE e.asset_id=a.id) AS last_event
+        FROM module_assets a
+        LEFT JOIN lookup_list_items st ON a.status_id=st.id
+        LEFT JOIN lookup_list_items ty ON a.type_id=ty.id
+        LEFT JOIN contractors u ON a.assignee_id=u.id
+        WHERE 1=1";
+$params = [];
+if ($filters['status_id']) { $sql .= ' AND a.status_id=:status'; $params[':status']=$filters['status_id']; }
+if ($filters['type_id']) { $sql .= ' AND a.type_id=:type'; $params[':type']=$filters['type_id']; }
+if ($filters['assigned']!==null) {
+  if ($filters['assigned']) { $sql .= ' AND a.assignee_id IS NOT NULL'; }
+  else { $sql .= ' AND a.assignee_id IS NULL'; }
+}
+if ($filters['tag']!=='') { $sql .= ' AND a.asset_tag LIKE :tag'; $params[':tag']='%'.$filters['tag'].'%'; }
+$sql .= ' ORDER BY a.date_created DESC';
+$stmt = $pdo->prepare($sql);
+$stmt->execute($params);
+$assets = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+$statuses = get_lookup_items($pdo,'ASSET_STATUS');
+$types = get_lookup_items($pdo,'ASSET_TYPE');
+?>
+<h2 class="mb-4">Assets</h2>
+<?= flash_message($_SESSION['message'] ?? '', 'success'); ?>
+<?= flash_message($_SESSION['error_message'] ?? '', 'danger'); ?>
+<?php unset($_SESSION['message'], $_SESSION['error_message']); ?>
+<div class="mb-3 d-flex gap-2">
+  <?php if (user_has_permission('assets','create')): ?>
+  <a class="btn btn-sm btn-success" href="asset.php">Add Asset</a>
+  <?php endif; ?>
+</div>
+<form class="row g-2 mb-3" method="get">
+  <div class="col-auto">
+    <select class="form-select form-select-sm" name="status_id">
+      <option value="">Status</option>
+      <?php foreach($statuses as $s): ?>
+      <option value="<?= $s['id']; ?>" <?= $filters['status_id']==$s['id']?'selected':''; ?>><?= e($s['label']); ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div class="col-auto">
+    <select class="form-select form-select-sm" name="type_id">
+      <option value="">Type</option>
+      <?php foreach($types as $t): ?>
+      <option value="<?= $t['id']; ?>" <?= $filters['type_id']==$t['id']?'selected':''; ?>><?= e($t['label']); ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div class="col-auto">
+    <select class="form-select form-select-sm" name="assigned">
+      <option value="">Assignment</option>
+      <option value="1" <?= $filters['assigned']===1?'selected':''; ?>>Assigned</option>
+      <option value="0" <?= $filters['assigned']===0?'selected':''; ?>>Unassigned</option>
+    </select>
+  </div>
+  <div class="col-auto">
+    <input class="form-control form-control-sm" name="tag" placeholder="Tag" value="<?= e($filters['tag']); ?>">
+  </div>
+  <div class="col-auto">
+    <button class="btn btn-sm btn-primary" type="submit">Filter</button>
+  </div>
+</form>
+<div class="table-responsive">
+  <table class="table table-striped table-sm mb-0">
+    <thead>
+      <tr>
+        <th>Tag</th>
+        <th>Type</th>
+        <th>Model</th>
+        <th>Serial</th>
+        <th>Status</th>
+        <th>Assignee</th>
+        <th>Warranty Days Left</th>
+        <th>Last Event</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <?php foreach($assets as $a): ?>
+      <tr>
+        <td><?= e($a['asset_tag']); ?></td>
+        <td><?= e($a['type_label']); ?></td>
+        <td><?= e($a['model']); ?></td>
+        <td><?= e($a['serial']); ?></td>
+        <td><?= e($a['status_label']); ?></td>
+        <td><?= e($a['assignee']); ?></td>
+        <td><?php if($a['warranty_expiration']){ $days=(new DateTime())->diff(new DateTime($a['warranty_expiration']))->format('%r%a'); echo e($days);} ?></td>
+        <td><?= e($a['last_event']); ?></td>
+        <td>
+          <a class="btn btn-sm btn-primary" href="asset.php?id=<?= $a['id']; ?>">View</a>
+        </td>
+      </tr>
+      <?php endforeach; ?>
+    </tbody>
+  </table>
+</div>
+<?php require '../admin_footer.php'; ?>

--- a/admin/assets/lib/qrlib.php
+++ b/admin/assets/lib/qrlib.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ * PHP QR Code encoder
+ *
+ * Root library file, prepares environment and includes dependencies
+ *
+ * Based on libqrencode C library distributed under LGPL 2.1
+ * Copyright (C) 2006, 2007, 2008, 2009 Kentaro Fukuchi <fukuchi@megaui.net>
+ *
+ * PHP QR Code is distributed under LGPL 3
+ * Copyright (C) 2010 Dominik Dzienia <deltalab at poczta dot fm>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+	
+	$QR_BASEDIR = dirname(__FILE__).DIRECTORY_SEPARATOR;
+	
+	// Required libs
+	
+	include $QR_BASEDIR."qrconst.php";
+	include $QR_BASEDIR."qrconfig.php";
+	include $QR_BASEDIR."qrtools.php";
+	include $QR_BASEDIR."qrspec.php";
+	include $QR_BASEDIR."qrimage.php";
+	include $QR_BASEDIR."qrvect.php";
+	include $QR_BASEDIR."qrinput.php";
+	include $QR_BASEDIR."qrbitstream.php";
+	include $QR_BASEDIR."qrsplit.php";
+	include $QR_BASEDIR."qrrscode.php";
+	include $QR_BASEDIR."qrmask.php";
+	include $QR_BASEDIR."qrencode.php";
+

--- a/admin/assets/view.php
+++ b/admin/assets/view.php
@@ -1,0 +1,3 @@
+<?php
+require 'asset.php';
+?>


### PR DESCRIPTION
## Summary
- add `/admin/assets` interface to manage hardware with filters, listing, and form
- create CRUD handlers with asset tag generator and file uploads
- include basic assignment, return and QR label endpoints
- add SQL migrations for asset tables

## Testing
- `php -l admin/assets/index.php`
- `php -l admin/assets/asset.php`
- `php -l admin/assets/functions/create.php`
- `php -l admin/assets/functions/update.php`
- `php -l admin/assets/functions/delete.php`
- `php -l admin/assets/functions/assign.php`
- `php -l admin/assets/functions/return.php`
- `php -l admin/assets/functions/upload_file.php`
- `php -l admin/assets/functions/delete_file.php`
- `php -l admin/assets/functions/label.php`
- `php -l admin/assets/functions/labels.php`


------
https://chatgpt.com/codex/tasks/task_e_68b1638e63ac8333a72ae65d62db9d4d