### PR TITLE
Add security headers to PHP header

### DIFF
--- a/includes/php_header.php
+++ b/includes/php_header.php
@@ -5,6 +5,12 @@ ini_set('display_errors', $devMode ? '1' : '0');
 ini_set('log_errors', '1');
 ini_set('error_log', __DIR__ . '/../logs/php-error.txt');
 ob_start();
+if (!headers_sent()) {
+  header('X-Frame-Options: DENY');
+  header('X-Content-Type-Options: nosniff');
+  header('Referrer-Policy: same-origin');
+  header("Content-Security-Policy: frame-ancestors 'none';");
+}
 if (session_status() !== PHP_SESSION_ACTIVE) {
   session_set_cookie_params([
     'lifetime' => 0,


### PR DESCRIPTION
## Summary
- add security headers (X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Content-Security-Policy) guarded by `if (!headers_sent())` in `includes/php_header.php`

## Testing
- `php -l includes/php_header.php`
- `composer test` *(fails: Command "test" is not defined.)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b23b28e0833393b81cb50b0b258e