### PR TITLE
Enhance Minder notes with rich editor and filtering

### DIFF
--- a/admin/minder/notes/functions/delete.php
+++ b/admin/minder/notes/functions/delete.php
@@ -42,8 +42,8 @@ foreach ($files as $fp) {
     if ($fp) @unlink($rootDir . $fp);
 }
 $pdo->prepare('DELETE FROM admin_minder_notes_files WHERE note_id = :id')->execute([':id'=>$id]);
-$pdo->prepare('DELETE FROM admin_minder_notes_person WHERE note_id = :id')->execute([':id'=>$id]);
-$pdo->prepare('DELETE FROM admin_minder_notes_contractor WHERE note_id = :id')->execute([':id'=>$id]);
+$pdo->prepare('DELETE FROM admin_minder_notes_persons WHERE note_id = :id')->execute([':id'=>$id]);
+$pdo->prepare('DELETE FROM admin_minder_notes_contractors WHERE note_id = :id')->execute([':id'=>$id]);
 $pdo->prepare('DELETE FROM admin_minder_notes WHERE id = :id')->execute([':id'=>$id]);
 
 admin_audit_log($pdo,$this_user_id,'admin_minder_notes',$id,'DELETE',json_encode($old),null);

--- a/admin/minder/notes/functions/delete_file.php
+++ b/admin/minder/notes/functions/delete_file.php
@@ -1,0 +1,21 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../../includes/php_header.php';
+require_permission('minder_note','update');
+
+if (!verify_csrf_token($_GET['csrf_token'] ?? '')) { http_response_code(403); exit('Invalid CSRF token'); }
+$id = (int)($_GET['id'] ?? 0);
+$note_id = (int)($_GET['note_id'] ?? 0);
+if (!$id || !$note_id) { http_response_code(400); exit('Missing data'); }
+$stmt = $pdo->prepare('SELECT file_path FROM admin_minder_notes_files WHERE id=:id AND note_id=:nid');
+$stmt->execute([':id'=>$id, ':nid'=>$note_id]);
+$file = $stmt->fetch(PDO::FETCH_ASSOC);
+if ($file) {
+  $path = dirname(__DIR__,4) . '/' . $file['file_path'];
+  if (is_file($path)) { @unlink($path); }
+  $pdo->prepare('DELETE FROM admin_minder_notes_files WHERE id=:id')->execute([':id'=>$id]);
+  admin_audit_log($pdo,$this_user_id,'admin_minder_notes_files',$id,'DELETE',json_encode($file),null);
+}
+header('Location: ../note.php?id=' . $note_id);
+exit;
+?>

--- a/admin/minder/notes/functions/link_contractor.php
+++ b/admin/minder/notes/functions/link_contractor.php
@@ -26,14 +26,14 @@ if (!$note_id || !$contractor_id) {
 }
 
 try {
-    $stmt = $pdo->prepare('INSERT INTO admin_minder_notes_contractor (note_id, contractor_id, user_id, user_updated) VALUES (:note,:contractor,:uid,:uid)');
+    $stmt = $pdo->prepare('INSERT INTO admin_minder_notes_contractors (note_id, contractor_id, user_id, user_updated) VALUES (:note,:contractor,:uid,:uid)');
     $stmt->execute([
         ':note' => $note_id,
         ':contractor' => $contractor_id,
         ':uid' => $this_user_id
     ]);
     $linkId = (int)$pdo->lastInsertId();
-    admin_audit_log($pdo,$this_user_id,'admin_minder_notes_contractor',$linkId,'CREATE',null,json_encode(['contractor_id'=>$contractor_id]));
+    admin_audit_log($pdo,$this_user_id,'admin_minder_notes_contractors',$linkId,'CREATE',null,json_encode(['contractor_id'=>$contractor_id]));
     echo json_encode(['success'=>true,'id'=>$linkId]);
 } catch (PDOException $e) {
     http_response_code(500);

--- a/admin/minder/notes/functions/link_person.php
+++ b/admin/minder/notes/functions/link_person.php
@@ -26,14 +26,14 @@ if (!$note_id || !$person_id) {
 }
 
 try {
-    $stmt = $pdo->prepare('INSERT INTO admin_minder_notes_person (note_id, person_id, user_id, user_updated) VALUES (:note,:person,:uid,:uid)');
+    $stmt = $pdo->prepare('INSERT INTO admin_minder_notes_persons (note_id, person_id, user_id, user_updated) VALUES (:note,:person,:uid,:uid)');
     $stmt->execute([
         ':note' => $note_id,
         ':person' => $person_id,
         ':uid' => $this_user_id
     ]);
     $linkId = (int)$pdo->lastInsertId();
-    admin_audit_log($pdo,$this_user_id,'admin_minder_notes_person',$linkId,'CREATE',null,json_encode(['person_id'=>$person_id]));
+    admin_audit_log($pdo,$this_user_id,'admin_minder_notes_persons',$linkId,'CREATE',null,json_encode(['person_id'=>$person_id]));
     echo json_encode(['success'=>true,'id'=>$linkId]);
 } catch (PDOException $e) {
     http_response_code(500);

--- a/admin/minder/notes/functions/list.php
+++ b/admin/minder/notes/functions/list.php
@@ -1,0 +1,37 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../../includes/php_header.php';
+require_permission('minder_note','read');
+
+$search = trim($_POST['search'] ?? '');
+$category = $_POST['category'] !== '' ? (int)$_POST['category'] : null;
+$status = $_POST['status'] !== '' ? (int)$_POST['status'] : null;
+
+$sql = "SELECT n.id, n.title, n.body, n.date_created, u.email AS user_email
+        FROM admin_minder_notes n
+        LEFT JOIN users u ON n.user_id = u.id";
+$conds = [];
+$params = [];
+if ($search !== '') {
+  $conds[] = '(n.title LIKE :search OR n.body LIKE :search)';
+  $params[':search'] = '%'.$search.'%';
+}
+if ($category) {
+  $conds[] = 'n.category_id = :category';
+  $params[':category'] = $category;
+}
+if ($status) {
+  $conds[] = 'n.status_id = :status';
+  $params[':status'] = $status;
+}
+if ($conds) {
+  $sql .= ' WHERE '.implode(' AND ', $conds);
+}
+$sql .= ' ORDER BY n.date_created DESC';
+$stmt = $pdo->prepare($sql);
+$stmt->execute($params);
+$notes = $stmt->fetchAll(PDO::FETCH_ASSOC);
+foreach ($notes as $note) {
+  echo '<div class="timeline-item"><div class="row g-3"><div class="col-auto"><div class="timeline-item-bar position-relative"><div class="icon-item icon-item-md rounded-7 border border-translucent"><span class="fa-solid fa-note-sticky text-info fs-9"></span></div><span class="timeline-bar border-end border-dashed"></span></div></div><div class="col"><div class="d-flex justify-content-between"><div class="d-flex mb-2"><h6 class="lh-sm mb-0 me-2 text-body-secondary timeline-item-title"><a class="text-body" href="note.php?id=' . $note['id'] . '">' . e($note['title']) . '</a></h6></div><p class="text-body-quaternary fs-9 mb-0 text-nowrap timeline-time"><span class="fa-regular fa-clock me-1"></span>' . e(date('M j, Y g:i a', strtotime($note['date_created']))) . '</p></div><h6 class="fs-10 fw-normal mb-3">by <a class="fw-semibold" href="#">' . e($note['user_email'] ?? '') . '</a></h6><p class="fs-9 text-body-secondary w-sm-60 mb-5">' . $note['body'] . '</p></div></div></div>';
+}
+?>

--- a/admin/minder/notes/functions/unlink_contractor.php
+++ b/admin/minder/notes/functions/unlink_contractor.php
@@ -1,0 +1,14 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../../includes/php_header.php';
+require_permission('minder_note','update');
+
+if (!verify_csrf_token($_GET['csrf_token'] ?? '')) { http_response_code(403); exit('Invalid CSRF token'); }
+$id = (int)($_GET['id'] ?? 0);
+$note_id = (int)($_GET['note_id'] ?? 0);
+if (!$id || !$note_id) { http_response_code(400); exit('Missing data'); }
+$pdo->prepare('DELETE FROM admin_minder_notes_contractors WHERE id=:id')->execute([':id'=>$id]);
+admin_audit_log($pdo,$this_user_id,'admin_minder_notes_contractors',$id,'DELETE',null,null);
+header('Location: ../note.php?id=' . $note_id);
+exit;
+?>

--- a/admin/minder/notes/functions/unlink_person.php
+++ b/admin/minder/notes/functions/unlink_person.php
@@ -1,0 +1,14 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../../includes/php_header.php';
+require_permission('minder_note','update');
+
+if (!verify_csrf_token($_GET['csrf_token'] ?? '')) { http_response_code(403); exit('Invalid CSRF token'); }
+$id = (int)($_GET['id'] ?? 0);
+$note_id = (int)($_GET['note_id'] ?? 0);
+if (!$id || !$note_id) { http_response_code(400); exit('Missing data'); }
+$pdo->prepare('DELETE FROM admin_minder_notes_persons WHERE id=:id')->execute([':id'=>$id]);
+admin_audit_log($pdo,$this_user_id,'admin_minder_notes_persons',$id,'DELETE',null,null);
+header('Location: ../note.php?id=' . $note_id);
+exit;
+?>

--- a/admin/minder/notes/index.php
+++ b/admin/minder/notes/index.php
@@ -7,12 +7,19 @@ $notesStmt = $pdo->query("SELECT n.id, n.title, n.body, n.date_created, u.email 
                            LEFT JOIN users u ON n.user_id = u.id
                            ORDER BY n.date_created DESC");
 $notes = $notesStmt->fetchAll(PDO::FETCH_ASSOC);
+$categories = get_lookup_items($pdo, 'ADMIN_MINDER_NOTE_CATEGORY');
+$statuses   = get_lookup_items($pdo, 'ADMIN_MINDER_NOTE_STATUS');
 ?>
 <h2 class="mb-4">Minder Notes</h2>
 <?php if (user_has_permission('minder_note','create')): ?>
   <a href="note.php" class="btn btn-success mb-3"><span class="fa-solid fa-plus"></span><span class="visually-hidden">Add</span></a>
-<?php endif; ?>
-<div class="timeline-basic mb-9">
+  <?php endif; ?>
+  <div class="row g-2 mb-3">
+    <div class="col-md-4"><input type="text" id="searchNotes" class="form-control" placeholder="Search..."></div>
+    <div class="col-md-3"><select id="filterCategory" class="form-select"><option value="">All Categories</option><?php foreach ($categories as $c): ?><option value="<?= $c['id']; ?>"><?= e($c['label']); ?></option><?php endforeach; ?></select></div>
+    <div class="col-md-3"><select id="filterStatus" class="form-select"><option value="">All Statuses</option><?php foreach ($statuses as $s): ?><option value="<?= $s['id']; ?>"><?= e($s['label']); ?></option><?php endforeach; ?></select></div>
+  </div>
+  <div id="notesTimeline" class="timeline-basic mb-9">
   <?php foreach ($notes as $note): ?>
   <div class="timeline-item">
     <div class="row g-3">
@@ -29,10 +36,27 @@ $notes = $notesStmt->fetchAll(PDO::FETCH_ASSOC);
           <p class="text-body-quaternary fs-9 mb-0 text-nowrap timeline-time"><span class="fa-regular fa-clock me-1"></span><?= e(date('M j, Y g:i a', strtotime($note['date_created']))); ?></p>
         </div>
         <h6 class="fs-10 fw-normal mb-3">by <a class="fw-semibold" href="#">"><?= e($note['user_email'] ?? ''); ?></a></h6>
-        <p class="fs-9 text-body-secondary w-sm-60 mb-5"><?= nl2br(e($note['body'])); ?></p>
+          <p class="fs-9 text-body-secondary w-sm-60 mb-5"><?= $note['body']; ?></p>
       </div>
     </div>
   </div>
   <?php endforeach; ?>
-</div>
-<?php require_once __DIR__ . '/../../admin_footer.php'; ?>
+  </div>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  const search = document.getElementById('searchNotes');
+  const cat = document.getElementById('filterCategory');
+  const status = document.getElementById('filterStatus');
+  const timeline = document.getElementById('notesTimeline');
+  let timer;
+  function loadNotes(){
+    const params = new URLSearchParams({search: search.value, category: cat.value, status: status.value});
+    fetch('functions/list.php', {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body: params})
+      .then(r => r.text()).then(html => { timeline.innerHTML = html; });
+  }
+  search.addEventListener('input', () => { clearTimeout(timer); timer = setTimeout(loadNotes,300); });
+  cat.addEventListener('change', loadNotes);
+  status.addEventListener('change', loadNotes);
+});
+</script>
+  <?php require_once __DIR__ . '/../../admin_footer.php'; ?>


### PR DESCRIPTION
## Summary
- Replace note textarea with Quill-based rich text editor
- Display existing attachments and linked persons/contractors with delete controls
- Support searching and filtering notes with AJAX-powered timeline updates

## Testing
- `php -l admin/minder/notes/note.php`
- `php -l admin/minder/notes/index.php`
- `php -l admin/minder/notes/functions/link_person.php`
- `php -l admin/minder/notes/functions/link_contractor.php`
- `php -l admin/minder/notes/functions/delete.php`
- `php -l admin/minder/notes/functions/delete_file.php`
- `php -l admin/minder/notes/functions/unlink_person.php`
- `php -l admin/minder/notes/functions/unlink_contractor.php`
- `php -l admin/minder/notes/functions/list.php`


------
https://chatgpt.com/codex/tasks/task_e_68b28d625b148333a0619809623be4d2