### PR TITLE
Add Tasks card to Minder page

### DIFF
--- a/admin/minder/index.php
+++ b/admin/minder/index.php
@@ -22,5 +22,14 @@ require_permission('minder_module','read');
       </div>
     </div>
   </div>
+  <div class="col-md-6 col-lg-4">
+    <div class="card shadow-sm h-100">
+      <div class="card-body d-flex flex-column">
+        <h5 class="card-title">Tasks</h5>
+        <p class="card-text">Manage tasks.</p>
+        <a href="tasks/index.php" class="btn btn-primary mt-auto">Open</a>
+      </div>
+    </div>
+  </div>
 </div>
 <?php require '../admin_footer.php'; ?>


### PR DESCRIPTION
## Summary
- add Tasks card to Minder module index with link to tasks/index.php

## Testing
- `php -l admin/minder/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68b2aea98dec8333966e9b9214bc1f90