### PR TITLE
feat(agency): add organization filter and file icons

### DIFF
--- a/module/agency/include/board_view.php
+++ b/module/agency/include/board_view.php
@@ -17,7 +17,19 @@ foreach ($agencies as $agency) {
           <?php foreach (($data['items'] ?? []) as $agency): ?>
             <div class="card mb-2">
               <div class="card-body p-2">
+                <?php if (!empty($agency['file_name'])): ?>
+                  <a href="download.php?id=<?= $agency['id']; ?>" class="me-1">
+                    <?php if (strpos($agency['file_type'], 'image/') === 0): ?>
+                      <img src="uploads/agency/<?= e($agency['file_path']); ?>" alt="<?= e($agency['file_name']); ?>" class="rounded" style="height:24px; width:24px; object-fit:cover;">
+                    <?php else: ?>
+                      <i class="fa-regular fa-paperclip"></i>
+                    <?php endif; ?>
+                  </a>
+                <?php endif; ?>
                 <?= e($agency['name']); ?>
+                <?php if (!empty($agency['organization_name'])): ?>
+                  <span class="badge bg-info-subtle text-info ms-1"><?= h($agency['organization_name']); ?></span>
+                <?php endif; ?>
                 <span class="badge bg-primary-subtle text-primary ms-1"><?= (int)$agency['user_count']; ?></span>
                 <span class="badge bg-secondary-subtle text-secondary ms-1"><?= (int)$agency['person_count']; ?></span>
               </div>

--- a/module/agency/include/card_view.php
+++ b/module/agency/include/card_view.php
@@ -8,7 +8,19 @@
         <div class="card h-100">
           <div class="card-body">
             <h5 class="card-title mb-1">
+              <?php if (!empty($agency['file_name'])): ?>
+                <a href="download.php?id=<?= $agency['id']; ?>" class="me-1">
+                  <?php if (strpos($agency['file_type'], 'image/') === 0): ?>
+                    <img src="uploads/agency/<?= e($agency['file_path']); ?>" alt="<?= e($agency['file_name']); ?>" class="rounded" style="height:32px; width:32px; object-fit:cover;">
+                  <?php else: ?>
+                    <i class="fa-regular fa-paperclip"></i>
+                  <?php endif; ?>
+                </a>
+              <?php endif; ?>
               <?php echo e($agency['name']); ?>
+              <?php if (!empty($agency['organization_name'])): ?>
+                <span class="badge bg-info-subtle text-info ms-1"><?= h($agency['organization_name']); ?></span>
+              <?php endif; ?>
               <span class="badge bg-primary-subtle text-primary ms-1"><?= (int)$agency['user_count']; ?></span>
               <span class="badge bg-secondary-subtle text-secondary ms-1"><?= (int)$agency['person_count']; ?></span>
             </h5>

--- a/module/agency/include/list_view.php
+++ b/module/agency/include/list_view.php
@@ -5,10 +5,10 @@
   <div class="card-body">
     <form method="get" class="row g-2">
       <input type="hidden" name="action" value="list">
-      <div class="col-sm-4">
+      <div class="col-sm-3">
         <input class="form-control" type="text" name="name" placeholder="Search name" value="<?= h($filters['name']); ?>">
       </div>
-      <div class="col-sm-3">
+      <div class="col-sm-2">
         <select class="form-select" name="status">
           <option value="">All Statuses</option>
           <?php foreach ($statusList as $id => $status): ?>
@@ -17,6 +17,14 @@
         </select>
       </div>
       <div class="col-sm-3">
+        <select class="form-select" name="org">
+          <option value="">All Organizations</option>
+          <?php foreach ($organizations as $org): ?>
+            <option value="<?= $org['id']; ?>" <?= $filters['org']==$org['id'] ? 'selected' : '' ?>><?= h($org['name']); ?></option>
+          <?php endforeach; ?>
+        </select>
+      </div>
+      <div class="col-sm-2">
         <select class="form-select" name="lead">
           <option value="">All Leads</option>
           <?php foreach ($leadUsers as $user): ?>
@@ -45,7 +53,19 @@
           <?php foreach ($agencies as $agency): ?>
             <tr>
               <td class="align-middle name">
+                <?php if (!empty($agency['file_name'])): ?>
+                  <a href="download.php?id=<?= $agency['id']; ?>" class="me-1">
+                    <?php if (strpos($agency['file_type'], 'image/') === 0): ?>
+                      <img src="uploads/agency/<?= e($agency['file_path']); ?>" alt="<?= e($agency['file_name']); ?>" class="rounded" style="height:24px; width:24px; object-fit:cover;">
+                    <?php else: ?>
+                      <i class="fa-regular fa-paperclip"></i>
+                    <?php endif; ?>
+                  </a>
+                <?php endif; ?>
                 <?php echo e($agency['name']); ?>
+                <?php if (!empty($agency['organization_name'])): ?>
+                  <span class="badge bg-info-subtle text-info ms-1"><?= h($agency['organization_name']); ?></span>
+                <?php endif; ?>
                 <span class="badge bg-primary-subtle text-primary ms-1"><?= (int)$agency['user_count']; ?></span>
                 <span class="badge bg-secondary-subtle text-secondary ms-1"><?= (int)$agency['person_count']; ?></span>
               </td>


### PR DESCRIPTION
## Summary
- allow agencies to be filtered by organization
- surface organization badges and attachment icons in list, card, and board views

## Testing
- `php -l module/agency/index.php module/agency/include/list_view.php module/agency/include/card_view.php module/agency/include/board_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68b2600443488333a5a7c3d426a69213