### PR TITLE
Add category support and CRUD for corporate strategies

### DIFF
--- a/admin/corporate/strategy/functions/create_strategy.php
+++ b/admin/corporate/strategy/functions/create_strategy.php
@@ -8,10 +8,28 @@ $title = trim($_POST['title'] ?? '');
 $corporateId = (int)($_POST['corporate_id'] ?? 1);
 $statusId = $_POST['status'] !== '' ? (int)$_POST['status'] : null;
 $priorityId = $_POST['priority'] !== '' ? (int)$_POST['priority'] : null;
+$categoryId = $_POST['category_id'] !== '' ? (int)$_POST['category_id'] : null;
 $description = trim($_POST['description'] ?? '');
-$targetStart = $_POST['target_start'] ?? null;
-$targetEnd = $_POST['target_end'] ?? null;
+$targetStart = $_POST['target_start'] !== '' ? $_POST['target_start'] : null;
+$targetEnd = $_POST['target_end'] !== '' ? $_POST['target_end'] : null;
 $tags = trim($_POST['tags'] ?? '');
+
+$validStatus   = array_column(get_lookup_items($pdo,'CORPORATE_STRATEGY_STATUS'),'id');
+$validPriority = array_column(get_lookup_items($pdo,'CORPORATE_STRATEGY_PRIORITY'),'id');
+$validCategory = array_column(get_lookup_items($pdo,'CORPORATE_STRATEGY_CATEGORY'),'id');
+
+if ($statusId !== null && !in_array($statusId,$validStatus, true)) {
+  echo json_encode(['success'=>false,'error'=>'Invalid status']);
+  exit;
+}
+if ($priorityId !== null && !in_array($priorityId,$validPriority, true)) {
+  echo json_encode(['success'=>false,'error'=>'Invalid priority']);
+  exit;
+}
+if ($categoryId !== null && !in_array($categoryId,$validCategory, true)) {
+  echo json_encode(['success'=>false,'error'=>'Invalid category']);
+  exit;
+}
 
 if ($title === '') {
   echo json_encode(['success' => false, 'error' => 'Title is required']);
@@ -19,7 +37,7 @@ if ($title === '') {
 }
 
 try {
-  $stmt = $pdo->prepare('INSERT INTO module_strategy (user_id,user_updated,corporate_id,title,description,status_id,priority_id,target_start,target_end) VALUES (:uid,:uid,:cid,:title,:description,:status,:priority,:tstart,:tend)');
+  $stmt = $pdo->prepare('INSERT INTO module_strategy (user_id,user_updated,corporate_id,title,description,status_id,priority_id,category_id,target_start,target_end) VALUES (:uid,:uid,:cid,:title,:description,:status,:priority,:category,:tstart,:tend)');
   $stmt->execute([
     ':uid' => $this_user_id,
     ':cid' => $corporateId,
@@ -27,6 +45,7 @@ try {
     ':description' => $description !== '' ? $description : null,
     ':status' => $statusId,
     ':priority' => $priorityId,
+    ':category' => $categoryId,
     ':tstart' => $targetStart,
     ':tend' => $targetEnd
   ]);

--- a/admin/corporate/strategy/functions/delete_strategy.php
+++ b/admin/corporate/strategy/functions/delete_strategy.php
@@ -3,4 +3,35 @@ if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
 require_permission('admin_strategy', 'delete');
 header('Content-Type: application/json');
-echo json_encode(['success' => false, 'error' => 'Not implemented']);
+
+$id = (int)($_POST['id'] ?? 0);
+if (!$id) {
+  echo json_encode(['success' => false, 'error' => 'Invalid ID']);
+  exit;
+}
+
+$stmt = $pdo->prepare('SELECT * FROM module_strategy WHERE id = :id');
+$stmt->execute([':id' => $id]);
+$existing = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$existing) {
+  echo json_encode(['success' => false, 'error' => 'Strategy not found']);
+  exit;
+}
+
+try {
+  $pdo->beginTransaction();
+  $pdo->prepare('DELETE kr FROM module_strategy_key_results kr JOIN module_strategy_objectives o ON kr.objective_id = o.id WHERE o.strategy_id = :id')->execute([':id' => $id]);
+  $pdo->prepare('DELETE FROM module_strategy_objectives WHERE strategy_id = :id')->execute([':id' => $id]);
+  $pdo->prepare('DELETE FROM module_strategy_tags WHERE strategy_id = :id')->execute([':id' => $id]);
+  $pdo->prepare('DELETE FROM module_strategy_collaborators WHERE strategy_id = :id')->execute([':id' => $id]);
+  $pdo->prepare('DELETE FROM module_strategy_notes WHERE strategy_id = :id')->execute([':id' => $id]);
+  $pdo->prepare('DELETE FROM module_strategy_files WHERE strategy_id = :id')->execute([':id' => $id]);
+  $pdo->prepare('DELETE FROM module_strategy WHERE id = :id')->execute([':id' => $id]);
+  $pdo->commit();
+  admin_audit_log($pdo, $this_user_id, 'module_strategy', $id, 'DELETE', json_encode($existing), null, 'Deleted strategy');
+  echo json_encode(['success' => true]);
+} catch (PDOException $e) {
+  $pdo->rollBack();
+  echo json_encode(['success' => false, 'error' => 'Database error']);
+}
+

--- a/admin/corporate/strategy/functions/read_strategies.php
+++ b/admin/corporate/strategy/functions/read_strategies.php
@@ -6,11 +6,21 @@ header('Content-Type: application/json');
 
 $status = trim($_GET['status'] ?? '');
 $priority = trim($_GET['priority'] ?? '');
+$category = trim($_GET['category'] ?? '');
 $tags = trim($_GET['tags'] ?? '');
 
-$sql = 'SELECT s.id, s.title, s.status_id, s.priority_id, GROUP_CONCAT(t.tag) AS tags
+$sql = 'SELECT s.id, s.title,
+               s.status_id, ls.label AS status_label, COALESCE(lsattr.attr_value, "secondary") AS status_color,
+               s.priority_id, lp.label AS priority_label, COALESCE(lpattr.attr_value, "secondary") AS priority_color,
+               s.category_id, lc.label AS category_label,
+               GROUP_CONCAT(t.tag) AS tags
         FROM module_strategy s
         LEFT JOIN module_strategy_tags t ON t.strategy_id = s.id
+        LEFT JOIN lookup_list_items ls ON s.status_id = ls.id
+        LEFT JOIN lookup_list_item_attributes lsattr ON ls.id = lsattr.item_id AND lsattr.attr_code = "COLOR-CLASS"
+        LEFT JOIN lookup_list_items lp ON s.priority_id = lp.id
+        LEFT JOIN lookup_list_item_attributes lpattr ON lp.id = lpattr.item_id AND lpattr.attr_code = "COLOR-CLASS"
+        LEFT JOIN lookup_list_items lc ON s.category_id = lc.id
         WHERE 1=1';
 $params = [];
 if ($status !== '') {
@@ -20,6 +30,10 @@ if ($status !== '') {
 if ($priority !== '') {
   $sql .= ' AND s.priority_id = :priority';
   $params[':priority'] = $priority;
+}
+if ($category !== '') {
+  $sql .= ' AND s.category_id = :category';
+  $params[':category'] = $category;
 }
 $sql .= ' GROUP BY s.id';
 if ($tags !== '') {

--- a/admin/corporate/strategy/functions/update_strategy.php
+++ b/admin/corporate/strategy/functions/update_strategy.php
@@ -3,4 +3,130 @@ if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
 require_permission('admin_strategy', 'update');
 header('Content-Type: application/json');
-echo json_encode(['success' => false, 'error' => 'Not implemented']);
+
+$id = (int)($_POST['id'] ?? 0);
+if (!$id) {
+  echo json_encode(['success' => false, 'error' => 'Invalid ID']);
+  exit;
+}
+
+$stmt = $pdo->prepare('SELECT * FROM module_strategy WHERE id = :id');
+$stmt->execute([':id' => $id]);
+$existing = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$existing) {
+  echo json_encode(['success' => false, 'error' => 'Strategy not found']);
+  exit;
+}
+
+$title       = isset($_POST['title']) ? trim($_POST['title']) : null;
+$statusId    = array_key_exists('status', $_POST)      ? ($_POST['status'] !== '' ? (int)$_POST['status'] : null) : null;
+$priorityId  = array_key_exists('priority', $_POST)    ? ($_POST['priority'] !== '' ? (int)$_POST['priority'] : null) : null;
+$categoryId  = array_key_exists('category_id', $_POST) ? ($_POST['category_id'] !== '' ? (int)$_POST['category_id'] : null) : null;
+$description = array_key_exists('description', $_POST) ? trim($_POST['description']) : null;
+$targetStart = array_key_exists('target_start', $_POST) ? ($_POST['target_start'] !== '' ? $_POST['target_start'] : null) : null;
+$targetEnd   = array_key_exists('target_end', $_POST) ? ($_POST['target_end'] !== '' ? $_POST['target_end'] : null) : null;
+$tags        = isset($_POST['tags']) ? trim($_POST['tags']) : null;
+
+$validStatus   = array_column(get_lookup_items($pdo, 'CORPORATE_STRATEGY_STATUS'), 'id');
+$validPriority = array_column(get_lookup_items($pdo, 'CORPORATE_STRATEGY_PRIORITY'), 'id');
+$validCategory = array_column(get_lookup_items($pdo, 'CORPORATE_STRATEGY_CATEGORY'), 'id');
+
+if ($statusId !== null && !in_array($statusId, $validStatus, true)) {
+  echo json_encode(['success' => false, 'error' => 'Invalid status']);
+  exit;
+}
+if ($priorityId !== null && !in_array($priorityId, $validPriority, true)) {
+  echo json_encode(['success' => false, 'error' => 'Invalid priority']);
+  exit;
+}
+if ($categoryId !== null && !in_array($categoryId, $validCategory, true)) {
+  echo json_encode(['success' => false, 'error' => 'Invalid category']);
+  exit;
+}
+
+$fields = [];
+$params = [':id' => $id, ':uid' => $this_user_id];
+$changes = [];
+
+if ($title !== null) {
+  $fields[] = 'title = :title';
+  $params[':title'] = $title;
+  $changes['title'] = $title;
+}
+if (array_key_exists('description', $_POST)) {
+  $fields[] = 'description = :description';
+  $params[':description'] = ($description !== '' ? $description : null);
+  $changes['description'] = $params[':description'];
+}
+if (array_key_exists('status', $_POST)) {
+  if ($statusId === null) {
+    $fields[] = 'status_id = NULL';
+    $changes['status_id'] = null;
+  } else {
+    $fields[] = 'status_id = :status';
+    $params[':status'] = $statusId;
+    $changes['status_id'] = $statusId;
+  }
+}
+if (array_key_exists('priority', $_POST)) {
+  if ($priorityId === null) {
+    $fields[] = 'priority_id = NULL';
+    $changes['priority_id'] = null;
+  } else {
+    $fields[] = 'priority_id = :priority';
+    $params[':priority'] = $priorityId;
+    $changes['priority_id'] = $priorityId;
+  }
+}
+if (array_key_exists('category_id', $_POST)) {
+  if ($categoryId === null) {
+    $fields[] = 'category_id = NULL';
+    $changes['category_id'] = null;
+  } else {
+    $fields[] = 'category_id = :category';
+    $params[':category'] = $categoryId;
+    $changes['category_id'] = $categoryId;
+  }
+}
+if (array_key_exists('target_start', $_POST)) {
+  if ($targetStart === null) {
+    $fields[] = 'target_start = NULL';
+    $changes['target_start'] = null;
+  } else {
+    $fields[] = 'target_start = :tstart';
+    $params[':tstart'] = $targetStart;
+    $changes['target_start'] = $targetStart;
+  }
+}
+if (array_key_exists('target_end', $_POST)) {
+  if ($targetEnd === null) {
+    $fields[] = 'target_end = NULL';
+    $changes['target_end'] = null;
+  } else {
+    $fields[] = 'target_end = :tend';
+    $params[':tend'] = $targetEnd;
+    $changes['target_end'] = $targetEnd;
+  }
+}
+
+if ($fields) {
+  $sql = 'UPDATE module_strategy SET ' . implode(',', $fields) . ', user_updated = :uid WHERE id = :id';
+  $upd = $pdo->prepare($sql);
+  $upd->execute($params);
+}
+
+if ($tags !== null) {
+  $pdo->prepare('DELETE FROM module_strategy_tags WHERE strategy_id = :id')->execute([':id' => $id]);
+  if ($tags !== '') {
+    $ins = $pdo->prepare('INSERT INTO module_strategy_tags (user_id,user_updated,strategy_id,tag) VALUES (:uid,:uid,:sid,:tag)');
+    foreach (array_filter(array_map('trim', explode(',', $tags))) as $tag) {
+      if ($tag === '') continue;
+      $ins->execute([':uid' => $this_user_id, ':sid' => $id, ':tag' => $tag]);
+    }
+  }
+}
+
+admin_audit_log($pdo, $this_user_id, 'module_strategy', $id, 'UPDATE', json_encode($existing), json_encode($changes), 'Updated strategy');
+
+echo json_encode(['success' => true]);
+


### PR DESCRIPTION
## Summary
- load strategy status, priority, and category lookups and render filter & modal options
- include category and date fields when creating and updating strategies with validation
- provide update and delete endpoints for strategies and enrich list API with lookup names and colors

## Testing
- `php -l admin/corporate/strategy/index.php`
- `php -l admin/corporate/strategy/functions/create_strategy.php`
- `php -l admin/corporate/strategy/functions/update_strategy.php`
- `php -l admin/corporate/strategy/functions/delete_strategy.php`
- `php -l admin/corporate/strategy/functions/read_strategies.php`


------
https://chatgpt.com/codex/tasks/task_e_68b2ac1a7e08833391a5cb7d8850d2b1