### PR TITLE
Log calendar list errors and return generic message

### DIFF
--- a/functions/list.php
+++ b/functions/list.php
@@ -36,5 +36,6 @@ try {
   if (ob_get_length()) {
     ob_clean();
   }
-  echo json_encode(['error' => $e->getMessage()]);
+  error_log($e->getMessage());
+  echo json_encode(['error' => 'Internal error']);
 }


### PR DESCRIPTION
## Summary
- Log exception messages in calendar list function
- Hide internal error details from API responses

## Testing
- `php -l functions/list.php`

------
https://chatgpt.com/codex/tasks/task_e_68b2b22e04308333b892b73e0b665a72