### PR TITLE
Add admin minder reminders module

### DIFF
--- a/admin/minder/reminders/functions/create.php
+++ b/admin/minder/reminders/functions/create.php
@@ -1,0 +1,92 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/php_header.php';
+require_permission('minder_reminder','create');
+
+$isAjax = ($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '') === 'XMLHttpRequest'
+    || str_contains($_SERVER['HTTP_ACCEPT'] ?? '', 'application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+  if ($isAjax) {
+    header('Content-Type: application/json');
+    http_response_code(405);
+    echo json_encode(['success'=>false,'error'=>'Method not allowed']);
+  } else {
+    $_SESSION['error_message'] = 'Method not allowed';
+    header('Location: ../reminder.php');
+  }
+  exit;
+}
+
+if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+  if ($isAjax) {
+    header('Content-Type: application/json');
+    http_response_code(403);
+    echo json_encode(['success'=>false,'error'=>'Invalid CSRF token']);
+  } else {
+    $_SESSION['error_message'] = 'Invalid CSRF token';
+    header('Location: ../reminder.php');
+  }
+  exit;
+}
+
+$title = trim($_POST['title'] ?? '');
+if ($title === '') {
+  if ($isAjax) {
+    header('Content-Type: application/json');
+    http_response_code(400);
+    echo json_encode(['success'=>false,'error'=>'Title required']);
+  } else {
+    $_SESSION['error_message'] = 'Title required';
+    header('Location: ../reminder.php');
+  }
+  exit;
+}
+$description = $_POST['description'] ?? null;
+$remind_at = $_POST['remind_at'] ?? null;
+$type_id = $_POST['type_id'] !== '' ? (int)$_POST['type_id'] : null;
+$status_id = $_POST['status_id'] !== '' ? (int)$_POST['status_id'] : null;
+$person_ids = isset($_POST['person_ids']) ? array_map('intval', (array)$_POST['person_ids']) : [];
+$contractor_ids = isset($_POST['contractor_ids']) ? array_map('intval', (array)$_POST['contractor_ids']) : [];
+
+$reminderId = 0;
+try {
+  $stmt = $pdo->prepare('INSERT INTO admin_minder_reminders (title, description, remind_at, type_id, status_id, user_id, user_updated) VALUES (:title,:description,:remind_at,:type_id,:status_id,:uid,:uid)');
+  $stmt->execute([
+    ':title' => $title,
+    ':description' => $description,
+    ':remind_at' => $remind_at ?: null,
+    ':type_id' => $type_id,
+    ':status_id' => $status_id,
+    ':uid' => $this_user_id
+  ]);
+  $reminderId = (int)$pdo->lastInsertId();
+  foreach ($person_ids as $pid) {
+    $pdo->prepare('INSERT INTO admin_minder_reminders_person (reminder_id, person_id, user_id, user_updated) VALUES (:rid,:pid,:uid,:uid)')
+        ->execute([':rid'=>$reminderId, ':pid'=>$pid, ':uid'=>$this_user_id]);
+  }
+  foreach ($contractor_ids as $cid) {
+    $pdo->prepare('INSERT INTO admin_minder_reminders_contractor (reminder_id, contractor_id, user_id, user_updated) VALUES (:rid,:cid,:uid,:uid)')
+        ->execute([':rid'=>$reminderId, ':cid'=>$cid, ':uid'=>$this_user_id]);
+  }
+} catch (PDOException $e) {
+  if ($isAjax) {
+    header('Content-Type: application/json');
+    echo json_encode(['success'=>false,'error'=>$e->getMessage()]);
+  } else {
+    $_SESSION['error_message'] = 'Unable to save reminder';
+    header('Location: ../reminder.php');
+  }
+  exit;
+}
+
+admin_audit_log($pdo, $this_user_id, 'admin_minder_reminders', $reminderId, 'CREATE', null, json_encode(['title'=>$title]), 'Created reminder');
+
+if ($isAjax) {
+  header('Content-Type: application/json');
+  echo json_encode(['success'=>true,'id'=>$reminderId]);
+} else {
+  $_SESSION['message'] = 'Reminder saved';
+  header('Location: ../reminder.php?id=' . $reminderId);
+}
+exit;

--- a/admin/minder/reminders/functions/delete.php
+++ b/admin/minder/reminders/functions/delete.php
@@ -1,0 +1,32 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/php_header.php';
+require_permission('minder_reminder','delete');
+
+$method = $_SERVER['REQUEST_METHOD'];
+if ($method !== 'POST' && $method !== 'GET') {
+  http_response_code(405);
+  exit;
+}
+
+$id = isset($_POST['id']) ? (int)$_POST['id'] : (int)($_GET['id'] ?? 0);
+$token = $_POST['csrf_token'] ?? ($_GET['csrf_token'] ?? '');
+if (!hash_equals($_SESSION['csrf_token'] ?? '', $token)) {
+  die('Invalid CSRF token');
+}
+if (!$id) {
+  die('Invalid ID');
+}
+
+$oldStmt = $pdo->prepare('SELECT * FROM admin_minder_reminders WHERE id = :id');
+$oldStmt->execute([':id'=>$id]);
+$old = $oldStmt->fetch(PDO::FETCH_ASSOC);
+
+$pdo->prepare('DELETE FROM admin_minder_reminders_files WHERE reminder_id = :id')->execute([':id'=>$id]);
+$pdo->prepare('DELETE FROM admin_minder_reminders_person WHERE reminder_id = :id')->execute([':id'=>$id]);
+$pdo->prepare('DELETE FROM admin_minder_reminders_contractor WHERE reminder_id = :id')->execute([':id'=>$id]);
+$pdo->prepare('DELETE FROM admin_minder_reminders WHERE id = :id')->execute([':id'=>$id]);
+
+admin_audit_log($pdo, $this_user_id, 'admin_minder_reminders', $id, 'DELETE', json_encode($old), null, 'Deleted reminder');
+
+header('Location: ../index.php');

--- a/admin/minder/reminders/functions/link_contractor.php
+++ b/admin/minder/reminders/functions/link_contractor.php
@@ -1,0 +1,48 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/php_header.php';
+require_permission('minder_reminder','update');
+
+$isAjax = ($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '') === 'XMLHttpRequest'
+    || str_contains($_SERVER['HTTP_ACCEPT'] ?? '', 'application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+  http_response_code(405);
+  exit;
+}
+
+if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+  if ($isAjax) {
+    header('Content-Type: application/json');
+    http_response_code(403);
+    echo json_encode(['success'=>false,'error'=>'Invalid CSRF token']);
+  } else {
+    die('Invalid CSRF token');
+  }
+  exit;
+}
+
+$reminder_id = isset($_POST['reminder_id']) ? (int)$_POST['reminder_id'] : 0;
+$contractor_id = isset($_POST['contractor_id']) ? (int)$_POST['contractor_id'] : 0;
+if (!$reminder_id || !$contractor_id) {
+  if ($isAjax) {
+    header('Content-Type: application/json');
+    http_response_code(400);
+    echo json_encode(['success'=>false,'error'=>'Missing data']);
+  } else {
+    die('Missing data');
+  }
+  exit;
+}
+
+$pdo->prepare('INSERT INTO admin_minder_reminders_contractor (reminder_id, contractor_id, user_id, user_updated) VALUES (:rid,:cid,:uid,:uid)')
+    ->execute([':rid'=>$reminder_id, ':cid'=>$contractor_id, ':uid'=>$this_user_id]);
+
+admin_audit_log($pdo, $this_user_id, 'admin_minder_reminders_contractor', $reminder_id, 'CREATE', null, json_encode(['contractor_id'=>$contractor_id]), 'Linked contractor');
+
+if ($isAjax) {
+  header('Content-Type: application/json');
+  echo json_encode(['success'=>true]);
+} else {
+  header('Location: ../reminder.php?id=' . $reminder_id);
+}

--- a/admin/minder/reminders/functions/link_person.php
+++ b/admin/minder/reminders/functions/link_person.php
@@ -1,0 +1,48 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/php_header.php';
+require_permission('minder_reminder','update');
+
+$isAjax = ($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '') === 'XMLHttpRequest'
+    || str_contains($_SERVER['HTTP_ACCEPT'] ?? '', 'application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+  http_response_code(405);
+  exit;
+}
+
+if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+  if ($isAjax) {
+    header('Content-Type: application/json');
+    http_response_code(403);
+    echo json_encode(['success'=>false,'error'=>'Invalid CSRF token']);
+  } else {
+    die('Invalid CSRF token');
+  }
+  exit;
+}
+
+$reminder_id = isset($_POST['reminder_id']) ? (int)$_POST['reminder_id'] : 0;
+$person_id = isset($_POST['person_id']) ? (int)$_POST['person_id'] : 0;
+if (!$reminder_id || !$person_id) {
+  if ($isAjax) {
+    header('Content-Type: application/json');
+    http_response_code(400);
+    echo json_encode(['success'=>false,'error'=>'Missing data']);
+  } else {
+    die('Missing data');
+  }
+  exit;
+}
+
+$pdo->prepare('INSERT INTO admin_minder_reminders_person (reminder_id, person_id, user_id, user_updated) VALUES (:rid,:pid,:uid,:uid)')
+    ->execute([':rid'=>$reminder_id, ':pid'=>$person_id, ':uid'=>$this_user_id]);
+
+admin_audit_log($pdo, $this_user_id, 'admin_minder_reminders_person', $reminder_id, 'CREATE', null, json_encode(['person_id'=>$person_id]), 'Linked person');
+
+if ($isAjax) {
+  header('Content-Type: application/json');
+  echo json_encode(['success'=>true]);
+} else {
+  header('Location: ../reminder.php?id=' . $reminder_id);
+}

--- a/admin/minder/reminders/functions/update.php
+++ b/admin/minder/reminders/functions/update.php
@@ -1,0 +1,112 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/php_header.php';
+require_permission('minder_reminder','update');
+
+$isAjax = ($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '') === 'XMLHttpRequest'
+    || str_contains($_SERVER['HTTP_ACCEPT'] ?? '', 'application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+  if ($isAjax) {
+    header('Content-Type: application/json');
+    http_response_code(405);
+    echo json_encode(['success'=>false,'error'=>'Method not allowed']);
+  } else {
+    $_SESSION['error_message'] = 'Method not allowed';
+    header('Location: ../reminder.php');
+  }
+  exit;
+}
+
+if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+  if ($isAjax) {
+    header('Content-Type: application/json');
+    http_response_code(403);
+    echo json_encode(['success'=>false,'error'=>'Invalid CSRF token']);
+  } else {
+    $_SESSION['error_message'] = 'Invalid CSRF token';
+    header('Location: ../reminder.php');
+  }
+  exit;
+}
+
+$id = (int)($_POST['id'] ?? 0);
+if (!$id) {
+  if ($isAjax) {
+    header('Content-Type: application/json');
+    http_response_code(400);
+    echo json_encode(['success'=>false,'error'=>'Invalid ID']);
+  } else {
+    $_SESSION['error_message'] = 'Invalid ID';
+    header('Location: ../reminder.php');
+  }
+  exit;
+}
+
+$title = trim($_POST['title'] ?? '');
+if ($title === '') {
+  if ($isAjax) {
+    header('Content-Type: application/json');
+    http_response_code(400);
+    echo json_encode(['success'=>false,'error'=>'Title required']);
+  } else {
+    $_SESSION['error_message'] = 'Title required';
+    header('Location: ../reminder.php?id=' . $id);
+  }
+  exit;
+}
+$description = $_POST['description'] ?? null;
+$remind_at = $_POST['remind_at'] ?? null;
+$type_id = $_POST['type_id'] !== '' ? (int)$_POST['type_id'] : null;
+$status_id = $_POST['status_id'] !== '' ? (int)$_POST['status_id'] : null;
+$person_ids = isset($_POST['person_ids']) ? array_map('intval', (array)$_POST['person_ids']) : [];
+$contractor_ids = isset($_POST['contractor_ids']) ? array_map('intval', (array)$_POST['contractor_ids']) : [];
+
+try {
+  $oldStmt = $pdo->prepare('SELECT * FROM admin_minder_reminders WHERE id = :id');
+  $oldStmt->execute([':id'=>$id]);
+  $old = $oldStmt->fetch(PDO::FETCH_ASSOC);
+  if (!$old) {
+    throw new Exception('Reminder not found');
+  }
+  $stmt = $pdo->prepare('UPDATE admin_minder_reminders SET title=:title, description=:description, remind_at=:remind_at, type_id=:type_id, status_id=:status_id, user_updated=:uid WHERE id=:id');
+  $stmt->execute([
+    ':title' => $title,
+    ':description' => $description,
+    ':remind_at' => $remind_at ?: null,
+    ':type_id' => $type_id,
+    ':status_id' => $status_id,
+    ':uid' => $this_user_id,
+    ':id' => $id
+  ]);
+  $pdo->prepare('DELETE FROM admin_minder_reminders_person WHERE reminder_id = :id')->execute([':id'=>$id]);
+  foreach ($person_ids as $pid) {
+    $pdo->prepare('INSERT INTO admin_minder_reminders_person (reminder_id, person_id, user_id, user_updated) VALUES (:rid,:pid,:uid,:uid)')
+        ->execute([':rid'=>$id, ':pid'=>$pid, ':uid'=>$this_user_id]);
+  }
+  $pdo->prepare('DELETE FROM admin_minder_reminders_contractor WHERE reminder_id = :id')->execute([':id'=>$id]);
+  foreach ($contractor_ids as $cid) {
+    $pdo->prepare('INSERT INTO admin_minder_reminders_contractor (reminder_id, contractor_id, user_id, user_updated) VALUES (:rid,:cid,:uid,:uid)')
+        ->execute([':rid'=>$id, ':cid'=>$cid, ':uid'=>$this_user_id]);
+  }
+} catch (Exception $e) {
+  if ($isAjax) {
+    header('Content-Type: application/json');
+    echo json_encode(['success'=>false,'error'=>$e->getMessage()]);
+  } else {
+    $_SESSION['error_message'] = 'Unable to update reminder';
+    header('Location: ../reminder.php?id=' . $id);
+  }
+  exit;
+}
+
+admin_audit_log($pdo, $this_user_id, 'admin_minder_reminders', $id, 'UPDATE', json_encode($old), json_encode(['title'=>$title]), 'Updated reminder');
+
+if ($isAjax) {
+  header('Content-Type: application/json');
+  echo json_encode(['success'=>true]);
+} else {
+  $_SESSION['message'] = 'Reminder updated';
+  header('Location: ../reminder.php?id=' . $id);
+}
+exit;

--- a/admin/minder/reminders/functions/upload_file.php
+++ b/admin/minder/reminders/functions/upload_file.php
@@ -1,0 +1,56 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../includes/php_header.php';
+require_permission('minder_reminder','update');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+  http_response_code(405);
+  exit;
+}
+
+if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+  die('Invalid CSRF token');
+}
+
+$reminder_id = isset($_POST['reminder_id']) ? (int)$_POST['reminder_id'] : 0;
+if (!$reminder_id || empty($_FILES['file']['name'])) {
+  die('Missing data');
+}
+
+$file = $_FILES['file'];
+if ($file['error'] !== UPLOAD_ERR_OK) {
+  die('Upload error');
+}
+if ($file['size'] > 10 * 1024 * 1024) {
+  die('File too large');
+}
+
+$finfo = finfo_open(FILEINFO_MIME_TYPE);
+$mime = finfo_file($finfo, $file['tmp_name']);
+finfo_close($finfo);
+
+$safe = preg_replace('/[^a-zA-Z0-9_-]/', '_', pathinfo($file['name'], PATHINFO_FILENAME));
+$ext = pathinfo($file['name'], PATHINFO_EXTENSION);
+$filename = $safe . '_' . time() . '.' . $ext;
+$destDir = __DIR__ . '/../../../assets/files/minder/reminders/';
+if (!is_dir($destDir)) { mkdir($destDir, 0755, true); }
+$dest = $destDir . $filename;
+if (!move_uploaded_file($file['tmp_name'], $dest)) {
+  die('Failed to save file');
+}
+
+$relPath = 'assets/files/minder/reminders/' . $filename;
+$pdo->prepare('INSERT INTO admin_minder_reminders_files (reminder_id, file_name, file_path, file_size, file_type, user_id, user_updated) VALUES (:rid,:name,:path,:size,:type,:uid,:uid)')
+    ->execute([
+      ':rid' => $reminder_id,
+      ':name' => $file['name'],
+      ':path' => $relPath,
+      ':size' => $file['size'],
+      ':type' => $mime,
+      ':uid' => $this_user_id
+    ]);
+$fileId = (int)$pdo->lastInsertId();
+
+admin_audit_log($pdo, $this_user_id, 'admin_minder_reminders_files', $fileId, 'CREATE', null, json_encode(['file'=>$file['name']]), 'Uploaded file');
+
+header('Location: ../reminder.php?id=' . $reminder_id);

--- a/admin/minder/reminders/index.php
+++ b/admin/minder/reminders/index.php
@@ -1,0 +1,19 @@
+<?php
+require_once __DIR__ . '/../../admin_header.php';
+require_permission('minder_reminder','read');
+?>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/main.min.css">
+<div class="container-fluid py-4">
+  <div id="appCalendar"></div>
+</div>
+<script src="<?= getURLDir(); ?>vendors/fullcalendar/index.global.min.js"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    var calendarEl = document.getElementById('appCalendar');
+    var calendar = new FullCalendar.Calendar(calendarEl, {
+      initialView: 'dayGridMonth'
+    });
+    calendar.render();
+  });
+</script>
+<?php require __DIR__ . '/../../admin_footer.php'; ?>

--- a/admin/minder/reminders/reminder.php
+++ b/admin/minder/reminders/reminder.php
@@ -1,0 +1,115 @@
+<?php
+require_once __DIR__ . '/../../admin_header.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$editing = $id > 0;
+
+if ($editing) {
+  require_permission('minder_reminder','update');
+  $stmt = $pdo->prepare('SELECT * FROM admin_minder_reminders WHERE id = :id');
+  $stmt->execute([':id' => $id]);
+  $reminder = $stmt->fetch(PDO::FETCH_ASSOC);
+  if (!$reminder) {
+    echo '<div class="alert alert-danger">Reminder not found.</div>';
+    require __DIR__ . '/../../admin_footer.php';
+    exit;
+  }
+  $pStmt = $pdo->prepare('SELECT person_id FROM admin_minder_reminders_person WHERE reminder_id = :id');
+  $pStmt->execute([':id'=>$id]);
+  $linkedPersons = $pStmt->fetchAll(PDO::FETCH_COLUMN);
+  $cStmt = $pdo->prepare('SELECT contractor_id FROM admin_minder_reminders_contractor WHERE reminder_id = :id');
+  $cStmt->execute([':id'=>$id]);
+  $linkedContractors = $cStmt->fetchAll(PDO::FETCH_COLUMN);
+} else {
+  require_permission('minder_reminder','create');
+  $reminder = [
+    'title' => '',
+    'description' => '',
+    'remind_at' => null,
+    'type_id' => null,
+    'status_id' => null
+  ];
+  $linkedPersons = [];
+  $linkedContractors = [];
+}
+
+$types = get_lookup_items($pdo, 'ADMIN_MINDER_REMINDER_TYPE');
+$statuses = get_lookup_items($pdo, 'ADMIN_MINDER_REMINDER_STATUS');
+$persons = $pdo->query("SELECT id, CONCAT(first_name,' ',last_name) AS name FROM person ORDER BY last_name, first_name")->fetchAll(PDO::FETCH_ASSOC);
+$contractors = $pdo->query("SELECT mc.id, CONCAT(p.first_name,' ',p.last_name) AS name FROM module_contractors mc LEFT JOIN person p ON mc.person_id = p.id ORDER BY p.last_name, p.first_name")->fetchAll(PDO::FETCH_ASSOC);
+
+$token = generate_csrf_token();
+?>
+<h2 class="mb-4"><?= $editing ? 'Edit Reminder' : 'Add Reminder'; ?></h2>
+<?= flash_message($_SESSION['message'] ?? '', 'success'); ?>
+<?= flash_message($_SESSION['error_message'] ?? '', 'danger'); ?>
+<?php unset($_SESSION['message'], $_SESSION['error_message']); ?>
+<form method="post" action="functions/<?= $editing ? 'update' : 'create'; ?>.php">
+  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+  <?php if ($editing): ?>
+  <input type="hidden" name="id" value="<?= $id; ?>">
+  <?php endif; ?>
+  <div class="mb-3">
+    <label class="form-label">Title</label>
+    <input type="text" name="title" class="form-control" value="<?= e($reminder['title']); ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Description</label>
+    <textarea name="description" class="form-control" rows="3"><?= e($reminder['description']); ?></textarea>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Remind At</label>
+    <input type="datetime-local" name="remind_at" class="form-control" value="<?= !empty($reminder['remind_at']) ? e(date('Y-m-d\\TH:i', strtotime($reminder['remind_at']))) : ''; ?>">
+  </div>
+  <div class="row mb-3">
+    <div class="col">
+      <label class="form-label">Type</label>
+      <select name="type_id" class="form-select">
+        <option value="">--</option>
+        <?php foreach ($types as $t): ?>
+        <option value="<?= (int)$t['id']; ?>" <?= $reminder['type_id'] == $t['id'] ? 'selected' : ''; ?>><?= e($t['label']); ?></option>
+        <?php endforeach; ?>
+      </select>
+    </div>
+    <div class="col">
+      <label class="form-label">Status</label>
+      <select name="status_id" class="form-select">
+        <option value="">--</option>
+        <?php foreach ($statuses as $s): ?>
+        <option value="<?= (int)$s['id']; ?>" <?= $reminder['status_id'] == $s['id'] ? 'selected' : ''; ?>><?= e($s['label']); ?></option>
+        <?php endforeach; ?>
+      </select>
+    </div>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Persons</label>
+    <select name="person_ids[]" class="form-select" multiple>
+      <?php foreach ($persons as $p): ?>
+      <option value="<?= (int)$p['id']; ?>" <?= in_array($p['id'], $linkedPersons) ? 'selected' : ''; ?>><?= e($p['name']); ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Contractors</label>
+    <select name="contractor_ids[]" class="form-select" multiple>
+      <?php foreach ($contractors as $c): ?>
+      <option value="<?= (int)$c['id']; ?>" <?= in_array($c['id'], $linkedContractors) ? 'selected' : ''; ?>><?= e($c['name']); ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <button type="submit" class="btn btn-primary">Save</button>
+</form>
+
+<?php if ($editing): ?>
+<hr class="my-4">
+<h3 class="mb-3">Attachments</h3>
+<form method="post" enctype="multipart/form-data" action="functions/upload_file.php">
+  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+  <input type="hidden" name="reminder_id" value="<?= $id; ?>">
+  <div class="mb-3">
+    <input type="file" name="file" class="form-control" required>
+  </div>
+  <button class="btn btn-secondary" type="submit">Upload File</button>
+</form>
+<?php endif; ?>
+<?php require __DIR__ . '/../../admin_footer.php'; ?>


### PR DESCRIPTION
## Summary
- introduce admin minder reminders calendar page with FullCalendar
- add reminder form supporting types, statuses, people, contractors, and file uploads
- implement create/update/delete and linking APIs with CSRF, permission checks, and file storage

## Testing
- `find admin/minder/reminders -name '*.php' -print -exec php -l {} \;`

------
https://chatgpt.com/codex/tasks/task_e_68b26d004cf0833383a58ad1e48dd01d