### PR TITLE
Align asset module with updated RBAC and labeling

### DIFF
--- a/admin/corporate/assets/asset.php
+++ b/admin/corporate/assets/asset.php
@@ -1,6 +1,6 @@
 <?php
 require '../../admin_header.php';
-require_permission('admin_assets','read');
+require_permission('assets','read');
 
 function get_asset_tags(PDO $pdo, int $asset_id): array {
   $stmt = $pdo->prepare('SELECT tag FROM module_asset_tags WHERE asset_id=:id');
@@ -104,6 +104,24 @@ $tags = $editing ? get_asset_tags($pdo,$id) : [];
     <div class="col">
       <label class="form-label">Location</label>
       <input type="text" name="location" class="form-control" value="<?= e($asset['location'] ?? ''); ?>">
+    </div>
+  </div>
+  <div class="row mb-3">
+    <div class="col">
+      <div class="form-check mt-4">
+        <input class="form-check-input" type="checkbox" name="is_encrypted" value="1" <?= $asset && $asset['is_encrypted'] ? 'checked' : ''; ?>>
+        <label class="form-check-label">Encrypted</label>
+      </div>
+    </div>
+    <div class="col">
+      <div class="form-check mt-4">
+        <input class="form-check-input" type="checkbox" name="is_mdm_enrolled" value="1" <?= $asset && $asset['is_mdm_enrolled'] ? 'checked' : ''; ?>>
+        <label class="form-check-label">MDM Enrolled</label>
+      </div>
+    </div>
+    <div class="col">
+      <label class="form-label">Last Patch Date</label>
+      <input type="text" name="last_patch_date" class="form-control" data-flatpickr value="<?= e($asset['last_patch_date'] ?? ''); ?>">
     </div>
   </div>
   <div class="mb-3">
@@ -269,7 +287,11 @@ foreach ($events->fetchAll(PDO::FETCH_ASSOC) as $ev) {
         list.innerHTML = '';
         files.forEach(f => {
           const li = document.createElement('li');
-          li.textContent = f.file_path + ' ';
+          const link = document.createElement('a');
+          link.href = '../../assets/uploads/<?= $id; ?>/' + encodeURIComponent(f.file_path);
+          link.textContent = f.file_path;
+          li.appendChild(link);
+          li.append(' ');
           const btn = document.createElement('button');
           btn.className = 'btn btn-sm btn-danger';
           btn.textContent = 'Delete';

--- a/admin/corporate/assets/functions/assign.php
+++ b/admin/corporate/assets/functions/assign.php
@@ -1,7 +1,7 @@
 <?php
 if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
-require_permission('admin_assets','update');
+require_permission('assets','update');
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') { http_response_code(405); exit; }
 if (!verify_csrf_token($_POST['csrf_token'] ?? '')) { http_response_code(403); exit; }

--- a/admin/corporate/assets/functions/delete.php
+++ b/admin/corporate/assets/functions/delete.php
@@ -1,7 +1,7 @@
 <?php
 if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
-require_permission('admin_assets','delete');
+require_permission('assets','delete');
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
   $_SESSION['error_message'] = 'Method not allowed';

--- a/admin/corporate/assets/functions/delete_file.php
+++ b/admin/corporate/assets/functions/delete_file.php
@@ -1,7 +1,7 @@
 <?php
 if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
-require_permission('admin_assets','update');
+require_permission('assets','update');
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') { http_response_code(405); exit; }
 if (!verify_csrf_token($_POST['csrf_token'] ?? '')) { http_response_code(403); exit; }
@@ -10,7 +10,7 @@ $stmt = $pdo->prepare('SELECT asset_id,file_path FROM module_asset_files WHERE i
 $stmt->execute([':id'=>$id]);
 $file = $stmt->fetch(PDO::FETCH_ASSOC);
 if (!$file) { http_response_code(404); exit; }
-$path = __DIR__.'/../uploads/'.$file['asset_id'].'/'.$file['file_path'];
+$path = __DIR__ . '/../../../assets/uploads/' . $file['asset_id'] . '/' . $file['file_path'];
 if (is_file($path)) unlink($path);
 $pdo->prepare('DELETE FROM module_asset_files WHERE id=:id')->execute([':id'=>$id]);
 admin_audit_log($pdo,$this_user_id,'module_asset_files',$id,'asset.delete',json_encode($file),null,'Deleted file');

--- a/admin/corporate/assets/functions/helpers.php
+++ b/admin/corporate/assets/functions/helpers.php
@@ -1,20 +1,16 @@
 <?php
-function generate_asset_tag(PDO $pdo, int $type_id): string {
-    $stmt = $pdo->prepare('SELECT code FROM lookup_list_items WHERE id=:id');
-    $stmt->execute([':id'=>$type_id]);
-    $code = $stmt->fetchColumn();
-    if (!$code) { throw new Exception('Type code not found'); }
+function generate_asset_tag(PDO $pdo): string {
     $year = date('Y');
-    $seqStmt = $pdo->prepare('SELECT id, seq FROM module_asset_tag_seq WHERE type_id=:type_id AND year=:yr');
-    $seqStmt->execute([':type_id'=>$type_id, ':yr'=>$year]);
+    $seqStmt = $pdo->prepare('SELECT id, seq FROM module_asset_tag_seq WHERE type_id=0 AND year=:yr');
+    $seqStmt->execute([':yr'=>$year]);
     $row = $seqStmt->fetch(PDO::FETCH_ASSOC);
     if ($row) {
         $seq = $row['seq'] + 1;
         $pdo->prepare('UPDATE module_asset_tag_seq SET seq=:seq WHERE id=:id')->execute([':seq'=>$seq, ':id'=>$row['id']]);
     } else {
         $seq = 1;
-        $pdo->prepare('INSERT INTO module_asset_tag_seq (type_id, year, seq) VALUES (:type_id,:yr,1)')->execute([':type_id'=>$type_id, ':yr'=>$year]);
+        $pdo->prepare('INSERT INTO module_asset_tag_seq (type_id, year, seq) VALUES (0,:yr,1)')->execute([':yr'=>$year]);
     }
-    return sprintf('%s-%s-%04d', $code, $year, $seq);
+    return sprintf('AT-%s-%04d', $year, $seq);
 }
 ?>

--- a/admin/corporate/assets/functions/label.php
+++ b/admin/corporate/assets/functions/label.php
@@ -1,18 +1,21 @@
 <?php
 require_once __DIR__ . '/../../../../includes/php_header.php';
-require_permission('admin_assets','read');
-require_once __DIR__ . '/../lib/qrlib.php';
-
+require_permission('assets','read');
 $id = (int)($_GET['id'] ?? 0);
 $stmt = $pdo->prepare('SELECT asset_tag FROM module_assets WHERE id=:id');
 $stmt->execute([':id'=>$id]);
 $asset = $stmt->fetch(PDO::FETCH_ASSOC);
 if (!$asset) { die('Not found'); }
-$data = getURLDir()."admin/corporate/assets/view.php?id=".$id;
-ob_start();
-QRcode::png($data,false,QR_ECLEVEL_L,4);
-$qr = base64_encode(ob_get_clean());
-?><!DOCTYPE html><html><head><link rel="stylesheet" href="../labels.css"></head><body>
-<div class="label"><img src="data:image/png;base64,<?= $qr; ?>" alt="QR"><div class="text"><?= e($asset['asset_tag']); ?></div></div>
+$qrPath = __DIR__ . '/../../../assets/uploads/' . $id . '/qr/' . $asset['asset_tag'] . '.png';
+if (!is_file($qrPath)) {
+  require_once __DIR__ . '/../lib/qrlib.php';
+  if(!is_dir(dirname($qrPath))) mkdir(dirname($qrPath),0775,true);
+  QRcode::png(getURLDir()."admin/corporate/assets/view.php?id=".$id,$qrPath,QR_ECLEVEL_L,4);
+}
+$qr = base64_encode(file_get_contents($qrPath));
+$asset_tag = $asset['asset_tag'];
+?>
+<!DOCTYPE html><html><head><link rel="stylesheet" href="../labels.css"></head><body>
+<?php require __DIR__ . '/../label-template.php'; ?>
 </body></html>
 <?php

--- a/admin/corporate/assets/functions/list_files.php
+++ b/admin/corporate/assets/functions/list_files.php
@@ -1,7 +1,7 @@
 <?php
 if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
-require_permission('admin_assets','read');
+require_permission('assets','read');
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') { http_response_code(405); exit; }
 if (!verify_csrf_token($_POST['csrf_token'] ?? '')) { http_response_code(403); exit; }

--- a/admin/corporate/assets/functions/return.php
+++ b/admin/corporate/assets/functions/return.php
@@ -1,7 +1,7 @@
 <?php
 if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
-require_permission('admin_assets','update');
+require_permission('assets','update');
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') { http_response_code(405); exit; }
 if (!verify_csrf_token($_POST['csrf_token'] ?? '')) { http_response_code(403); exit; }

--- a/admin/corporate/assets/functions/update.php
+++ b/admin/corporate/assets/functions/update.php
@@ -2,7 +2,7 @@
 if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
 require_once __DIR__ . '/helpers.php';
-require_permission('admin_assets','update');
+require_permission('assets','update');
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
   $_SESSION['error_message'] = 'Method not allowed';
@@ -27,6 +27,9 @@ $warranty_expiration = $_POST['warranty_expiration'] ?: null;
 $purchase_price = $_POST['purchase_price'] !== '' ? (float)$_POST['purchase_price'] : null;
 $condition_id = $_POST['condition_id'] !== '' ? (int)$_POST['condition_id'] : null;
 $location = trim($_POST['location'] ?? '');
+$is_encrypted = isset($_POST['is_encrypted']) ? 1 : 0;
+$is_mdm_enrolled = isset($_POST['is_mdm_enrolled']) ? 1 : 0;
+$last_patch_date = $_POST['last_patch_date'] ?: null;
 $memo = $_POST['memo'] ?? null;
 $compliance_flags = isset($_POST['compliance']) ? implode(',', (array)$_POST['compliance']) : null;
 $tags = isset($_POST['tags']) ? array_filter(array_map('trim', (array)$_POST['tags'])) : [];
@@ -44,7 +47,7 @@ if (!$existing) {
 }
 
 try {
-  $pdo->prepare('UPDATE module_assets SET type_id=:type_id,status_id=:status_id,name=:name,vendor=:vendor,model=:model,serial=:serial,purchase_date=:purchase_date,warranty_expiration=:warranty_expiration,purchase_price=:purchase_price,condition_id=:condition_id,location=:location,compliance_flags=:compliance_flags,memo=:memo,user_updated=:uid WHERE id=:id')
+  $pdo->prepare('UPDATE module_assets SET type_id=:type_id,status_id=:status_id,name=:name,vendor=:vendor,model=:model,serial=:serial,purchase_date=:purchase_date,warranty_expiration=:warranty_expiration,purchase_price=:purchase_price,condition_id=:condition_id,location=:location,is_encrypted=:is_encrypted,is_mdm_enrolled=:is_mdm_enrolled,last_patch_date=:last_patch_date,compliance_flags=:compliance_flags,memo=:memo,user_updated=:uid WHERE id=:id')
       ->execute([
         ':type_id'=>$type_id,
         ':status_id'=>$status_id,
@@ -57,6 +60,9 @@ try {
         ':purchase_price'=>$purchase_price,
         ':condition_id'=>$condition_id,
         ':location'=>$location,
+        ':is_encrypted'=>$is_encrypted,
+        ':is_mdm_enrolled'=>$is_mdm_enrolled,
+        ':last_patch_date'=>$last_patch_date,
         ':compliance_flags'=>$compliance_flags,
         ':memo'=>$memo,
         ':uid'=>$this_user_id,
@@ -81,7 +87,10 @@ admin_audit_log($pdo,$this_user_id,'module_assets',$id,'asset.update',json_encod
   'serial'=>$serial,
   'purchase_price'=>$purchase_price,
   'condition_id'=>$condition_id,
-  'location'=>$location
+  'location'=>$location,
+  'is_encrypted'=>$is_encrypted,
+  'is_mdm_enrolled'=>$is_mdm_enrolled,
+  'last_patch_date'=>$last_patch_date
 ]),'Updated asset');
 
 $_SESSION['message'] = 'Asset updated';

--- a/admin/corporate/assets/functions/upload_file.php
+++ b/admin/corporate/assets/functions/upload_file.php
@@ -1,7 +1,7 @@
 <?php
 if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
-require_permission('admin_assets','update');
+require_permission('assets','update');
 
 $asset_id = (int)($_POST['asset_id'] ?? 0);
 if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
@@ -14,7 +14,7 @@ if (!isset($_FILES['file']) || $_FILES['file']['error'] !== UPLOAD_ERR_OK) {
   echo 'Upload error';
   exit;
 }
-$uploadDir = __DIR__ . '/../uploads/' . $asset_id . '/';
+$uploadDir = __DIR__ . '/../../../assets/uploads/' . $asset_id . '/';
 if (!is_dir($uploadDir)) { mkdir($uploadDir,0775,true); }
 $filename = basename($_FILES['file']['name']);
 $target = $uploadDir . $filename;

--- a/admin/corporate/assets/index.php
+++ b/admin/corporate/assets/index.php
@@ -1,6 +1,6 @@
 <?php
 require '../../admin_header.php';
-require_permission('admin_assets','read');
+require_permission('assets','read');
 
 $token = generate_csrf_token();
 
@@ -42,9 +42,10 @@ $types = get_lookup_items($pdo,'ASSET_TYPE');
 <?= flash_message($_SESSION['error_message'] ?? '', 'danger'); ?>
 <?php unset($_SESSION['message'], $_SESSION['error_message']); ?>
 <div class="mb-3 d-flex gap-2">
-  <?php if (user_has_permission('admin_assets','create')): ?>
+  <?php if (user_has_permission('assets','create')): ?>
   <a class="btn btn-sm btn-success" href="asset.php">Add Asset</a>
   <?php endif; ?>
+  <button class="btn btn-sm btn-secondary" type="button" id="print-labels">Print Labels</button>
 </div>
 <form class="row g-2 mb-3" method="get">
   <div class="col-auto">
@@ -81,6 +82,7 @@ $types = get_lookup_items($pdo,'ASSET_TYPE');
   <table class="table table-striped table-sm mb-0">
     <thead>
       <tr>
+        <th><input type="checkbox" id="select-all"></th>
         <th>Tag</th>
         <th>Type</th>
         <th>Model</th>
@@ -95,6 +97,7 @@ $types = get_lookup_items($pdo,'ASSET_TYPE');
     <tbody>
       <?php foreach($assets as $a): ?>
       <tr>
+        <td><input type="checkbox" class="asset-select" value="<?= $a['id']; ?>"></td>
         <td><?= e($a['asset_tag']); ?></td>
         <td><?= e($a['type_label']); ?></td>
         <td><?= e($a['model']); ?></td>
@@ -111,4 +114,13 @@ $types = get_lookup_items($pdo,'ASSET_TYPE');
     </tbody>
   </table>
 </div>
+<script>
+document.getElementById('select-all').addEventListener('change',e=>{
+  document.querySelectorAll('.asset-select').forEach(cb=>cb.checked=e.target.checked);
+});
+document.getElementById('print-labels').addEventListener('click',()=>{
+  const ids=[...document.querySelectorAll('.asset-select:checked')].map(cb=>cb.value).join(',');
+  if(ids) window.open('labels.php?ids='+ids,'_blank');
+});
+</script>
 <?php require '../admin_footer.php'; ?>

--- a/admin/corporate/assets/label-template.php
+++ b/admin/corporate/assets/label-template.php
@@ -1,0 +1,4 @@
+<div class="label">
+  <img src="data:image/png;base64,<?= $qr; ?>" alt="QR">
+  <div class="text"><?= e($asset_tag); ?></div>
+</div>

--- a/admin/corporate/assets/labels.css
+++ b/admin/corporate/assets/labels.css
@@ -1,6 +1,6 @@
 .label {
-  width: 200px;
-  height: 100px;
+  width: 1.5in;
+  height: 1.5in;
   border: 1px solid #000;
   display: flex;
   flex-direction: column;
@@ -11,8 +11,8 @@
   margin: 4px;
 }
 .label img {
-  max-width: 80px;
-  max-height: 80px;
+  max-width: 1in;
+  max-height: 1in;
 }
 .label .text {
   margin-top: 4px;


### PR DESCRIPTION
## Summary
- Switch asset module to `assets` RBAC scope and persist new encryption, MDM, and patch metadata
- Generate `AT-YYYY-####` asset tags and store QR codes with reusable label template
- Enable bulk label printing and consolidate uploads under `/admin/assets/uploads`

## Testing
- `php -l admin/corporate/assets/index.php`
- `php -l admin/corporate/assets/asset.php`
- `php -l admin/corporate/assets/labels.php`
- `php -l admin/corporate/assets/functions/assign.php`
- `php -l admin/corporate/assets/functions/return.php`
- `php -l admin/corporate/assets/functions/delete.php`
- `php -l admin/corporate/assets/functions/create.php`
- `php -l admin/corporate/assets/functions/update.php`
- `php -l admin/corporate/assets/functions/upload_file.php`
- `php -l admin/corporate/assets/functions/delete_file.php`
- `php -l admin/corporate/assets/functions/list_files.php`
- `php -l admin/corporate/assets/functions/label.php`
- `php -l admin/corporate/assets/functions/helpers.php`
- `php -l admin/corporate/assets/label-template.php`


------
https://chatgpt.com/codex/tasks/task_e_68b28d776fbc8333bc7bf5f6a903fed1