### PR TITLE
Enable AJAX filtering and file previews for agencies

### DIFF
--- a/module/agency/assets/index.js
+++ b/module/agency/assets/index.js
@@ -1,0 +1,46 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('agency-filter-form');
+  const results = document.getElementById('agency-results');
+  if (!form || !results) return;
+
+  function attachNavHandlers() {
+    results.querySelectorAll('nav a').forEach(a => {
+      a.addEventListener('click', e => {
+        e.preventDefault();
+        const url = new URL(a.href);
+        const action = url.searchParams.get('action') || 'card';
+        const actionField = form.querySelector('input[name="action"]');
+        if (actionField) actionField.value = action;
+        submitForm();
+      });
+    });
+  }
+
+  function submitForm() {
+    const params = new URLSearchParams(new FormData(form));
+    const qs = params.toString();
+    fetch('index.php?ajax=1&' + qs, {
+      headers: { 'X-Requested-With': 'XMLHttpRequest' }
+    })
+      .then(r => r.text())
+      .then(html => {
+        results.innerHTML = html;
+        attachNavHandlers();
+        if (typeof refreshFsLightbox === 'function') {
+          refreshFsLightbox();
+        }
+        history.replaceState(null, '', 'index.php?' + qs);
+      })
+      .catch(err => console.error('Agency AJAX error:', err));
+  }
+
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    submitForm();
+  });
+
+  form.addEventListener('change', () => submitForm());
+
+  attachNavHandlers();
+});
+

--- a/module/agency/include/board_view.php
+++ b/module/agency/include/board_view.php
@@ -17,17 +17,29 @@ foreach ($agencies as $agency) {
           <?php foreach (($data['items'] ?? []) as $agency): ?>
             <div class="card mb-2">
               <div class="card-body p-2">
-                <?php if (!empty($agency['file_name']) && strpos($agency['file_type'], 'image/') === 0): ?>
-                  <a href="uploads/agency/<?= e($agency['file_path']); ?>" data-fslightbox="agency" class="me-1">
-                    <img src="uploads/agency/<?= e($agency['file_path']); ?>" alt="<?= e($agency['file_name']); ?>" class="rounded" style="height:24px; width:24px; object-fit:cover;">
+                <?php if (!empty($agency['file_name'])): ?>
+                  <?php
+                    $fileUrl = 'uploads/agency/' . $agency['file_path'];
+                    $mime = $agency['file_type'] ?? '';
+                    $previewable = preg_match('/^(image|video|audio|text)\//', $mime) || $mime === 'application/pdf';
+                    $isImage = strpos($mime, 'image/') === 0;
+                  ?>
+                  <?php if ($previewable): ?>
+                    <a href="<?= h($fileUrl); ?>" data-fslightbox="agency"<?= $isImage ? '' : ' data-type="iframe"' ?> class="me-1">
+                      <?php if ($isImage): ?>
+                        <img src="<?= h($fileUrl); ?>" alt="<?= e($agency['file_name']); ?>" class="rounded" style="height:24px; width:24px; object-fit:cover;">
+                      <?php else: ?>
+                        <i class="fa-regular fa-file"></i>
+                      <?php endif; ?>
+                    </a>
+                  <?php else: ?>
+                    <a href="<?= h($fileUrl); ?>" target="_blank" rel="noopener" class="me-1"><i class="fa-regular fa-file"></i></a>
+                  <?php endif; ?>
+                  <a href="download.php?type=agency&id=<?= $agency['id']; ?>" class="ms-1 text-body" title="Download">
+                    <i class="fa-solid fa-download"></i>
                   </a>
                 <?php endif; ?>
                 <?= e($agency['name']); ?>
-                <?php if (!empty($agency['file_name'])): ?>
-                  <a href="download.php?type=agency&id=<?= $agency['id']; ?>" class="ms-1 text-body">
-                    <i class="fa-regular fa-paperclip"></i>
-                  </a>
-                <?php endif; ?>
                 <?php if (!empty($agency['organization_name'])): ?>
                   <span class="badge bg-info-subtle text-info ms-1"><?= h($agency['organization_name']); ?></span>
                 <?php endif; ?>

--- a/module/agency/include/card_view.php
+++ b/module/agency/include/card_view.php
@@ -8,17 +8,29 @@
         <div class="card h-100">
           <div class="card-body">
             <h5 class="card-title mb-1">
-              <?php if (!empty($agency['file_name']) && strpos($agency['file_type'], 'image/') === 0): ?>
-                <a href="uploads/agency/<?= e($agency['file_path']); ?>" data-fslightbox="agency" class="me-1">
-                  <img src="uploads/agency/<?= e($agency['file_path']); ?>" alt="<?= e($agency['file_name']); ?>" class="rounded" style="height:32px; width:32px; object-fit:cover;">
+              <?php if (!empty($agency['file_name'])): ?>
+                <?php
+                  $fileUrl = 'uploads/agency/' . $agency['file_path'];
+                  $mime = $agency['file_type'] ?? '';
+                  $previewable = preg_match('/^(image|video|audio|text)\//', $mime) || $mime === 'application/pdf';
+                  $isImage = strpos($mime, 'image/') === 0;
+                ?>
+                <?php if ($previewable): ?>
+                  <a href="<?= h($fileUrl); ?>" data-fslightbox="agency"<?= $isImage ? '' : ' data-type="iframe"' ?> class="me-1">
+                    <?php if ($isImage): ?>
+                      <img src="<?= h($fileUrl); ?>" alt="<?= e($agency['file_name']); ?>" class="rounded" style="height:32px; width:32px; object-fit:cover;">
+                    <?php else: ?>
+                      <i class="fa-regular fa-file"></i>
+                    <?php endif; ?>
+                  </a>
+                <?php else: ?>
+                  <a href="<?= h($fileUrl); ?>" target="_blank" rel="noopener" class="me-1"><i class="fa-regular fa-file"></i></a>
+                <?php endif; ?>
+                <a href="download.php?type=agency&id=<?= $agency['id']; ?>" class="ms-1 text-body" title="Download">
+                  <i class="fa-solid fa-download"></i>
                 </a>
               <?php endif; ?>
               <?= e($agency['name']); ?>
-              <?php if (!empty($agency['file_name'])): ?>
-                <a href="download.php?type=agency&id=<?= $agency['id']; ?>" class="ms-1 text-body">
-                  <i class="fa-regular fa-paperclip"></i>
-                </a>
-              <?php endif; ?>
               <?php if (!empty($agency['organization_name'])): ?>
                 <span class="badge bg-info-subtle text-info ms-1"><?= h($agency['organization_name']); ?></span>
               <?php endif; ?>

--- a/module/agency/include/list_view.php
+++ b/module/agency/include/list_view.php
@@ -15,17 +15,29 @@
           <?php foreach ($agencies as $agency): ?>
             <tr>
               <td class="align-middle name">
-                <?php if (!empty($agency['file_name']) && strpos($agency['file_type'], 'image/') === 0): ?>
-                  <a href="uploads/agency/<?= e($agency['file_path']); ?>" data-fslightbox="agency" class="me-1">
-                    <img src="uploads/agency/<?= e($agency['file_path']); ?>" alt="<?= e($agency['file_name']); ?>" class="rounded" style="height:24px; width:24px; object-fit:cover;">
+                <?php if (!empty($agency['file_name'])): ?>
+                  <?php
+                    $fileUrl = 'uploads/agency/' . $agency['file_path'];
+                    $mime = $agency['file_type'] ?? '';
+                    $previewable = preg_match('/^(image|video|audio|text)\//', $mime) || $mime === 'application/pdf';
+                    $isImage = strpos($mime, 'image/') === 0;
+                  ?>
+                  <?php if ($previewable): ?>
+                    <a href="<?= h($fileUrl); ?>" data-fslightbox="agency"<?= $isImage ? '' : ' data-type="iframe"' ?> class="me-1">
+                      <?php if ($isImage): ?>
+                        <img src="<?= h($fileUrl); ?>" alt="<?= e($agency['file_name']); ?>" class="rounded" style="height:24px; width:24px; object-fit:cover;">
+                      <?php else: ?>
+                        <i class="fa-regular fa-file"></i>
+                      <?php endif; ?>
+                    </a>
+                  <?php else: ?>
+                    <a href="<?= h($fileUrl); ?>" target="_blank" rel="noopener" class="me-1"><i class="fa-regular fa-file"></i></a>
+                  <?php endif; ?>
+                  <a href="download.php?type=agency&id=<?= $agency['id']; ?>" class="ms-1 text-body" title="Download">
+                    <i class="fa-solid fa-download"></i>
                   </a>
                 <?php endif; ?>
                 <?= e($agency['name']); ?>
-                <?php if (!empty($agency['file_name'])): ?>
-                  <a href="download.php?type=agency&id=<?= $agency['id']; ?>" class="ms-1 text-body">
-                    <i class="fa-regular fa-paperclip"></i>
-                  </a>
-                <?php endif; ?>
                 <?php if (!empty($agency['organization_name'])): ?>
                   <span class="badge bg-info-subtle text-info ms-1"><?= h($agency['organization_name']); ?></span>
                 <?php endif; ?>

--- a/module/agency/index.php
+++ b/module/agency/index.php
@@ -60,6 +60,29 @@ $stmt = $pdo->prepare($sql);
 $stmt->execute($params);
 $agencies = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
+// Buffer the view content (tabs + view)
+ob_start();
+?>
+<nav class="nav nav-pills mb-3">
+  <a class="nav-link <?= $action === 'card' ? 'active' : ''; ?>" href="?<?= http_build_query(array_merge(['action' => 'card'], $queryFilters)); ?>">Card view</a>
+  <a class="nav-link <?= $action === 'list' ? 'active' : ''; ?>" href="?<?= http_build_query(array_merge(['action' => 'list'], $queryFilters)); ?>">List view</a>
+  <a class="nav-link <?= $action === 'board' ? 'active' : ''; ?>" href="?<?= http_build_query(array_merge(['action' => 'board'], $queryFilters)); ?>">Board view</a>
+</nav>
+<?php
+if ($action === 'list') {
+  require 'include/list_view.php';
+} elseif ($action === 'board') {
+  require 'include/board_view.php';
+} else {
+  require 'include/card_view.php';
+}
+$viewHtml = ob_get_clean();
+
+if (isset($_GET['ajax'])) {
+  echo $viewHtml;
+  exit;
+}
+
 require '../../includes/html_header.php';
 ?>
 <main class="main" id="top">
@@ -68,7 +91,7 @@ require '../../includes/html_header.php';
   <div id="main_content" class="content">
     <div class="card mb-3">
       <div class="card-body">
-        <form method="get" class="row g-2">
+        <form method="get" class="row g-2" id="agency-filter-form">
           <input type="hidden" name="action" value="<?= h($action); ?>">
           <div class="col-sm-3">
             <input class="form-control" type="text" name="name" placeholder="Search name" value="<?= h($filters['name']); ?>">
@@ -103,21 +126,12 @@ require '../../includes/html_header.php';
         </form>
       </div>
     </div>
-    <nav class="nav nav-pills mb-3">
-      <a class="nav-link <?= $action === 'card' ? 'active' : ''; ?>" href="?<?= http_build_query(array_merge(['action' => 'card'], $queryFilters)); ?>">Card view</a>
-      <a class="nav-link <?= $action === 'list' ? 'active' : ''; ?>" href="?<?= http_build_query(array_merge(['action' => 'list'], $queryFilters)); ?>">List view</a>
-      <a class="nav-link <?= $action === 'board' ? 'active' : ''; ?>" href="?<?= http_build_query(array_merge(['action' => 'board'], $queryFilters)); ?>">Board view</a>
-    </nav>
-    <?php
-      if ($action === 'list') {
-        require 'include/list_view.php';
-      } elseif ($action === 'board') {
-        require 'include/board_view.php';
-      } else {
-        require 'include/card_view.php';
-      }
-    ?>
+    <div id="agency-results">
+      <?= $viewHtml ?>
+    </div>
     <?php require '../../includes/html_footer.php'; ?>
   </div>
 </main>
+<script src="<?= getURLDir(); ?>module/agency/assets/index.js"></script>
 <?php $loadFsLightbox = true; require '../../includes/js_footer.php'; ?>
+


### PR DESCRIPTION
## Summary
- Load agency card/list/board views via AJAX so filters and tab changes update without full reload
- Detect file MIME types for agency attachments and preview supported formats in a lightbox or new tab with download fallback
- Reinitialize fslightbox after dynamic content swaps

## Testing
- `php -l module/agency/index.php`
- `php -l module/agency/include/card_view.php`
- `php -l module/agency/include/list_view.php`
- `php -l module/agency/include/board_view.php`
- `node --check module/agency/assets/index.js`

------
https://chatgpt.com/codex/tasks/task_e_68b2af1db51883339e4a8a14abe78787