### PR TITLE
Adjust minder task permission keys and file paths

### DIFF
--- a/admin/minder/tasks/functions/add_assignment.php
+++ b/admin/minder/tasks/functions/add_assignment.php
@@ -1,7 +1,7 @@
 <?php
 if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
-require_permission('admin_task', 'create');
+require_permission('minder_task', 'create');
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
   http_response_code(405);
@@ -25,6 +25,6 @@ $pdo->prepare('INSERT INTO admin_task_assignments (task_id, assigned_user_id, us
       ':uid' => $this_user_id
     ]);
 
-admin_audit_log($pdo, $this_user_id, 'admin_task_assignments', $task_id, 'CREATE', null, json_encode(['assigned_user_id'=>$assigned_user_id]), 'Added assignment');
+admin_audit_log($pdo, $this_user_id, 'minder_task_assignments', $task_id, 'CREATE', null, json_encode(['assigned_user_id'=>$assigned_user_id]), 'Added assignment');
 
 header('Location: ../task.php?id=' . $task_id);

--- a/admin/minder/tasks/functions/add_comment.php
+++ b/admin/minder/tasks/functions/add_comment.php
@@ -1,7 +1,7 @@
 <?php
 if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
-require_permission('admin_task', 'create');
+require_permission('minder_task', 'create');
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
   http_response_code(405);
@@ -22,6 +22,6 @@ $pdo->prepare('INSERT INTO admin_task_comments (task_id, user_id, comment, user_
     ->execute([':task' => $task_id, ':uid' => $this_user_id, ':comment' => $comment]);
 $cid = (int)$pdo->lastInsertId();
 
-admin_audit_log($pdo, $this_user_id, 'admin_task_comments', $cid, 'CREATE', null, json_encode(['comment'=>$comment]), 'Added comment');
+admin_audit_log($pdo, $this_user_id, 'minder_task_comments', $cid, 'CREATE', null, json_encode(['comment'=>$comment]), 'Added comment');
 
 header('Location: ../task.php?id=' . $task_id);

--- a/admin/minder/tasks/functions/create.php
+++ b/admin/minder/tasks/functions/create.php
@@ -1,7 +1,7 @@
 <?php
 if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
-require_permission('admin_task', 'create');
+require_permission('minder_task', 'create');
 
 $isAjax = ($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '') === 'XMLHttpRequest'
     || str_contains($_SERVER['HTTP_ACCEPT'] ?? '', 'application/json');
@@ -92,7 +92,7 @@ try {
   exit;
 }
 
-admin_audit_log($pdo, $this_user_id, 'admin_task', $taskId, 'CREATE', null, json_encode(['name'=>$name]), 'Created task');
+admin_audit_log($pdo, $this_user_id, 'minder_task', $taskId, 'CREATE', null, json_encode(['name'=>$name]), 'Created task');
 
 if ($isAjax) {
   header('Content-Type: application/json');

--- a/admin/minder/tasks/functions/delete.php
+++ b/admin/minder/tasks/functions/delete.php
@@ -1,7 +1,7 @@
 <?php
 if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
-require_permission('admin_task', 'delete');
+require_permission('minder_task', 'delete');
 
 $method = $_SERVER['REQUEST_METHOD'];
 if ($method !== 'POST' && $method !== 'GET') {
@@ -27,6 +27,6 @@ $pdo->prepare('DELETE FROM admin_task_assignments WHERE task_id = :id')->execute
 $pdo->prepare('DELETE FROM admin_task_comments WHERE task_id = :id')->execute([':id' => $id]);
 $pdo->prepare('DELETE FROM admin_task_files WHERE task_id = :id')->execute([':id' => $id]);
 
-admin_audit_log($pdo, $this_user_id, 'admin_task', $id, 'DELETE', json_encode($old), null, 'Deleted task');
+admin_audit_log($pdo, $this_user_id, 'minder_task', $id, 'DELETE', json_encode($old), null, 'Deleted task');
 
 header('Location: ../index.php');

--- a/admin/minder/tasks/functions/delete_comment.php
+++ b/admin/minder/tasks/functions/delete_comment.php
@@ -1,7 +1,7 @@
 <?php
 if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
-require_permission('admin_task', 'delete');
+require_permission('minder_task', 'delete');
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
   http_response_code(405);
@@ -20,7 +20,7 @@ $stmt->execute([':id' => $id]);
 $comment = $stmt->fetch(PDO::FETCH_ASSOC);
 if ($comment) {
   $pdo->prepare('DELETE FROM admin_task_comments WHERE id = :id')->execute([':id' => $id]);
-  admin_audit_log($pdo, $this_user_id, 'admin_task_comments', $id, 'DELETE', json_encode($comment), null, 'Deleted comment');
+  admin_audit_log($pdo, $this_user_id, 'minder_task_comments', $id, 'DELETE', json_encode($comment), null, 'Deleted comment');
   header('Location: ../task.php?id=' . $comment['task_id']);
 } else {
   header('Location: ../index.php');

--- a/admin/minder/tasks/functions/delete_file.php
+++ b/admin/minder/tasks/functions/delete_file.php
@@ -1,7 +1,7 @@
 <?php
 if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
-require_permission('admin_task', 'delete');
+require_permission('minder_task', 'delete');
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
   http_response_code(405);
@@ -25,7 +25,7 @@ if ($file) {
   if ($fullPath && file_exists($fullPath)) {
     unlink($fullPath);
   }
-  admin_audit_log($pdo, $this_user_id, 'admin_task_files', $id, 'DELETE', json_encode($file), null, 'Deleted file');
+  admin_audit_log($pdo, $this_user_id, 'minder_task_files', $id, 'DELETE', json_encode($file), null, 'Deleted file');
   header('Location: ../task.php?id=' . $file['task_id']);
 } else {
   header('Location: ../index.php');

--- a/admin/minder/tasks/functions/quick_add.php
+++ b/admin/minder/tasks/functions/quick_add.php
@@ -1,7 +1,7 @@
 <?php
 if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
-require_permission('admin_task', 'create');
+require_permission('minder_task', 'create');
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
   http_response_code(405);
@@ -35,6 +35,6 @@ $pdo->prepare('INSERT INTO admin_task_assignments (task_id, assigned_user_id, us
       ':uid' => $this_user_id
     ]);
 
-admin_audit_log($pdo, $this_user_id, 'admin_task', $taskId, 'CREATE', null, json_encode(['name'=>$name]), 'Quick add');
+admin_audit_log($pdo, $this_user_id, 'minder_task', $taskId, 'CREATE', null, json_encode(['name'=>$name]), 'Quick add');
 
 header('Location: ../index.php');

--- a/admin/minder/tasks/functions/remove_assignment.php
+++ b/admin/minder/tasks/functions/remove_assignment.php
@@ -1,7 +1,7 @@
 <?php
 if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
-require_permission('admin_task', 'delete');
+require_permission('minder_task', 'delete');
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
   http_response_code(405);
@@ -24,6 +24,6 @@ $pdo->prepare('DELETE FROM admin_task_assignments WHERE task_id = :task_id AND a
       ':assigned_user_id' => $assigned_user_id
     ]);
 
-admin_audit_log($pdo, $this_user_id, 'admin_task_assignments', $task_id, 'DELETE', json_encode(['assigned_user_id'=>$assigned_user_id]), null, 'Removed assignment');
+admin_audit_log($pdo, $this_user_id, 'minder_task_assignments', $task_id, 'DELETE', json_encode(['assigned_user_id'=>$assigned_user_id]), null, 'Removed assignment');
 
 header('Location: ../task.php?id=' . $task_id);

--- a/admin/minder/tasks/functions/update.php
+++ b/admin/minder/tasks/functions/update.php
@@ -1,7 +1,7 @@
 <?php
 if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
-require_permission('admin_task', 'update');
+require_permission('minder_task', 'update');
 
 $isAjax = ($_SERVER['HTTP_X_REQUESTED_WITH'] ?? '') === 'XMLHttpRequest'
     || str_contains($_SERVER['HTTP_ACCEPT'] ?? '', 'application/json');
@@ -96,7 +96,7 @@ foreach ($assigned_user_ids as $assigned_user_id) {
       ]);
 }
 
-admin_audit_log($pdo, $this_user_id, 'admin_task', $id, 'UPDATE', json_encode($old), json_encode(['name'=>$name]), 'Updated task');
+admin_audit_log($pdo, $this_user_id, 'minder_task', $id, 'UPDATE', json_encode($old), json_encode(['name'=>$name]), 'Updated task');
 
 if ($isAjax) {
   header('Content-Type: application/json');

--- a/admin/minder/tasks/functions/upload_file.php
+++ b/admin/minder/tasks/functions/upload_file.php
@@ -1,7 +1,7 @@
 <?php
 if (session_status() !== PHP_SESSION_ACTIVE) session_start();
 require_once __DIR__ . '/../../../../includes/php_header.php';
-require_permission('admin_task', 'create');
+require_permission('minder_task', 'create');
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
   http_response_code(405);
@@ -39,7 +39,7 @@ if (!move_uploaded_file($file['tmp_name'], $dest)) {
   die('Failed to save file');
 }
 
-$relPath = 'admin/tasks/uploads/' . $filename;
+$relPath = 'admin/minder/tasks/uploads/' . $filename;
 $pdo->prepare('INSERT INTO admin_task_files (task_id, file_name, file_path, file_size, file_type, user_id, user_updated) VALUES (:task,:name,:path,:size,:type,:uid,:uid)')
     ->execute([
       ':task' => $task_id,
@@ -51,6 +51,6 @@ $pdo->prepare('INSERT INTO admin_task_files (task_id, file_name, file_path, file
     ]);
 $fileId = (int)$pdo->lastInsertId();
 
-admin_audit_log($pdo, $this_user_id, 'admin_task_files', $fileId, 'CREATE', null, json_encode(['file'=>$file['name']]), 'Uploaded file');
+admin_audit_log($pdo, $this_user_id, 'minder_task_files', $fileId, 'CREATE', null, json_encode(['file'=>$file['name']]), 'Uploaded file');
 
 header('Location: ../task.php?id=' . $task_id);

--- a/admin/minder/tasks/index.php
+++ b/admin/minder/tasks/index.php
@@ -1,6 +1,6 @@
 <?php
-require '../admin_header.php';
-require_permission('admin_task','read');
+require '../../admin_header.php';
+require_permission('minder_task','read');
 
 $token = generate_csrf_token();
 
@@ -33,7 +33,7 @@ $users = $userStmt->fetchAll(PDO::FETCH_ASSOC);
 <?= flash_message($_SESSION['error_message'] ?? '', 'danger'); ?>
 <?php unset($_SESSION['message'], $_SESSION['error_message']); ?>
 <div class="mb-3 d-flex gap-2">
-  <?php if (user_has_permission('admin_task','create')): ?>
+  <?php if (user_has_permission('minder_task','create')): ?>
   <button class="btn btn-sm btn-success" id="addTaskBtn">Add Task</button>
   <form class="d-flex gap-2" method="post" action="functions/quick_add.php">
     <input type="hidden" name="csrf_token" value="<?= $token; ?>">
@@ -73,10 +73,10 @@ $users = $userStmt->fetchAll(PDO::FETCH_ASSOC);
           <td class="status"><?= e($t['status_label']); ?></td>
           <td class="priority"><?= e($t['priority_label']); ?></td>
           <td>
-            <?php if (user_has_permission('admin_task', 'update')): ?>
+            <?php if (user_has_permission('minder_task', 'update')): ?>
             <a class="btn btn-sm btn-warning" href="task.php?id=<?= $t['id']; ?>">Edit</a>
             <?php endif; ?>
-            <?php if (user_has_permission('admin_task','delete')): ?>
+            <?php if (user_has_permission('minder_task','delete')): ?>
             <form method="post" action="functions/delete.php" class="d-inline" onsubmit="return confirm('Delete this task?');">
               <input type="hidden" name="id" value="<?= $t['id']; ?>">
               <input type="hidden" name="csrf_token" value="<?= $token; ?>">
@@ -203,7 +203,7 @@ document.addEventListener('DOMContentLoaded', function () {
   const taskModalLabel = document.getElementById('taskModalLabel');
   const tasksTableBody = document.querySelector('#tasks tbody.list');
   const addTaskBtn = document.getElementById('addTaskBtn');
-  const canDelete = <?= user_has_permission('admin_task','delete') ? 'true' : 'false'; ?>;
+  const canDelete = <?= user_has_permission('minder_task','delete') ? 'true' : 'false'; ?>;
   const jsonHeaders = {
     'X-Requested-With': 'XMLHttpRequest',
     'Accept': 'application/json'
@@ -273,4 +273,4 @@ document.addEventListener('DOMContentLoaded', function () {
   });
 });
 </script>
-<?php require '../admin_footer.php'; ?>
+<?php require '../../admin_footer.php'; ?>

--- a/admin/minder/tasks/task.php
+++ b/admin/minder/tasks/task.php
@@ -1,11 +1,11 @@
 <?php
-require_once __DIR__ . '/../admin_header.php';
+require '../../admin_header.php';
 
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 $editing = $id > 0;
 
 if ($editing) {
-  require_permission('admin_task','update');
+  require_permission('minder_task','update');
   $stmt = $pdo->prepare('SELECT * FROM admin_task WHERE id = :id');
   $stmt->execute([':id' => $id]);
   $task = $stmt->fetch(PDO::FETCH_ASSOC);
@@ -14,7 +14,7 @@ if ($editing) {
     exit;
   }
 } else {
-  require_permission('admin_task','create');
+  require_permission('minder_task','create');
   $task = [
     'name' => '',
     'description' => '',
@@ -139,10 +139,10 @@ $token = generate_csrf_token();
   <div class="mb-3">
     <button class="btn btn-sm btn-primary" type="submit">Save</button>
       <?php if ($editing): ?>
-      <?php if (user_has_permission('admin_task','delete')): ?>
+      <?php if (user_has_permission('minder_task','delete')): ?>
       <a href="functions/delete.php?id=<?= $id; ?>&csrf_token=<?= $token; ?>" class="btn btn-sm btn-danger" onclick="return confirm('Delete this task?');">Delete</a>
       <?php endif; ?>
       <?php endif; ?>
   </div>
 </form>
-<?php require_once __DIR__ . '/../admin_footer.php'; ?>
+<?php require '../../admin_footer.php'; ?>


### PR DESCRIPTION
## Summary
- load admin header/footer from project root on minder task pages
- switch task permission checks from `admin_task` to `minder_task` and update audit logs
- store uploaded task files in `admin/minder/tasks/uploads/`

## Testing
- `php -l admin/minder/tasks/index.php`
- `php -l admin/minder/tasks/task.php`
- `for f in admin/minder/tasks/functions/*.php; do php -l "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_68b2aea88b048333b4318486981dd36e