### PR TITLE
Add minder notes module with timeline and handlers

### DIFF
--- a/admin/minder/notes/functions/create.php
+++ b/admin/minder/notes/functions/create.php
@@ -1,0 +1,46 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../../includes/php_header.php';
+require_permission('minder_note','create');
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success'=>false,'error'=>'Method not allowed']);
+    exit;
+}
+
+if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+    http_response_code(403);
+    echo json_encode(['success'=>false,'error'=>'Invalid CSRF token']);
+    exit;
+}
+
+$title = trim($_POST['title'] ?? '');
+$body  = trim($_POST['body'] ?? '');
+$category_id = $_POST['category_id'] !== '' ? (int)$_POST['category_id'] : null;
+$status_id   = $_POST['status_id'] !== '' ? (int)$_POST['status_id'] : null;
+
+if ($title === '' || $body === '') {
+    http_response_code(400);
+    echo json_encode(['success'=>false,'error'=>'Title and body required']);
+    exit;
+}
+
+try {
+    $stmt = $pdo->prepare('INSERT INTO admin_minder_notes (title, body, category_id, status_id, user_id, user_updated) VALUES (:title,:body,:category_id,:status_id,:uid,:uid)');
+    $stmt->execute([
+        ':title' => $title,
+        ':body' => $body,
+        ':category_id' => $category_id,
+        ':status_id' => $status_id,
+        ':uid' => $this_user_id
+    ]);
+    $id = (int)$pdo->lastInsertId();
+    admin_audit_log($pdo,$this_user_id,'admin_minder_notes',$id,'CREATE',null,json_encode(['title'=>$title]));
+    echo json_encode(['success'=>true,'id'=>$id]);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['success'=>false,'error'=>$e->getMessage()]);
+}

--- a/admin/minder/notes/functions/delete.php
+++ b/admin/minder/notes/functions/delete.php
@@ -1,0 +1,51 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../../includes/php_header.php';
+require_permission('minder_note','delete');
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success'=>false,'error'=>'Method not allowed']);
+    exit;
+}
+
+if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+    http_response_code(403);
+    echo json_encode(['success'=>false,'error'=>'Invalid CSRF token']);
+    exit;
+}
+
+$id = (int)($_POST['id'] ?? ($_GET['id'] ?? 0));
+if (!$id) {
+    http_response_code(400);
+    echo json_encode(['success'=>false,'error'=>'Invalid ID']);
+    exit;
+}
+
+$oldStmt = $pdo->prepare('SELECT * FROM admin_minder_notes WHERE id = :id');
+$oldStmt->execute([':id'=>$id]);
+$old = $oldStmt->fetch(PDO::FETCH_ASSOC);
+
+if (!$old) {
+    http_response_code(404);
+    echo json_encode(['success'=>false,'error'=>'Not found']);
+    exit;
+}
+
+$fileStmt = $pdo->prepare('SELECT file_path FROM admin_minder_notes_files WHERE note_id = :id');
+$fileStmt->execute([':id'=>$id]);
+$files = $fileStmt->fetchAll(PDO::FETCH_COLUMN);
+$rootDir = dirname(__DIR__, 4) . '/';
+foreach ($files as $fp) {
+    if ($fp) @unlink($rootDir . $fp);
+}
+$pdo->prepare('DELETE FROM admin_minder_notes_files WHERE note_id = :id')->execute([':id'=>$id]);
+$pdo->prepare('DELETE FROM admin_minder_notes_person WHERE note_id = :id')->execute([':id'=>$id]);
+$pdo->prepare('DELETE FROM admin_minder_notes_contractor WHERE note_id = :id')->execute([':id'=>$id]);
+$pdo->prepare('DELETE FROM admin_minder_notes WHERE id = :id')->execute([':id'=>$id]);
+
+admin_audit_log($pdo,$this_user_id,'admin_minder_notes',$id,'DELETE',json_encode($old),null);
+
+echo json_encode(['success'=>true]);

--- a/admin/minder/notes/functions/link_contractor.php
+++ b/admin/minder/notes/functions/link_contractor.php
@@ -1,0 +1,41 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../../includes/php_header.php';
+require_permission('minder_note','update');
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success'=>false,'error'=>'Method not allowed']);
+    exit;
+}
+
+if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+    http_response_code(403);
+    echo json_encode(['success'=>false,'error'=>'Invalid CSRF token']);
+    exit;
+}
+
+$note_id = (int)($_POST['note_id'] ?? 0);
+$contractor_id = (int)($_POST['contractor_id'] ?? 0);
+if (!$note_id || !$contractor_id) {
+    http_response_code(400);
+    echo json_encode(['success'=>false,'error'=>'Missing data']);
+    exit;
+}
+
+try {
+    $stmt = $pdo->prepare('INSERT INTO admin_minder_notes_contractor (note_id, contractor_id, user_id, user_updated) VALUES (:note,:contractor,:uid,:uid)');
+    $stmt->execute([
+        ':note' => $note_id,
+        ':contractor' => $contractor_id,
+        ':uid' => $this_user_id
+    ]);
+    $linkId = (int)$pdo->lastInsertId();
+    admin_audit_log($pdo,$this_user_id,'admin_minder_notes_contractor',$linkId,'CREATE',null,json_encode(['contractor_id'=>$contractor_id]));
+    echo json_encode(['success'=>true,'id'=>$linkId]);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['success'=>false,'error'=>$e->getMessage()]);
+}

--- a/admin/minder/notes/functions/link_person.php
+++ b/admin/minder/notes/functions/link_person.php
@@ -1,0 +1,41 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../../includes/php_header.php';
+require_permission('minder_note','update');
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success'=>false,'error'=>'Method not allowed']);
+    exit;
+}
+
+if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+    http_response_code(403);
+    echo json_encode(['success'=>false,'error'=>'Invalid CSRF token']);
+    exit;
+}
+
+$note_id = (int)($_POST['note_id'] ?? 0);
+$person_id = (int)($_POST['person_id'] ?? 0);
+if (!$note_id || !$person_id) {
+    http_response_code(400);
+    echo json_encode(['success'=>false,'error'=>'Missing data']);
+    exit;
+}
+
+try {
+    $stmt = $pdo->prepare('INSERT INTO admin_minder_notes_person (note_id, person_id, user_id, user_updated) VALUES (:note,:person,:uid,:uid)');
+    $stmt->execute([
+        ':note' => $note_id,
+        ':person' => $person_id,
+        ':uid' => $this_user_id
+    ]);
+    $linkId = (int)$pdo->lastInsertId();
+    admin_audit_log($pdo,$this_user_id,'admin_minder_notes_person',$linkId,'CREATE',null,json_encode(['person_id'=>$person_id]));
+    echo json_encode(['success'=>true,'id'=>$linkId]);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['success'=>false,'error'=>$e->getMessage()]);
+}

--- a/admin/minder/notes/functions/update.php
+++ b/admin/minder/notes/functions/update.php
@@ -1,0 +1,51 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../../includes/php_header.php';
+require_permission('minder_note','update');
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success'=>false,'error'=>'Method not allowed']);
+    exit;
+}
+
+if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+    http_response_code(403);
+    echo json_encode(['success'=>false,'error'=>'Invalid CSRF token']);
+    exit;
+}
+
+$id = (int)($_POST['id'] ?? 0);
+$title = trim($_POST['title'] ?? '');
+$body  = trim($_POST['body'] ?? '');
+$category_id = $_POST['category_id'] !== '' ? (int)$_POST['category_id'] : null;
+$status_id   = $_POST['status_id'] !== '' ? (int)$_POST['status_id'] : null;
+
+if (!$id || $title === '' || $body === '') {
+    http_response_code(400);
+    echo json_encode(['success'=>false,'error'=>'Missing data']);
+    exit;
+}
+
+$oldStmt = $pdo->prepare('SELECT * FROM admin_minder_notes WHERE id = :id');
+$oldStmt->execute([':id'=>$id]);
+$old = $oldStmt->fetch(PDO::FETCH_ASSOC);
+
+try {
+    $stmt = $pdo->prepare('UPDATE admin_minder_notes SET title=:title, body=:body, category_id=:category_id, status_id=:status_id, user_updated=:uid WHERE id=:id');
+    $stmt->execute([
+        ':title' => $title,
+        ':body' => $body,
+        ':category_id' => $category_id,
+        ':status_id' => $status_id,
+        ':uid' => $this_user_id,
+        ':id' => $id
+    ]);
+    admin_audit_log($pdo,$this_user_id,'admin_minder_notes',$id,'UPDATE',json_encode($old),json_encode(['title'=>$title]));
+    echo json_encode(['success'=>true]);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['success'=>false,'error'=>$e->getMessage()]);
+}

--- a/admin/minder/notes/functions/upload.php
+++ b/admin/minder/notes/functions/upload.php
@@ -1,0 +1,73 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../../includes/php_header.php';
+require_permission('minder_note','update');
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success'=>false,'error'=>'Method not allowed']);
+    exit;
+}
+
+if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+    http_response_code(403);
+    echo json_encode(['success'=>false,'error'=>'Invalid CSRF token']);
+    exit;
+}
+
+$note_id = (int)($_POST['note_id'] ?? 0);
+if (!$note_id || empty($_FILES['file']['name'])) {
+    http_response_code(400);
+    echo json_encode(['success'=>false,'error'=>'Missing data']);
+    exit;
+}
+
+$file = $_FILES['file'];
+if ($file['error'] !== UPLOAD_ERR_OK) {
+    http_response_code(400);
+    echo json_encode(['success'=>false,'error'=>'Upload error']);
+    exit;
+}
+if ($file['size'] > 10 * 1024 * 1024) {
+    http_response_code(400);
+    echo json_encode(['success'=>false,'error'=>'File too large']);
+    exit;
+}
+
+$finfo = finfo_open(FILEINFO_MIME_TYPE);
+$mime = finfo_file($finfo, $file['tmp_name']);
+finfo_close($finfo);
+
+$safe = preg_replace('/[^a-zA-Z0-9_-]/', '_', pathinfo($file['name'], PATHINFO_FILENAME));
+$ext  = pathinfo($file['name'], PATHINFO_EXTENSION);
+$filename = $safe . '_' . time() . '.' . $ext;
+$destDir = dirname(__DIR__, 4) . '/assets/files/minder/notes/';
+if (!is_dir($destDir)) { mkdir($destDir, 0755, true); }
+$dest = $destDir . $filename;
+if (!move_uploaded_file($file['tmp_name'], $dest)) {
+    http_response_code(500);
+    echo json_encode(['success'=>false,'error'=>'Failed to save file']);
+    exit;
+}
+
+$relPath = 'assets/files/minder/notes/' . $filename;
+try {
+    $stmt = $pdo->prepare('INSERT INTO admin_minder_notes_files (note_id, file_name, file_path, file_size, file_type, user_id, user_updated) VALUES (:note_id,:name,:path,:size,:type,:uid,:uid)');
+    $stmt->execute([
+        ':note_id' => $note_id,
+        ':name' => $file['name'],
+        ':path' => $relPath,
+        ':size' => $file['size'],
+        ':type' => $mime,
+        ':uid' => $this_user_id
+    ]);
+    $fid = (int)$pdo->lastInsertId();
+    admin_audit_log($pdo,$this_user_id,'admin_minder_notes_files',$fid,'UPLOAD',null,json_encode(['file'=>$file['name']]));
+    echo json_encode(['success'=>true,'id'=>$fid,'name'=>$file['name'],'path'=>$relPath]);
+} catch (PDOException $e) {
+    @unlink($dest);
+    http_response_code(500);
+    echo json_encode(['success'=>false,'error'=>$e->getMessage()]);
+}

--- a/admin/minder/notes/index.php
+++ b/admin/minder/notes/index.php
@@ -1,0 +1,38 @@
+<?php
+require_once __DIR__ . '/../../admin_header.php';
+require_permission('minder_note', 'read');
+
+$notesStmt = $pdo->query("SELECT n.id, n.title, n.body, n.date_created, u.email AS user_email
+                           FROM admin_minder_notes n
+                           LEFT JOIN users u ON n.user_id = u.id
+                           ORDER BY n.date_created DESC");
+$notes = $notesStmt->fetchAll(PDO::FETCH_ASSOC);
+?>
+<h2 class="mb-4">Minder Notes</h2>
+<?php if (user_has_permission('minder_note','create')): ?>
+  <a href="note.php" class="btn btn-success mb-3"><span class="fa-solid fa-plus"></span><span class="visually-hidden">Add</span></a>
+<?php endif; ?>
+<div class="timeline-basic mb-9">
+  <?php foreach ($notes as $note): ?>
+  <div class="timeline-item">
+    <div class="row g-3">
+      <div class="col-auto">
+        <div class="timeline-item-bar position-relative">
+          <div class="icon-item icon-item-md rounded-7 border border-translucent"><span class="fa-solid fa-note-sticky text-info fs-9"></span></div><span class="timeline-bar border-end border-dashed"></span>
+        </div>
+      </div>
+      <div class="col">
+        <div class="d-flex justify-content-between">
+          <div class="d-flex mb-2">
+            <h6 class="lh-sm mb-0 me-2 text-body-secondary timeline-item-title"><a class="text-body" href="note.php?id=<?= $note['id']; ?>"><?= e($note['title']); ?></a></h6>
+          </div>
+          <p class="text-body-quaternary fs-9 mb-0 text-nowrap timeline-time"><span class="fa-regular fa-clock me-1"></span><?= e(date('M j, Y g:i a', strtotime($note['date_created']))); ?></p>
+        </div>
+        <h6 class="fs-10 fw-normal mb-3">by <a class="fw-semibold" href="#">"><?= e($note['user_email'] ?? ''); ?></a></h6>
+        <p class="fs-9 text-body-secondary w-sm-60 mb-5"><?= nl2br(e($note['body'])); ?></p>
+      </div>
+    </div>
+  </div>
+  <?php endforeach; ?>
+</div>
+<?php require_once __DIR__ . '/../../admin_footer.php'; ?>

--- a/admin/minder/notes/note.php
+++ b/admin/minder/notes/note.php
@@ -1,0 +1,122 @@
+<?php
+require_once __DIR__ . '/../../admin_header.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$editing = $id > 0;
+
+if ($editing) {
+    require_permission('minder_note', 'update');
+    $stmt = $pdo->prepare('SELECT * FROM admin_minder_notes WHERE id = :id');
+    $stmt->execute([':id' => $id]);
+    $note = $stmt->fetch(PDO::FETCH_ASSOC);
+    if (!$note) {
+        echo '<div class="alert alert-danger">Note not found.</div>';
+        require_once __DIR__ . '/../../admin_footer.php';
+        exit;
+    }
+} else {
+    require_permission('minder_note', 'create');
+    $note = [
+        'title' => '',
+        'body' => '',
+        'category_id' => null,
+        'status_id' => null
+    ];
+}
+
+$categories = get_lookup_items($pdo, 'ADMIN_MINDER_NOTE_CATEGORY');
+$statuses   = get_lookup_items($pdo, 'ADMIN_MINDER_NOTE_STATUS');
+
+$personStmt = $pdo->query('SELECT id, CONCAT(first_name, " ", last_name) AS name FROM person ORDER BY first_name, last_name');
+$persons = $personStmt->fetchAll(PDO::FETCH_ASSOC);
+
+$contractorStmt = $pdo->query('SELECT mc.id, CONCAT(p.first_name, " ", p.last_name) AS name FROM module_contractors mc JOIN person p ON mc.person_id = p.id ORDER BY p.first_name, p.last_name');
+$contractors = $contractorStmt->fetchAll(PDO::FETCH_ASSOC);
+
+$token = generate_csrf_token();
+?>
+<h2 class="mb-4"><?= $editing ? 'Edit Note' : 'Add Note'; ?></h2>
+<?= flash_message($_SESSION['message'] ?? '', 'success'); ?>
+<?= flash_message($_SESSION['error_message'] ?? '', 'danger'); ?>
+<?php unset($_SESSION['message'], $_SESSION['error_message']); ?>
+<form method="post" action="functions/<?= $editing ? 'update' : 'create'; ?>.php">
+  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+  <?php if ($editing): ?>
+    <input type="hidden" name="id" value="<?= $id; ?>">
+  <?php endif; ?>
+  <div class="mb-3">
+    <label class="form-label">Title</label>
+    <input type="text" name="title" class="form-control" value="<?= e($note['title']); ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Body</label>
+    <textarea name="body" class="form-control" rows="4" required><?= e($note['body']); ?></textarea>
+  </div>
+  <div class="row mb-3">
+    <div class="col">
+      <label class="form-label">Category</label>
+      <select name="category_id" class="form-select">
+        <option value="">--</option>
+        <?php foreach ($categories as $cat): ?>
+          <option value="<?= $cat['id']; ?>" <?= $note['category_id'] == $cat['id'] ? 'selected' : ''; ?>><?= e($cat['label']); ?></option>
+        <?php endforeach; ?>
+      </select>
+    </div>
+    <div class="col">
+      <label class="form-label">Status</label>
+      <select name="status_id" class="form-select">
+        <option value="">--</option>
+        <?php foreach ($statuses as $st): ?>
+          <option value="<?= $st['id']; ?>" <?= $note['status_id'] == $st['id'] ? 'selected' : ''; ?>><?= e($st['label']); ?></option>
+        <?php endforeach; ?>
+      </select>
+    </div>
+  </div>
+  <div class="mb-3">
+    <button class="btn btn-sm btn-primary" type="submit">Save</button>
+    <?php if ($editing && user_has_permission('minder_note','delete')): ?>
+      <a href="functions/delete.php?id=<?= $id; ?>&csrf_token=<?= $token; ?>" class="btn btn-sm btn-danger" onclick="return confirm('Delete this note?');">Delete</a>
+    <?php endif; ?>
+  </div>
+</form>
+<?php if ($editing): ?>
+<hr>
+<form method="post" action="functions/upload.php" enctype="multipart/form-data" class="mb-4">
+  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+  <input type="hidden" name="note_id" value="<?= $id; ?>">
+  <div class="mb-3">
+    <label class="form-label">Attachment</label>
+    <input type="file" name="file" class="form-control" required>
+  </div>
+  <button class="btn btn-secondary btn-sm" type="submit">Upload</button>
+</form>
+<form method="post" action="functions/link_person.php" class="mb-3">
+  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+  <input type="hidden" name="note_id" value="<?= $id; ?>">
+  <div class="mb-3">
+    <label class="form-label">Link Person</label>
+    <select name="person_id" class="form-select">
+      <option value="">-- Person --</option>
+      <?php foreach ($persons as $p): ?>
+        <option value="<?= $p['id']; ?>"><?= e($p['name']); ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <button class="btn btn-secondary btn-sm" type="submit">Link</button>
+</form>
+<form method="post" action="functions/link_contractor.php" class="mb-3">
+  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+  <input type="hidden" name="note_id" value="<?= $id; ?>">
+  <div class="mb-3">
+    <label class="form-label">Link Contractor</label>
+    <select name="contractor_id" class="form-select">
+      <option value="">-- Contractor --</option>
+      <?php foreach ($contractors as $c): ?>
+        <option value="<?= $c['id']; ?>"><?= e($c['name']); ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <button class="btn btn-secondary btn-sm" type="submit">Link</button>
+</form>
+<?php endif; ?>
+<?php require_once __DIR__ . '/../../admin_footer.php'; ?>


### PR DESCRIPTION
## Summary
- Add minder notes index timeline view and note management form
- Implement create/update/delete/upload/link handlers with CSRF-protected JSON APIs
- Set up storage path for note attachments

## Testing
- `php -l admin/minder/notes/index.php`
- `php -l admin/minder/notes/note.php`
- `php -l admin/minder/notes/functions/create.php`
- `php -l admin/minder/notes/functions/update.php`
- `php -l admin/minder/notes/functions/delete.php`
- `php -l admin/minder/notes/functions/upload.php`
- `php -l admin/minder/notes/functions/link_person.php`
- `php -l admin/minder/notes/functions/link_contractor.php`


------
https://chatgpt.com/codex/tasks/task_e_68b26d00e33c8333a1361c25fd264dfa