### PR TITLE
Add lightbox previews and filter bar for agencies

### DIFF
--- a/includes/js_footer.php
+++ b/includes/js_footer.php
@@ -14,6 +14,16 @@
     <script src="<?php echo getURLDir(); ?>vendors/dhtmlx-gantt/dhtmlxgantt.js"></script>
     <script src="<?php echo getURLDir(); ?>vendors/flatpickr/flatpickr.min.js"></script>
     <script src="<?php echo getURLDir(); ?>vendors/glightbox/glightbox.min.js"></script>
+    <?php if (!empty($loadFsLightbox)): ?>
+      <script src="<?php echo getURLDir(); ?>vendors/fslightbox/fslightbox.js"></script>
+      <script>
+        document.addEventListener('DOMContentLoaded', function () {
+          if (typeof refreshFsLightbox === 'function') {
+            refreshFsLightbox();
+          }
+        });
+      </script>
+    <?php endif; ?>
 
     <!-- Phoenix Core & Config -->
     <script src="<?php echo getURLDir(); ?>assets/js/config.js"></script>

--- a/module/agency/include/board_view.php
+++ b/module/agency/include/board_view.php
@@ -17,16 +17,17 @@ foreach ($agencies as $agency) {
           <?php foreach (($data['items'] ?? []) as $agency): ?>
             <div class="card mb-2">
               <div class="card-body p-2">
-                <?php if (!empty($agency['file_name'])): ?>
-                  <a href="download.php?id=<?= $agency['id']; ?>" class="me-1">
-                    <?php if (strpos($agency['file_type'], 'image/') === 0): ?>
-                      <img src="uploads/agency/<?= e($agency['file_path']); ?>" alt="<?= e($agency['file_name']); ?>" class="rounded" style="height:24px; width:24px; object-fit:cover;">
-                    <?php else: ?>
-                      <i class="fa-regular fa-paperclip"></i>
-                    <?php endif; ?>
+                <?php if (!empty($agency['file_name']) && strpos($agency['file_type'], 'image/') === 0): ?>
+                  <a href="uploads/agency/<?= e($agency['file_path']); ?>" data-fslightbox="agency" class="me-1">
+                    <img src="uploads/agency/<?= e($agency['file_path']); ?>" alt="<?= e($agency['file_name']); ?>" class="rounded" style="height:24px; width:24px; object-fit:cover;">
                   </a>
                 <?php endif; ?>
                 <?= e($agency['name']); ?>
+                <?php if (!empty($agency['file_name'])): ?>
+                  <a href="download.php?type=agency&id=<?= $agency['id']; ?>" class="ms-1 text-body">
+                    <i class="fa-regular fa-paperclip"></i>
+                  </a>
+                <?php endif; ?>
                 <?php if (!empty($agency['organization_name'])): ?>
                   <span class="badge bg-info-subtle text-info ms-1"><?= h($agency['organization_name']); ?></span>
                 <?php endif; ?>

--- a/module/agency/include/card_view.php
+++ b/module/agency/include/card_view.php
@@ -8,16 +8,17 @@
         <div class="card h-100">
           <div class="card-body">
             <h5 class="card-title mb-1">
-              <?php if (!empty($agency['file_name'])): ?>
-                <a href="download.php?id=<?= $agency['id']; ?>" class="me-1">
-                  <?php if (strpos($agency['file_type'], 'image/') === 0): ?>
-                    <img src="uploads/agency/<?= e($agency['file_path']); ?>" alt="<?= e($agency['file_name']); ?>" class="rounded" style="height:32px; width:32px; object-fit:cover;">
-                  <?php else: ?>
-                    <i class="fa-regular fa-paperclip"></i>
-                  <?php endif; ?>
+              <?php if (!empty($agency['file_name']) && strpos($agency['file_type'], 'image/') === 0): ?>
+                <a href="uploads/agency/<?= e($agency['file_path']); ?>" data-fslightbox="agency" class="me-1">
+                  <img src="uploads/agency/<?= e($agency['file_path']); ?>" alt="<?= e($agency['file_name']); ?>" class="rounded" style="height:32px; width:32px; object-fit:cover;">
                 </a>
               <?php endif; ?>
-              <?php echo e($agency['name']); ?>
+              <?= e($agency['name']); ?>
+              <?php if (!empty($agency['file_name'])): ?>
+                <a href="download.php?type=agency&id=<?= $agency['id']; ?>" class="ms-1 text-body">
+                  <i class="fa-regular fa-paperclip"></i>
+                </a>
+              <?php endif; ?>
               <?php if (!empty($agency['organization_name'])): ?>
                 <span class="badge bg-info-subtle text-info ms-1"><?= h($agency['organization_name']); ?></span>
               <?php endif; ?>

--- a/module/agency/include/list_view.php
+++ b/module/agency/include/list_view.php
@@ -1,44 +1,6 @@
 <?php
 // List view of agencies
 ?>
-<div class="card mb-3">
-  <div class="card-body">
-    <form method="get" class="row g-2">
-      <input type="hidden" name="action" value="list">
-      <div class="col-sm-3">
-        <input class="form-control" type="text" name="name" placeholder="Search name" value="<?= h($filters['name']); ?>">
-      </div>
-      <div class="col-sm-2">
-        <select class="form-select" name="status">
-          <option value="">All Statuses</option>
-          <?php foreach ($statusList as $id => $status): ?>
-            <option value="<?= $id ?>" <?= $filters['status']==$id ? 'selected' : '' ?>><?= h($status['label']); ?></option>
-          <?php endforeach; ?>
-        </select>
-      </div>
-      <div class="col-sm-3">
-        <select class="form-select" name="org">
-          <option value="">All Organizations</option>
-          <?php foreach ($organizations as $org): ?>
-            <option value="<?= $org['id']; ?>" <?= $filters['org']==$org['id'] ? 'selected' : '' ?>><?= h($org['name']); ?></option>
-          <?php endforeach; ?>
-        </select>
-      </div>
-      <div class="col-sm-2">
-        <select class="form-select" name="lead">
-          <option value="">All Leads</option>
-          <?php foreach ($leadUsers as $user): ?>
-            <option value="<?= $user['id']; ?>" <?= $filters['lead']==$user['id'] ? 'selected' : '' ?>><?= h($user['name']); ?></option>
-          <?php endforeach; ?>
-        </select>
-      </div>
-      <div class="col-sm-2">
-        <button class="btn btn-primary w-100" type="submit">Filter</button>
-      </div>
-    </form>
-  </div>
-</div>
-
 <div class="card">
   <div class="card-body p-0">
     <div class="table-responsive scrollbar">
@@ -53,16 +15,17 @@
           <?php foreach ($agencies as $agency): ?>
             <tr>
               <td class="align-middle name">
-                <?php if (!empty($agency['file_name'])): ?>
-                  <a href="download.php?id=<?= $agency['id']; ?>" class="me-1">
-                    <?php if (strpos($agency['file_type'], 'image/') === 0): ?>
-                      <img src="uploads/agency/<?= e($agency['file_path']); ?>" alt="<?= e($agency['file_name']); ?>" class="rounded" style="height:24px; width:24px; object-fit:cover;">
-                    <?php else: ?>
-                      <i class="fa-regular fa-paperclip"></i>
-                    <?php endif; ?>
+                <?php if (!empty($agency['file_name']) && strpos($agency['file_type'], 'image/') === 0): ?>
+                  <a href="uploads/agency/<?= e($agency['file_path']); ?>" data-fslightbox="agency" class="me-1">
+                    <img src="uploads/agency/<?= e($agency['file_path']); ?>" alt="<?= e($agency['file_name']); ?>" class="rounded" style="height:24px; width:24px; object-fit:cover;">
                   </a>
                 <?php endif; ?>
-                <?php echo e($agency['name']); ?>
+                <?= e($agency['name']); ?>
+                <?php if (!empty($agency['file_name'])): ?>
+                  <a href="download.php?type=agency&id=<?= $agency['id']; ?>" class="ms-1 text-body">
+                    <i class="fa-regular fa-paperclip"></i>
+                  </a>
+                <?php endif; ?>
                 <?php if (!empty($agency['organization_name'])): ?>
                   <span class="badge bg-info-subtle text-info ms-1"><?= h($agency['organization_name']); ?></span>
                 <?php endif; ?>

--- a/module/agency/index.php
+++ b/module/agency/index.php
@@ -10,6 +10,8 @@ $filters = [
   'lead'   => $_GET['lead'] ?? '',
   'org'    => $_GET['org'] ?? ''
 ];
+$queryFilters = array_filter($filters, fn($v) => $v !== '');
+$filterQuery = http_build_query($queryFilters);
 
 // Fetch agencies and status lookup
 $statusList = array_column(get_lookup_items($pdo, 'AGENCY_STATUS'), null, 'id');
@@ -64,10 +66,47 @@ require '../../includes/html_header.php';
   <?php // require '../../includes/left_navigation.php'; ?>
   <?php require '../../includes/navigation.php'; ?>
   <div id="main_content" class="content">
+    <div class="card mb-3">
+      <div class="card-body">
+        <form method="get" class="row g-2">
+          <input type="hidden" name="action" value="<?= h($action); ?>">
+          <div class="col-sm-3">
+            <input class="form-control" type="text" name="name" placeholder="Search name" value="<?= h($filters['name']); ?>">
+          </div>
+          <div class="col-sm-2">
+            <select class="form-select" name="status">
+              <option value="">All Statuses</option>
+              <?php foreach ($statusList as $id => $status): ?>
+                <option value="<?= $id ?>" <?= $filters['status']==$id ? 'selected' : '' ?>><?= h($status['label']); ?></option>
+              <?php endforeach; ?>
+            </select>
+          </div>
+          <div class="col-sm-3">
+            <select class="form-select" name="org">
+              <option value="">All Organizations</option>
+              <?php foreach ($organizations as $org): ?>
+                <option value="<?= $org['id']; ?>" <?= $filters['org']==$org['id'] ? 'selected' : '' ?>><?= h($org['name']); ?></option>
+              <?php endforeach; ?>
+            </select>
+          </div>
+          <div class="col-sm-2">
+            <select class="form-select" name="lead">
+              <option value="">All Leads</option>
+              <?php foreach ($leadUsers as $user): ?>
+                <option value="<?= $user['id']; ?>" <?= $filters['lead']==$user['id'] ? 'selected' : '' ?>><?= h($user['name']); ?></option>
+              <?php endforeach; ?>
+            </select>
+          </div>
+          <div class="col-sm-2">
+            <button class="btn btn-primary w-100" type="submit">Filter</button>
+          </div>
+        </form>
+      </div>
+    </div>
     <nav class="nav nav-pills mb-3">
-      <a class="nav-link <?php echo $action === 'card' ? 'active' : ''; ?>" href="?action=card">Card view</a>
-      <a class="nav-link <?php echo $action === 'list' ? 'active' : ''; ?>" href="?action=list">List view</a>
-      <a class="nav-link <?php echo $action === 'board' ? 'active' : ''; ?>" href="?action=board">Board view</a>
+      <a class="nav-link <?= $action === 'card' ? 'active' : ''; ?>" href="?<?= http_build_query(array_merge(['action' => 'card'], $queryFilters)); ?>">Card view</a>
+      <a class="nav-link <?= $action === 'list' ? 'active' : ''; ?>" href="?<?= http_build_query(array_merge(['action' => 'list'], $queryFilters)); ?>">List view</a>
+      <a class="nav-link <?= $action === 'board' ? 'active' : ''; ?>" href="?<?= http_build_query(array_merge(['action' => 'board'], $queryFilters)); ?>">Board view</a>
     </nav>
     <?php
       if ($action === 'list') {
@@ -81,4 +120,4 @@ require '../../includes/html_header.php';
     <?php require '../../includes/html_footer.php'; ?>
   </div>
 </main>
-<?php require '../../includes/js_footer.php'; ?>
+<?php $loadFsLightbox = true; require '../../includes/js_footer.php'; ?>


### PR DESCRIPTION
## Summary
- Add persistent filter bar for agency views
- Preview agency attachments in fslightbox and provide explicit downloads
- Load fslightbox assets and initialize globally

## Testing
- `php -l module/agency/index.php`
- `php -l module/agency/include/card_view.php`
- `php -l module/agency/include/list_view.php`
- `php -l module/agency/include/board_view.php`
- `php -l includes/js_footer.php`


------
https://chatgpt.com/codex/tasks/task_e_68b28cfd78888333a1bf6abc5d35cc5a