### PR TITLE
Refactor reminders to support tabbed list/calendar and AJAX CRUD

### DIFF
--- a/admin/minder/reminders/functions/create.php
+++ b/admin/minder/reminders/functions/create.php
@@ -1,47 +1,28 @@
 <?php
 if (session_status() !== PHP_SESSION_ACTIVE) session_start();
-require_once __DIR__ . '/../../../includes/php_header.php';
+require_once __DIR__ . '/../../../../includes/php_header.php';
 require_permission('minder_reminder','create');
 
-$isAjax = ($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '') === 'XMLHttpRequest'
-    || str_contains($_SERVER['HTTP_ACCEPT'] ?? '', 'application/json');
+header('Content-Type: application/json');
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
-  if ($isAjax) {
-    header('Content-Type: application/json');
-    http_response_code(405);
-    echo json_encode(['success'=>false,'error'=>'Method not allowed']);
-  } else {
-    $_SESSION['error_message'] = 'Method not allowed';
-    header('Location: ../reminder.php');
-  }
+  http_response_code(405);
+  echo json_encode(['success'=>false,'error'=>'Method not allowed']);
   exit;
 }
 
 if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
-  if ($isAjax) {
-    header('Content-Type: application/json');
-    http_response_code(403);
-    echo json_encode(['success'=>false,'error'=>'Invalid CSRF token']);
-  } else {
-    $_SESSION['error_message'] = 'Invalid CSRF token';
-    header('Location: ../reminder.php');
-  }
+  http_response_code(403);
+  echo json_encode(['success'=>false,'error'=>'Invalid CSRF token']);
   exit;
 }
 
-$title = trim($_POST['title'] ?? '');
-if ($title === '') {
-  if ($isAjax) {
-    header('Content-Type: application/json');
+  $title = trim($_POST['title'] ?? '');
+  if ($title === '') {
     http_response_code(400);
     echo json_encode(['success'=>false,'error'=>'Title required']);
-  } else {
-    $_SESSION['error_message'] = 'Title required';
-    header('Location: ../reminder.php');
+    exit;
   }
-  exit;
-}
 $description = $_POST['description'] ?? null;
 $remind_at = $_POST['remind_at'] ?? null;
 $type_id = $_POST['type_id'] !== '' ? (int)$_POST['type_id'] : null;
@@ -62,31 +43,19 @@ try {
   ]);
   $reminderId = (int)$pdo->lastInsertId();
   foreach ($person_ids as $pid) {
-    $pdo->prepare('INSERT INTO admin_minder_reminders_person (reminder_id, person_id, user_id, user_updated) VALUES (:rid,:pid,:uid,:uid)')
+    $pdo->prepare('INSERT INTO admin_minder_reminders_persons (reminder_id, person_id, user_id, user_updated) VALUES (:rid,:pid,:uid,:uid)')
         ->execute([':rid'=>$reminderId, ':pid'=>$pid, ':uid'=>$this_user_id]);
   }
   foreach ($contractor_ids as $cid) {
-    $pdo->prepare('INSERT INTO admin_minder_reminders_contractor (reminder_id, contractor_id, user_id, user_updated) VALUES (:rid,:cid,:uid,:uid)')
+    $pdo->prepare('INSERT INTO admin_minder_reminders_contractors (reminder_id, contractor_id, user_id, user_updated) VALUES (:rid,:cid,:uid,:uid)')
         ->execute([':rid'=>$reminderId, ':cid'=>$cid, ':uid'=>$this_user_id]);
   }
 } catch (PDOException $e) {
-  if ($isAjax) {
-    header('Content-Type: application/json');
-    echo json_encode(['success'=>false,'error'=>$e->getMessage()]);
-  } else {
-    $_SESSION['error_message'] = 'Unable to save reminder';
-    header('Location: ../reminder.php');
-  }
+  echo json_encode(['success'=>false,'error'=>$e->getMessage()]);
   exit;
 }
 
 admin_audit_log($pdo, $this_user_id, 'admin_minder_reminders', $reminderId, 'CREATE', null, json_encode(['title'=>$title]), 'Created reminder');
 
-if ($isAjax) {
-  header('Content-Type: application/json');
-  echo json_encode(['success'=>true,'id'=>$reminderId]);
-} else {
-  $_SESSION['message'] = 'Reminder saved';
-  header('Location: ../reminder.php?id=' . $reminderId);
-}
+echo json_encode(['success'=>true,'id'=>$reminderId]);
 exit;

--- a/admin/minder/reminders/functions/delete_file.php
+++ b/admin/minder/reminders/functions/delete_file.php
@@ -1,0 +1,45 @@
+<?php
+if (session_status() !== PHP_SESSION_ACTIVE) session_start();
+require_once __DIR__ . '/../../../../includes/php_header.php';
+require_permission('minder_reminder','update');
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+  http_response_code(405);
+  echo json_encode(['success'=>false,'error'=>'Method not allowed']);
+  exit;
+}
+
+if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
+  http_response_code(403);
+  echo json_encode(['success'=>false,'error'=>'Invalid CSRF token']);
+  exit;
+}
+
+$id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+if (!$id) {
+  http_response_code(400);
+  echo json_encode(['success'=>false,'error'=>'Invalid ID']);
+  exit;
+}
+
+$stmt = $pdo->prepare('SELECT * FROM admin_minder_reminders_files WHERE id = :id');
+$stmt->execute([':id'=>$id]);
+$file = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$file) {
+  http_response_code(404);
+  echo json_encode(['success'=>false,'error'=>'File not found']);
+  exit;
+}
+
+$pdo->prepare('DELETE FROM admin_minder_reminders_files WHERE id = :id')->execute([':id'=>$id]);
+
+$path = __DIR__ . '/../../../../' . $file['file_path'];
+if (is_file($path)) {
+  @unlink($path);
+}
+
+admin_audit_log($pdo, $this_user_id, 'admin_minder_reminders_files', $id, 'DELETE', json_encode($file), null, 'Deleted file');
+
+echo json_encode(['success'=>true]);

--- a/admin/minder/reminders/functions/link_contractor.php
+++ b/admin/minder/reminders/functions/link_contractor.php
@@ -1,48 +1,33 @@
 <?php
 if (session_status() !== PHP_SESSION_ACTIVE) session_start();
-require_once __DIR__ . '/../../../includes/php_header.php';
+require_once __DIR__ . '/../../../../includes/php_header.php';
 require_permission('minder_reminder','update');
 
-$isAjax = ($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '') === 'XMLHttpRequest'
-    || str_contains($_SERVER['HTTP_ACCEPT'] ?? '', 'application/json');
+header('Content-Type: application/json');
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
   http_response_code(405);
+  echo json_encode(['success'=>false,'error'=>'Method not allowed']);
   exit;
 }
 
 if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
-  if ($isAjax) {
-    header('Content-Type: application/json');
-    http_response_code(403);
-    echo json_encode(['success'=>false,'error'=>'Invalid CSRF token']);
-  } else {
-    die('Invalid CSRF token');
-  }
+  http_response_code(403);
+  echo json_encode(['success'=>false,'error'=>'Invalid CSRF token']);
   exit;
 }
 
 $reminder_id = isset($_POST['reminder_id']) ? (int)$_POST['reminder_id'] : 0;
 $contractor_id = isset($_POST['contractor_id']) ? (int)$_POST['contractor_id'] : 0;
 if (!$reminder_id || !$contractor_id) {
-  if ($isAjax) {
-    header('Content-Type: application/json');
-    http_response_code(400);
-    echo json_encode(['success'=>false,'error'=>'Missing data']);
-  } else {
-    die('Missing data');
-  }
+  http_response_code(400);
+  echo json_encode(['success'=>false,'error'=>'Missing data']);
   exit;
 }
 
-$pdo->prepare('INSERT INTO admin_minder_reminders_contractor (reminder_id, contractor_id, user_id, user_updated) VALUES (:rid,:cid,:uid,:uid)')
+$pdo->prepare('INSERT INTO admin_minder_reminders_contractors (reminder_id, contractor_id, user_id, user_updated) VALUES (:rid,:cid,:uid,:uid)')
     ->execute([':rid'=>$reminder_id, ':cid'=>$contractor_id, ':uid'=>$this_user_id]);
 
-admin_audit_log($pdo, $this_user_id, 'admin_minder_reminders_contractor', $reminder_id, 'CREATE', null, json_encode(['contractor_id'=>$contractor_id]), 'Linked contractor');
+admin_audit_log($pdo, $this_user_id, 'admin_minder_reminders_contractors', $reminder_id, 'CREATE', null, json_encode(['contractor_id'=>$contractor_id]), 'Linked contractor');
 
-if ($isAjax) {
-  header('Content-Type: application/json');
-  echo json_encode(['success'=>true]);
-} else {
-  header('Location: ../reminder.php?id=' . $reminder_id);
-}
+echo json_encode(['success'=>true]);

--- a/admin/minder/reminders/functions/unlink_contractor.php
+++ b/admin/minder/reminders/functions/unlink_contractor.php
@@ -17,17 +17,17 @@ if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
   exit;
 }
 
-$reminder_id = isset($_POST['reminder_id']) ? (int)$_POST['reminder_id'] : 0;
-$person_id = isset($_POST['person_id']) ? (int)$_POST['person_id'] : 0;
-if (!$reminder_id || !$person_id) {
+$reminder_id   = isset($_POST['reminder_id']) ? (int)$_POST['reminder_id'] : 0;
+$contractor_id = isset($_POST['contractor_id']) ? (int)$_POST['contractor_id'] : 0;
+if (!$reminder_id || !$contractor_id) {
   http_response_code(400);
   echo json_encode(['success'=>false,'error'=>'Missing data']);
   exit;
 }
 
-$pdo->prepare('INSERT INTO admin_minder_reminders_persons (reminder_id, person_id, user_id, user_updated) VALUES (:rid,:pid,:uid,:uid)')
-    ->execute([':rid'=>$reminder_id, ':pid'=>$person_id, ':uid'=>$this_user_id]);
+$pdo->prepare('DELETE FROM admin_minder_reminders_contractors WHERE reminder_id = :rid AND contractor_id = :cid')
+    ->execute([':rid'=>$reminder_id, ':cid'=>$contractor_id]);
 
-admin_audit_log($pdo, $this_user_id, 'admin_minder_reminders_persons', $reminder_id, 'CREATE', null, json_encode(['person_id'=>$person_id]), 'Linked person');
+admin_audit_log($pdo, $this_user_id, 'admin_minder_reminders_contractors', $reminder_id, 'DELETE', json_encode(['contractor_id'=>$contractor_id]), null, 'Unlinked contractor');
 
 echo json_encode(['success'=>true]);

--- a/admin/minder/reminders/functions/unlink_person.php
+++ b/admin/minder/reminders/functions/unlink_person.php
@@ -18,16 +18,16 @@ if (!verify_csrf_token($_POST['csrf_token'] ?? '')) {
 }
 
 $reminder_id = isset($_POST['reminder_id']) ? (int)$_POST['reminder_id'] : 0;
-$person_id = isset($_POST['person_id']) ? (int)$_POST['person_id'] : 0;
+$person_id   = isset($_POST['person_id']) ? (int)$_POST['person_id'] : 0;
 if (!$reminder_id || !$person_id) {
   http_response_code(400);
   echo json_encode(['success'=>false,'error'=>'Missing data']);
   exit;
 }
 
-$pdo->prepare('INSERT INTO admin_minder_reminders_persons (reminder_id, person_id, user_id, user_updated) VALUES (:rid,:pid,:uid,:uid)')
-    ->execute([':rid'=>$reminder_id, ':pid'=>$person_id, ':uid'=>$this_user_id]);
+$pdo->prepare('DELETE FROM admin_minder_reminders_persons WHERE reminder_id = :rid AND person_id = :pid')
+    ->execute([':rid'=>$reminder_id, ':pid'=>$person_id]);
 
-admin_audit_log($pdo, $this_user_id, 'admin_minder_reminders_persons', $reminder_id, 'CREATE', null, json_encode(['person_id'=>$person_id]), 'Linked person');
+admin_audit_log($pdo, $this_user_id, 'admin_minder_reminders_persons', $reminder_id, 'DELETE', json_encode(['person_id'=>$person_id]), null, 'Unlinked person');
 
 echo json_encode(['success'=>true]);

--- a/admin/minder/reminders/index.php
+++ b/admin/minder/reminders/index.php
@@ -1,17 +1,66 @@
 <?php
 require_once __DIR__ . '/../../admin_header.php';
 require_permission('minder_reminder','read');
+
+$reminders = $pdo->query("SELECT r.id, r.title, r.description, r.remind_at,
+       GROUP_CONCAT(DISTINCT CONCAT(p.first_name,' ',p.last_name) SEPARATOR ', ') AS persons,
+       GROUP_CONCAT(DISTINCT CONCAT(cp.first_name,' ',cp.last_name) SEPARATOR ', ') AS contractors
+FROM admin_minder_reminders r
+LEFT JOIN admin_minder_reminders_persons rp ON r.id = rp.reminder_id
+LEFT JOIN person p ON rp.person_id = p.id
+LEFT JOIN admin_minder_reminders_contractors rc ON r.id = rc.reminder_id
+LEFT JOIN module_contractors mc ON rc.contractor_id = mc.id
+LEFT JOIN person cp ON mc.person_id = cp.id
+GROUP BY r.id
+ORDER BY r.remind_at IS NULL, r.remind_at")->fetchAll(PDO::FETCH_ASSOC);
+
+$events = [];
+foreach ($reminders as &$r) {
+  $r['users'] = trim($r['persons'] . ($r['contractors'] ? ', ' . $r['contractors'] : ''));
+  if (!empty($r['remind_at'])) {
+    $events[] = ['title'=>$r['title'], 'start'=>$r['remind_at'], 'url'=>'reminder.php?id='.(int)$r['id']];
+  }
+}
+unset($r);
 ?>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/main.min.css">
 <div class="container-fluid py-4">
-  <div id="appCalendar"></div>
+  <ul class="nav nav-tabs" id="reminderTabs" role="tablist">
+    <li class="nav-item" role="presentation">
+      <button class="nav-link active" id="list-tab" data-bs-toggle="tab" data-bs-target="#list" type="button" role="tab">List</button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" id="calendar-tab" data-bs-toggle="tab" data-bs-target="#calendar" type="button" role="tab">Calendar</button>
+    </li>
+  </ul>
+  <div class="tab-content mt-3">
+    <div class="tab-pane fade show active" id="list" role="tabpanel">
+      <table class="table">
+        <thead><tr><th>Title</th><th>Description</th><th>Remind At</th><th>Users</th></tr></thead>
+        <tbody>
+          <?php foreach ($reminders as $r): ?>
+          <tr>
+            <td><a href="reminder.php?id=<?= (int)$r['id']; ?>"><?= e($r['title']); ?></a></td>
+            <td><?= e($r['description']); ?></td>
+            <td><?= $r['remind_at'] ? e($r['remind_at']) : ''; ?></td>
+            <td><?= e($r['users']); ?></td>
+          </tr>
+          <?php endforeach; ?>
+        </tbody>
+      </table>
+    </div>
+    <div class="tab-pane fade" id="calendar" role="tabpanel">
+      <div id="appCalendar"></div>
+    </div>
+  </div>
 </div>
 <script src="<?= getURLDir(); ?>vendors/fullcalendar/index.global.min.js"></script>
 <script>
   document.addEventListener('DOMContentLoaded', function() {
     var calendarEl = document.getElementById('appCalendar');
     var calendar = new FullCalendar.Calendar(calendarEl, {
-      initialView: 'dayGridMonth'
+      initialView: 'dayGridMonth',
+      events: <?= json_encode($events); ?>
     });
     calendar.render();
   });

--- a/admin/minder/reminders/reminder.php
+++ b/admin/minder/reminders/reminder.php
@@ -14,12 +14,17 @@ if ($editing) {
     require __DIR__ . '/../../admin_footer.php';
     exit;
   }
-  $pStmt = $pdo->prepare('SELECT person_id FROM admin_minder_reminders_person WHERE reminder_id = :id');
+  $pStmt = $pdo->prepare("SELECT rp.person_id, CONCAT(p.first_name,' ',p.last_name) AS name FROM admin_minder_reminders_persons rp JOIN person p ON rp.person_id = p.id WHERE rp.reminder_id = :id");
   $pStmt->execute([':id'=>$id]);
-  $linkedPersons = $pStmt->fetchAll(PDO::FETCH_COLUMN);
-  $cStmt = $pdo->prepare('SELECT contractor_id FROM admin_minder_reminders_contractor WHERE reminder_id = :id');
+  $linkedPersonsData = $pStmt->fetchAll(PDO::FETCH_ASSOC);
+  $linkedPersons = array_column($linkedPersonsData, 'person_id');
+  $cStmt = $pdo->prepare("SELECT rc.contractor_id, CONCAT(p.first_name,' ',p.last_name) AS name FROM admin_minder_reminders_contractors rc JOIN module_contractors mc ON rc.contractor_id = mc.id LEFT JOIN person p ON mc.person_id = p.id WHERE rc.reminder_id = :id");
   $cStmt->execute([':id'=>$id]);
-  $linkedContractors = $cStmt->fetchAll(PDO::FETCH_COLUMN);
+  $linkedContractorsData = $cStmt->fetchAll(PDO::FETCH_ASSOC);
+  $linkedContractors = array_column($linkedContractorsData, 'contractor_id');
+  $fStmt = $pdo->prepare('SELECT id, file_name, file_path FROM admin_minder_reminders_files WHERE reminder_id = :id');
+  $fStmt->execute([':id'=>$id]);
+  $files = $fStmt->fetchAll(PDO::FETCH_ASSOC);
 } else {
   require_permission('minder_reminder','create');
   $reminder = [
@@ -29,8 +34,9 @@ if ($editing) {
     'type_id' => null,
     'status_id' => null
   ];
-  $linkedPersons = [];
-  $linkedContractors = [];
+  $linkedPersonsData = $linkedPersons = [];
+  $linkedContractorsData = $linkedContractors = [];
+  $files = [];
 }
 
 $types = get_lookup_items($pdo, 'ADMIN_MINDER_REMINDER_TYPE');
@@ -81,35 +87,158 @@ $token = generate_csrf_token();
       </select>
     </div>
   </div>
-  <div class="mb-3">
-    <label class="form-label">Persons</label>
-    <select name="person_ids[]" class="form-select" multiple>
-      <?php foreach ($persons as $p): ?>
-      <option value="<?= (int)$p['id']; ?>" <?= in_array($p['id'], $linkedPersons) ? 'selected' : ''; ?>><?= e($p['name']); ?></option>
-      <?php endforeach; ?>
-    </select>
-  </div>
-  <div class="mb-3">
-    <label class="form-label">Contractors</label>
-    <select name="contractor_ids[]" class="form-select" multiple>
-      <?php foreach ($contractors as $c): ?>
-      <option value="<?= (int)$c['id']; ?>" <?= in_array($c['id'], $linkedContractors) ? 'selected' : ''; ?>><?= e($c['name']); ?></option>
-      <?php endforeach; ?>
-    </select>
-  </div>
+    <div class="mb-3">
+      <label class="form-label">Persons</label>
+      <select name="person_ids[]" id="personSelect" class="form-select" multiple>
+        <?php foreach ($persons as $p): ?>
+        <option value="<?= (int)$p['id']; ?>" <?= in_array($p['id'], $linkedPersons) ? 'selected' : ''; ?>><?= e($p['name']); ?></option>
+        <?php endforeach; ?>
+      </select>
+    </div>
+    <?php if ($editing): ?>
+    <table class="table" id="personLinks">
+      <thead><tr><th>Name</th><th>Action</th></tr></thead>
+      <tbody>
+        <?php foreach ($linkedPersonsData as $lp): ?>
+        <tr data-id="<?= (int)$lp['person_id']; ?>">
+          <td><?= e($lp['name']); ?></td>
+          <td><button type="button" class="btn btn-sm btn-danger remove-person" data-id="<?= (int)$lp['person_id']; ?>">Delete</button></td>
+        </tr>
+        <?php endforeach; ?>
+      </tbody>
+    </table>
+    <?php endif; ?>
+    <div class="mb-3">
+      <label class="form-label">Contractors</label>
+      <select name="contractor_ids[]" id="contractorSelect" class="form-select" multiple>
+        <?php foreach ($contractors as $c): ?>
+        <option value="<?= (int)$c['id']; ?>" <?= in_array($c['id'], $linkedContractors) ? 'selected' : ''; ?>><?= e($c['name']); ?></option>
+        <?php endforeach; ?>
+      </select>
+    </div>
+    <?php if ($editing): ?>
+    <table class="table" id="contractorLinks">
+      <thead><tr><th>Name</th><th>Action</th></tr></thead>
+      <tbody>
+        <?php foreach ($linkedContractorsData as $lc): ?>
+        <tr data-id="<?= (int)$lc['contractor_id']; ?>">
+          <td><?= e($lc['name']); ?></td>
+          <td><button type="button" class="btn btn-sm btn-danger remove-contractor" data-id="<?= (int)$lc['contractor_id']; ?>">Delete</button></td>
+        </tr>
+        <?php endforeach; ?>
+      </tbody>
+    </table>
+    <?php endif; ?>
   <button type="submit" class="btn btn-primary">Save</button>
 </form>
 
 <?php if ($editing): ?>
-<hr class="my-4">
-<h3 class="mb-3">Attachments</h3>
-<form method="post" enctype="multipart/form-data" action="functions/upload_file.php">
-  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
-  <input type="hidden" name="reminder_id" value="<?= $id; ?>">
-  <div class="mb-3">
-    <input type="file" name="file" class="form-control" required>
-  </div>
-  <button class="btn btn-secondary" type="submit">Upload File</button>
-</form>
-<?php endif; ?>
-<?php require __DIR__ . '/../../admin_footer.php'; ?>
+  <hr class="my-4">
+  <h3 class="mb-3">Attachments</h3>
+  <form method="post" enctype="multipart/form-data" id="fileUploadForm" action="functions/upload_file.php">
+    <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+    <input type="hidden" name="reminder_id" value="<?= $id; ?>">
+    <div class="mb-3">
+      <input type="file" name="file" class="form-control" required>
+    </div>
+    <button class="btn btn-secondary" type="submit">Upload File</button>
+  </form>
+  <table class="table mt-3" id="filesTable">
+    <thead><tr><th>File</th><th>Action</th></tr></thead>
+    <tbody>
+      <?php foreach ($files as $f): ?>
+      <tr data-id="<?= (int)$f['id']; ?>">
+        <td><a href="/<?= e($f['file_path']); ?>" target="_blank"><?= e($f['file_name']); ?></a></td>
+        <td><button type="button" class="btn btn-sm btn-danger remove-file" data-id="<?= (int)$f['id']; ?>">Delete</button></td>
+      </tr>
+      <?php endforeach; ?>
+    </tbody>
+  </table>
+  <?php endif; ?>
+  <?php require __DIR__ . '/../../admin_footer.php'; ?>
+  <script>
+  document.addEventListener('DOMContentLoaded', function() {
+    const csrf = '<?= $token; ?>';
+    const reminderId = <?= $id; ?>;
+    function post(url, data){return fetch(url,{method:'POST',body:data}).then(r=>r.json());}
+
+    const mainForm = document.querySelector('form[action^="functions/"]');
+    if(mainForm){
+      mainForm.addEventListener('submit', e => {
+        e.preventDefault();
+        const fd = new FormData(mainForm);
+        post(mainForm.getAttribute('action'), fd).then(res => {
+          if(res.success){
+            if(res.id){ window.location = 'reminder.php?id='+res.id; }
+          }
+        });
+      });
+    }
+
+    document.querySelectorAll('.remove-person').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const pid = btn.dataset.id;
+        const fd = new FormData();
+        fd.append('csrf_token', csrf);
+        fd.append('reminder_id', reminderId);
+        fd.append('person_id', pid);
+        post('functions/unlink_person.php', fd).then(res => {
+          if(res.success){
+            document.querySelector(`#personLinks tr[data-id="${pid}"]`).remove();
+            const opt = document.querySelector(`#personSelect option[value="${pid}"]`);
+            if(opt) opt.selected = false;
+          }
+        });
+      });
+    });
+
+    document.querySelectorAll('.remove-contractor').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const cid = btn.dataset.id;
+        const fd = new FormData();
+        fd.append('csrf_token', csrf);
+        fd.append('reminder_id', reminderId);
+        fd.append('contractor_id', cid);
+        post('functions/unlink_contractor.php', fd).then(res => {
+          if(res.success){
+            document.querySelector(`#contractorLinks tr[data-id="${cid}"]`).remove();
+            const opt = document.querySelector(`#contractorSelect option[value="${cid}"]`);
+            if(opt) opt.selected = false;
+          }
+        });
+      });
+    });
+
+    document.querySelectorAll('.remove-file').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const fid = btn.dataset.id;
+        const fd = new FormData();
+        fd.append('csrf_token', csrf);
+        fd.append('id', fid);
+        post('functions/delete_file.php', fd).then(res => {
+          if(res.success){
+            document.querySelector(`#filesTable tr[data-id="${fid}"]`).remove();
+          }
+        });
+      });
+    });
+
+    const fileForm = document.getElementById('fileUploadForm');
+    if(fileForm){
+      fileForm.addEventListener('submit', e => {
+        e.preventDefault();
+        const fd = new FormData(fileForm);
+        post('functions/upload_file.php', fd).then(res => {
+          if(res.success){
+            const tbody = document.querySelector('#filesTable tbody');
+            const tr = document.createElement('tr');
+            tr.dataset.id = res.file_id;
+            tr.innerHTML = `<td><a href="/${res.path}" target="_blank">${res.name}</a></td><td><button type="button" class="btn btn-sm btn-danger remove-file" data-id="${res.file_id}">Delete</button></td>`;
+            tbody.appendChild(tr);
+            fileForm.reset();
+          }
+        });
+      });
+    }
+  });
+  </script>


### PR DESCRIPTION
## Summary
- use proper includes path and pluralized link tables for reminders module
- add tabbed list & calendar views for reminders index
- show linked persons, contractors, and attachments with AJAX removal and upload support

## Testing
- `php -l admin/minder/reminders/functions/create.php`
- `php -l admin/minder/reminders/functions/delete.php`
- `php -l admin/minder/reminders/functions/link_person.php`
- `php -l admin/minder/reminders/functions/link_contractor.php`
- `php -l admin/minder/reminders/functions/update.php`
- `php -l admin/minder/reminders/functions/upload_file.php`
- `php -l admin/minder/reminders/functions/unlink_person.php`
- `php -l admin/minder/reminders/functions/unlink_contractor.php`
- `php -l admin/minder/reminders/functions/delete_file.php`
- `php -l admin/minder/reminders/index.php`
- `php -l admin/minder/reminders/reminder.php`


------
https://chatgpt.com/codex/tasks/task_e_68b28d615f848333891fcc0e46a76000