### PR TITLE
Centralize hierarchy file uploads

### DIFF
--- a/admin/orgs/agency_edit.php
+++ b/admin/orgs/agency_edit.php
@@ -2,6 +2,7 @@
 require_once __DIR__ . '/../../includes/admin_guard.php';
 require_once __DIR__ . '/../../includes/functions.php';
 require_once __DIR__ . '/../../includes/helpers.php';
+require_once __DIR__ . '/../../includes/hierarchy_file.php';
 
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 $organization_id = isset($_GET['organization_id']) ? (int)$_GET['organization_id'] : null;
@@ -69,44 +70,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     admin_audit_log($pdo, $this_user_id, 'module_agency', $id, 'CREATE', null, json_encode(['organization_id'=>$organization_id,'name'=>$name,'main_person'=>$main_person,'status'=>$status]), 'Created agency');
   }
 
-  // handle file upload (max 5MB)
-  if (!empty($_FILES['upload_file']['name'])) {
-    $maxSize = 5 * 1024 * 1024; // 5MB
-    if ($_FILES['upload_file']['size'] <= $maxSize && is_uploaded_file($_FILES['upload_file']['tmp_name'])) {
-      $originalName = $_FILES['upload_file']['name'];
-      $fileSize = (int)$_FILES['upload_file']['size'];
-
-      $finfo = finfo_open(FILEINFO_MIME_TYPE);
-      $mime = finfo_file($finfo, $_FILES['upload_file']['tmp_name']);
-      finfo_close($finfo);
-
-      $allowedTypes = [
-        'image/jpeg' => 'jpg',
-        'image/png'  => 'png',
-        'image/gif'  => 'gif',
-        'image/webp' => 'webp',
-        'application/pdf' => 'pdf'
-      ];
-
-      if (isset($allowedTypes[$mime])) {
-        $ext = $allowedTypes[$mime];
-        $uploadDir = dirname(__DIR__, 2) . '/module/agency/uploads/agency/';
-        if (!is_dir($uploadDir)) {
-          mkdir($uploadDir, 0775, true);
-        }
-        if (!empty($file_path)) {
-          @unlink($uploadDir . $file_path);
-        }
-        $randomName = bin2hex(random_bytes(16)) . '.' . $ext;
-        $dest = $uploadDir . $randomName;
-        if (move_uploaded_file($_FILES['upload_file']['tmp_name'], $dest)) {
-          $fileStmt = $pdo->prepare('UPDATE module_agency SET file_name=?, file_path=?, file_size=?, file_type=? WHERE id=?');
-          $fileStmt->execute([$originalName, $randomName, $fileSize, $mime, $id]);
-          admin_audit_log($pdo, $this_user_id, 'module_agency', $id, 'UPLOAD', null, json_encode(['file_name'=>$originalName,'file_path'=>$randomName,'file_size'=>$fileSize,'file_type'=>$mime]), 'Uploaded agency file');
-        }
-      }
-    }
-  }
+  handle_hierarchy_upload($pdo, 'agency', $id, $_FILES['upload_file'] ?? [], $this_user_id, $file_path);
 
   header('Location: index.php');
   exit;

--- a/admin/orgs/division_edit.php
+++ b/admin/orgs/division_edit.php
@@ -2,6 +2,7 @@
 require_once __DIR__ . '/../../includes/admin_guard.php';
 require_once __DIR__ . '/../../includes/functions.php';
 require_once __DIR__ . '/../../includes/helpers.php';
+require_once __DIR__ . '/../../includes/hierarchy_file.php';
 
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 $agency_id = isset($_GET['agency_id']) ? (int)$_GET['agency_id'] : null;
@@ -69,44 +70,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     admin_audit_log($pdo, $this_user_id, 'module_division', $id, 'CREATE', null, json_encode(['agency_id'=>$agency_id,'name'=>$name,'main_person'=>$main_person,'status'=>$status]), 'Created division');
   }
 
-  // handle file upload (max 5MB)
-  if (!empty($_FILES['upload_file']['name'])) {
-    $maxSize = 5 * 1024 * 1024; // 5MB
-    if ($_FILES['upload_file']['size'] <= $maxSize && is_uploaded_file($_FILES['upload_file']['tmp_name'])) {
-      $originalName = $_FILES['upload_file']['name'];
-      $fileSize = (int)$_FILES['upload_file']['size'];
-
-      $finfo = finfo_open(FILEINFO_MIME_TYPE);
-      $mime = finfo_file($finfo, $_FILES['upload_file']['tmp_name']);
-      finfo_close($finfo);
-
-      $allowedTypes = [
-        'image/jpeg' => 'jpg',
-        'image/png'  => 'png',
-        'image/gif'  => 'gif',
-        'image/webp' => 'webp',
-        'application/pdf' => 'pdf'
-      ];
-
-      if (isset($allowedTypes[$mime])) {
-        $ext = $allowedTypes[$mime];
-        $uploadDir = dirname(__DIR__, 2) . '/module/agency/uploads/division/';
-        if (!is_dir($uploadDir)) {
-          mkdir($uploadDir, 0775, true);
-        }
-        if (!empty($file_path)) {
-          @unlink($uploadDir . $file_path);
-        }
-        $randomName = bin2hex(random_bytes(16)) . '.' . $ext;
-        $dest = $uploadDir . $randomName;
-        if (move_uploaded_file($_FILES['upload_file']['tmp_name'], $dest)) {
-          $fileStmt = $pdo->prepare('UPDATE module_division SET file_name=?, file_path=?, file_size=?, file_type=? WHERE id=?');
-          $fileStmt->execute([$originalName, $randomName, $fileSize, $mime, $id]);
-          admin_audit_log($pdo, $this_user_id, 'module_division', $id, 'UPLOAD', null, json_encode(['file_name'=>$originalName,'file_path'=>$randomName,'file_size'=>$fileSize,'file_type'=>$mime]), 'Uploaded division file');
-        }
-      }
-    }
-  }
+  handle_hierarchy_upload($pdo, 'division', $id, $_FILES['upload_file'] ?? [], $this_user_id, $file_path);
   header('Location: index.php');
   exit;
 }

--- a/admin/orgs/organization_edit.php
+++ b/admin/orgs/organization_edit.php
@@ -3,6 +3,7 @@
 require_once __DIR__ . '/../../includes/admin_guard.php';
 require_once __DIR__ . '/../../includes/functions.php';
 require_once __DIR__ . '/../../includes/helpers.php';
+require_once __DIR__ . '/../../includes/hierarchy_file.php';
 
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 $name = '';
@@ -85,44 +86,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     admin_audit_log($pdo, $this_user_id, 'module_organization', $id, 'CREATE', null, json_encode(['name'=>$name,'main_person'=>$main_person,'status'=>$status]), 'Created organization');
   }
 
-  // handle file upload (max 5MB)
-  if (!empty($_FILES['upload_file']['name'])) {
-    $maxSize = 5 * 1024 * 1024; // 5MB
-    if ($_FILES['upload_file']['size'] <= $maxSize && is_uploaded_file($_FILES['upload_file']['tmp_name'])) {
-      $originalName = $_FILES['upload_file']['name'];
-      $fileSize = (int)$_FILES['upload_file']['size'];
-
-      $finfo = finfo_open(FILEINFO_MIME_TYPE);
-      $mime = finfo_file($finfo, $_FILES['upload_file']['tmp_name']);
-      finfo_close($finfo);
-
-      $allowedTypes = [
-        'image/jpeg' => 'jpg',
-        'image/png'  => 'png',
-        'image/gif'  => 'gif',
-        'image/webp' => 'webp',
-        'application/pdf' => 'pdf'
-      ];
-
-      if (isset($allowedTypes[$mime])) {
-        $ext = $allowedTypes[$mime];
-        $uploadDir = dirname(__DIR__, 2) . '/module/agency/uploads/organization/';
-        if (!is_dir($uploadDir)) {
-          mkdir($uploadDir, 0775, true);
-        }
-        if (!empty($file_path)) {
-          @unlink($uploadDir . $file_path);
-        }
-        $randomName = bin2hex(random_bytes(16)) . '.' . $ext;
-        $dest = $uploadDir . $randomName;
-        if (move_uploaded_file($_FILES['upload_file']['tmp_name'], $dest)) {
-          $fileStmt = $pdo->prepare('UPDATE module_organization SET file_name=?, file_path=?, file_size=?, file_type=? WHERE id=?');
-          $fileStmt->execute([$originalName, $randomName, $fileSize, $mime, $id]);
-          admin_audit_log($pdo, $this_user_id, 'module_organization', $id, 'UPLOAD', null, json_encode(['file_name'=>$originalName,'file_path'=>$randomName,'file_size'=>$fileSize,'file_type'=>$mime]), 'Uploaded organization file');
-        }
-      }
-    }
-  }
+  handle_hierarchy_upload($pdo, 'organization', $id, $_FILES['upload_file'] ?? [], $this_user_id, $file_path);
   header('Location: index.php');
   exit;
 }

--- a/includes/hierarchy_file.php
+++ b/includes/hierarchy_file.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Handle hierarchy file upload for organization, agency, and division records.
+ */
+function handle_hierarchy_upload(PDO $pdo, string $type, int $id, array $file, int $uid, ?string $oldPath): void {
+    if (empty($file['name']) || ($file['error'] ?? UPLOAD_ERR_NO_FILE) !== UPLOAD_ERR_OK) {
+        return;
+    }
+
+    $maxSize = 5 * 1024 * 1024; // 5MB
+    if ($file['size'] > $maxSize || !is_uploaded_file($file['tmp_name'])) {
+        return;
+    }
+
+    $finfo = finfo_open(FILEINFO_MIME_TYPE);
+    $mime = finfo_file($finfo, $file['tmp_name']);
+    finfo_close($finfo);
+
+    $allowed = [
+        'image/jpeg' => 'jpg',
+        'image/png'  => 'png',
+        'image/gif'  => 'gif',
+        'image/webp' => 'webp',
+        'application/pdf' => 'pdf'
+    ];
+
+    if (!isset($allowed[$mime])) {
+        return;
+    }
+
+    $ext = $allowed[$mime];
+    $uploadDir = dirname(__DIR__) . '/module/agency/uploads/' . $type . '/';
+    if (!is_dir($uploadDir)) {
+        mkdir($uploadDir, 0775, true);
+    }
+
+    if ($oldPath) {
+        @unlink($uploadDir . $oldPath);
+    }
+
+    $randomName = bin2hex(random_bytes(16)) . '.' . $ext;
+    $dest = $uploadDir . $randomName;
+    if (!move_uploaded_file($file['tmp_name'], $dest)) {
+        return;
+    }
+
+    $stmt = $pdo->prepare("UPDATE module_{$type} SET file_name=?, file_path=?, file_size=?, file_type=? WHERE id=?");
+    $stmt->execute([$file['name'], $randomName, (int)$file['size'], $mime, $id]);
+
+    admin_audit_log($pdo, $uid, "module_{$type}", $id, 'UPLOAD', null, json_encode([
+        'file_name' => $file['name'],
+        'file_path' => $randomName,
+        'file_size' => (int)$file['size'],
+        'file_type' => $mime
+    ]), 'Uploaded ' . $type . ' file');
+}


### PR DESCRIPTION
## Summary
- add `handle_hierarchy_upload` helper to validate, move, and log hierarchy file uploads
- use new helper in organization, agency, and division edit pages

## Testing
- `php -l includes/hierarchy_file.php`
- `php -l admin/orgs/organization_edit.php`
- `php -l admin/orgs/agency_edit.php`
- `php -l admin/orgs/division_edit.php`


------
https://chatgpt.com/codex/tasks/task_e_68b26003d7b08333abf04a2c1633ac32