### PR TITLE
Hide attendee names in meeting form

### DIFF
--- a/admin/meetings/include/create_edit_view.php
+++ b/admin/meetings/include/create_edit_view.php
@@ -123,7 +123,7 @@ $token = generate_csrf_token();
     <div class="mb-3">
       <label for="attendeeSelect" class="form-label">Attendees</label>
       <select id="attendeeSelect" class="form-select" placeholder="Search user" multiple></select>
-      <div id="attendeeHiddenInputs"></div>
+      <div id="attendeeHiddenInputs" class="d-none"></div>
     </div>
     <div class="mb-3">
       <label class="form-label">Upload Files</label>
@@ -280,7 +280,7 @@ document.addEventListener('DOMContentLoaded', function(){
     attendeeHiddenInputs.innerHTML = '';
     attendeeChoices.getValue().forEach(function(choice){
       var wrapper = document.createElement('div');
-      wrapper.textContent = choice.label;
+      wrapper.className = 'd-none';
       var input = document.createElement('input');
       input.type = 'hidden';
       input.name = 'attendee_person_id[]';


### PR DESCRIPTION
## Summary
- Hide attendee hidden inputs container to prevent visible names under the select
- Suppress attendee labels in syncHiddenAttendees by applying `d-none` class

## Testing
- `php -l admin/meetings/include/create_edit_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68b2af44d2808333a81267a48a2d71a7