### PR TITLE
Add modals and AJAX actions for strategy tabs

### DIFF
--- a/admin/corporate/strategy/includes/collaborator_modal.php
+++ b/admin/corporate/strategy/includes/collaborator_modal.php
@@ -1,0 +1,26 @@
+<div class="modal fade" id="addCollaboratorModal" tabindex="-1" aria-labelledby="addCollaboratorLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <form id="addCollaboratorForm" class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="addCollaboratorLabel">Add Collaborator</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3">
+          <label for="collaboratorPerson" class="form-label">Person ID</label>
+          <input type="number" class="form-control" id="collaboratorPerson" name="person_id" required>
+        </div>
+        <div class="mb-3">
+          <label for="collaboratorRole" class="form-label">Role ID</label>
+          <input type="number" class="form-control" id="collaboratorRole" name="role_id">
+        </div>
+        <input type="hidden" name="strategy_id" class="strategy-id-input">
+        <?= csrf_field(); ?>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="submit" class="btn btn-primary">Save</button>
+      </div>
+    </form>
+  </div>
+</div>

--- a/admin/corporate/strategy/includes/file_modal.php
+++ b/admin/corporate/strategy/includes/file_modal.php
@@ -1,0 +1,22 @@
+<div class="modal fade" id="addFileModal" tabindex="-1" aria-labelledby="addFileLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <form id="uploadFileForm" class="modal-content" enctype="multipart/form-data">
+      <div class="modal-header">
+        <h5 class="modal-title" id="addFileLabel">Upload File</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3">
+          <label for="fileInput" class="form-label">File</label>
+          <input type="file" class="form-control" id="fileInput" name="file" required>
+        </div>
+        <input type="hidden" name="strategy_id" class="strategy-id-input">
+        <?= csrf_field(); ?>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="submit" class="btn btn-primary">Upload</button>
+      </div>
+    </form>
+  </div>
+</div>

--- a/admin/corporate/strategy/includes/kpi_modal.php
+++ b/admin/corporate/strategy/includes/kpi_modal.php
@@ -1,0 +1,22 @@
+<div class="modal fade" id="addKpiModal" tabindex="-1" aria-labelledby="addKpiLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <form id="addKpiForm" class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="addKpiLabel">Add KPI</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3">
+          <label for="kpiTitle" class="form-label">Title</label>
+          <input type="text" class="form-control" id="kpiTitle" name="title" required>
+        </div>
+        <input type="hidden" name="strategy_id" class="strategy-id-input">
+        <?= csrf_field(); ?>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="submit" class="btn btn-primary">Save</button>
+      </div>
+    </form>
+  </div>
+</div>

--- a/admin/corporate/strategy/includes/note_modal.php
+++ b/admin/corporate/strategy/includes/note_modal.php
@@ -1,0 +1,22 @@
+<div class="modal fade" id="addNoteModal" tabindex="-1" aria-labelledby="addNoteLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <form id="addNoteForm" class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="addNoteLabel">Add Note</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3">
+          <label for="noteText" class="form-label">Note</label>
+          <textarea class="form-control" id="noteText" name="note" required></textarea>
+        </div>
+        <input type="hidden" name="strategy_id" class="strategy-id-input">
+        <?= csrf_field(); ?>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="submit" class="btn btn-primary">Save</button>
+      </div>
+    </form>
+  </div>
+</div>

--- a/admin/corporate/strategy/includes/objective_modal.php
+++ b/admin/corporate/strategy/includes/objective_modal.php
@@ -1,0 +1,28 @@
+<div class="modal fade" id="addObjectiveModal" tabindex="-1" aria-labelledby="addObjectiveLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <form id="addObjectiveForm" class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="addObjectiveLabel">Add Objective</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3">
+          <label for="objectiveParent" class="form-label">Parent Objective</label>
+          <select class="form-select" id="objectiveParent" name="parent_id">
+            <option value="">Top Level</option>
+          </select>
+        </div>
+        <div class="mb-3">
+          <label for="objectiveTitle" class="form-label">Objective</label>
+          <input type="text" class="form-control" id="objectiveTitle" name="objective" required>
+        </div>
+        <input type="hidden" name="strategy_id" class="strategy-id-input">
+        <?= csrf_field(); ?>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="submit" class="btn btn-primary">Save</button>
+      </div>
+    </form>
+  </div>
+</div>

--- a/admin/corporate/strategy/index.php
+++ b/admin/corporate/strategy/index.php
@@ -61,12 +61,45 @@ $categoryItems = get_lookup_items($pdo,'CORPORATE_STRATEGY_CATEGORY');
   <div class="tab-content" id="strategyTabsContent">
     <div class="tab-pane fade show active p-3" id="overview" role="tabpanel">Select a strategy to see details.</div>
     <div class="tab-pane fade p-3" id="objectives" role="tabpanel">
+      <div class="d-flex justify-content-end">
+        <?php if (user_has_permission('admin_strategy','create')): ?>
+        <button class="btn btn-sm btn-primary" id="addObjectiveBtn" data-bs-toggle="modal" data-bs-target="#addObjectiveModal">Add Objective</button>
+        <?php endif; ?>
+      </div>
       <div id="objectivesTree" class="mt-3"></div>
     </div>
-    <div class="tab-pane fade p-3" id="collaborators" role="tabpanel">Collaborators content</div>
-    <div class="tab-pane fade p-3" id="notes" role="tabpanel">Notes content</div>
-    <div class="tab-pane fade p-3" id="files" role="tabpanel">Files content</div>
-    <div class="tab-pane fade p-3" id="kpi" role="tabpanel">KPI Dashboard content</div>
+    <div class="tab-pane fade p-3" id="collaborators" role="tabpanel">
+      <div class="d-flex justify-content-end mb-2">
+        <?php if (user_has_permission('admin_strategy','create')): ?>
+        <button class="btn btn-sm btn-primary" id="addCollaboratorBtn" data-bs-toggle="modal" data-bs-target="#addCollaboratorModal">Add Collaborator</button>
+        <?php endif; ?>
+      </div>
+      <ul class="list-group" id="collaboratorsList"></ul>
+    </div>
+    <div class="tab-pane fade p-3" id="notes" role="tabpanel">
+      <div class="d-flex justify-content-end mb-2">
+        <?php if (user_has_permission('admin_strategy','create')): ?>
+        <button class="btn btn-sm btn-primary" id="addNoteBtn" data-bs-toggle="modal" data-bs-target="#addNoteModal">Add Note</button>
+        <?php endif; ?>
+      </div>
+      <ul class="list-group" id="notesList"></ul>
+    </div>
+    <div class="tab-pane fade p-3" id="files" role="tabpanel">
+      <div class="d-flex justify-content-end mb-2">
+        <?php if (user_has_permission('admin_strategy','create')): ?>
+        <button class="btn btn-sm btn-primary" id="addFileBtn" data-bs-toggle="modal" data-bs-target="#addFileModal">Upload File</button>
+        <?php endif; ?>
+      </div>
+      <ul class="list-group" id="filesList"></ul>
+    </div>
+    <div class="tab-pane fade p-3" id="kpi" role="tabpanel">
+      <div class="d-flex justify-content-end mb-2">
+        <?php if (user_has_permission('admin_strategy','create')): ?>
+        <button class="btn btn-sm btn-primary" id="addKpiBtn" data-bs-toggle="modal" data-bs-target="#addKpiModal">Add KPI</button>
+        <?php endif; ?>
+      </div>
+      <ul class="list-group" id="kpiList"></ul>
+    </div>
   </div>
 </div>
 
@@ -135,10 +168,18 @@ $categoryItems = get_lookup_items($pdo,'CORPORATE_STRATEGY_CATEGORY');
   </div>
 </div>
 
+<?php require 'includes/objective_modal.php'; ?>
+<?php require 'includes/collaborator_modal.php'; ?>
+<?php require 'includes/note_modal.php'; ?>
+<?php require 'includes/file_modal.php'; ?>
+<?php require 'includes/kpi_modal.php'; ?>
+
 <script>
 $(function(){
   let strategiesCache = [];
+  let currentStrategyId = null;
   function escapeHtml(text=""){ return $('<div>').text(text).html(); }
+  function updateStrategyIdInputs(id){ $('.strategy-id-input').val(id); }
   function loadStrategies(){
     $.getJSON('functions/read_strategies.php',{
       status: $('#filterStatus').val(),
@@ -166,17 +207,25 @@ $(function(){
   $('#filterTags').on('keyup', debounce(loadStrategies,300));
   $('#strategyList').on('click','.strategy-item',function(){
     const id = $(this).data('id');
+    currentStrategyId = id;
     const strategy = strategiesCache.find(s => s.id == id);
     $('.strategy-item').removeClass('active');
     $(this).addClass('active');
+    updateStrategyIdInputs(id);
     if(strategy){
       $('#overview').html('<h4>'+escapeHtml(strategy.title)+'</h4>');
     }
     loadObjectives(id);
-    $('#collaborators').text('Loading...');
-    $('#notes').text('Loading...');
-    $('#files').text('Loading...');
-    $('#kpi').text('Loading...');
+    $('#collaboratorsList, #notesList, #filesList, #kpiList').html('');
+  });
+  $('a[data-bs-toggle="tab"]').on('shown.bs.tab', function(e){
+    if(!currentStrategyId) return;
+    const target = $(e.target).attr('data-bs-target');
+    if(target === '#collaborators') loadCollaborators(currentStrategyId);
+    if(target === '#notes') loadNotes(currentStrategyId);
+    if(target === '#files') loadFiles(currentStrategyId);
+    if(target === '#kpi') loadKpi(currentStrategyId);
+    if(target === '#objectives') loadObjectives(currentStrategyId);
   });
   $('#addStrategyForm').on('submit', function(e){
     e.preventDefault();
@@ -189,6 +238,83 @@ $(function(){
         if(window.phoenix && phoenix.toast){ phoenix.toast.error(resp.error || 'Error'); } else { alert(resp.error || 'Error'); }
       }
     }, 'json');
+  });
+  $('#addObjectiveForm').on('submit', function(e){
+    e.preventDefault();
+    $.post('functions/add_objective.php', $(this).serialize(), function(resp){
+      if(resp.success){
+        if(window.phoenix && phoenix.toast){ phoenix.toast.success('Objective added'); } else { alert('Objective added'); }
+        $('#addObjectiveModal').modal('hide');
+        loadObjectives(currentStrategyId);
+      } else {
+        if(window.phoenix && phoenix.toast){ phoenix.toast.error(resp.error || 'Error'); } else { alert(resp.error || 'Error'); }
+      }
+    },'json');
+  });
+  $('#addCollaboratorForm').on('submit', function(e){
+    e.preventDefault();
+    $.post('functions/add_collaborator.php', $(this).serialize(), function(resp){
+      if(resp.success){
+        if(window.phoenix && phoenix.toast){ phoenix.toast.success('Collaborator added'); } else { alert('Collaborator added'); }
+        $('#addCollaboratorModal').modal('hide');
+        loadCollaborators(currentStrategyId);
+      } else {
+        if(window.phoenix && phoenix.toast){ phoenix.toast.error(resp.error || 'Error'); } else { alert(resp.error || 'Error'); }
+      }
+    },'json');
+  });
+  $('#addNoteForm').on('submit', function(e){
+    e.preventDefault();
+    $.post('functions/add_note.php', $(this).serialize(), function(resp){
+      if(resp.success){
+        if(window.phoenix && phoenix.toast){ phoenix.toast.success('Note added'); } else { alert('Note added'); }
+        $('#addNoteModal').modal('hide');
+        loadNotes(currentStrategyId);
+      } else {
+        if(window.phoenix && phoenix.toast){ phoenix.toast.error(resp.error || 'Error'); } else { alert(resp.error || 'Error'); }
+      }
+    },'json');
+  });
+  $('#uploadFileForm').on('submit', function(e){
+    e.preventDefault();
+    const fd = new FormData(this);
+    $.ajax({
+      url:'functions/upload_file.php',
+      method:'POST',
+      data:fd,
+      processData:false,
+      contentType:false,
+      dataType:'json',
+      success:function(resp){
+        if(resp.success){
+          if(window.phoenix && phoenix.toast){ phoenix.toast.success('File uploaded'); } else { alert('File uploaded'); }
+          $('#addFileModal').modal('hide');
+          loadFiles(currentStrategyId);
+        } else {
+          if(window.phoenix && phoenix.toast){ phoenix.toast.error(resp.error || 'Error'); } else { alert(resp.error || 'Error'); }
+        }
+      }
+    });
+  });
+  $('#addKpiForm').on('submit', function(e){
+    e.preventDefault();
+    $.post('functions/add_key_result.php', $(this).serialize(), function(resp){
+      if(resp.success){
+        if(window.phoenix && phoenix.toast){ phoenix.toast.success('KPI added'); } else { alert('KPI added'); }
+        $('#addKpiModal').modal('hide');
+        loadKpi(currentStrategyId);
+      } else {
+        if(window.phoenix && phoenix.toast){ phoenix.toast.error(resp.error || 'Error'); } else { alert(resp.error || 'Error'); }
+      }
+    },'json');
+  });
+  $('#addObjectiveModal').on('show.bs.modal', function(){
+    const $sel = $('#objectiveParent');
+    $sel.html('<option value="">Top Level</option>');
+    $('#objectivesTree li > div span.flex-grow-1').each(function(){
+      const li = $(this).closest('li');
+      $sel.append('<option value="'+li.data('id')+'">'+escapeHtml($(this).text().trim())+'</option>');
+    });
   });
   function loadObjectives(strategyId){
     $.getJSON('functions/read_objectives.php',{strategy_id:strategyId},function(resp){
@@ -208,12 +334,66 @@ $(function(){
       }
     });
   }
+  function loadCollaborators(strategyId){
+    $.getJSON('functions/read_collaborators.php',{strategy_id:strategyId},function(resp){
+      if(resp.success){
+        if(resp.collaborators && resp.collaborators.length){
+          let html='';
+          resp.collaborators.forEach(c=>{
+            html += `<li class="list-group-item d-flex justify-content-between"><span>${escapeHtml(c.name || '')}</span><span class="text-body-secondary">${escapeHtml(c.role || '')}</span></li>`;
+          });
+          $('#collaboratorsList').html(html);
+        } else {
+          $('#collaboratorsList').html('<li class="list-group-item text-body-tertiary">No collaborators</li>');
+        }
+      }
+    });
+  }
+  function loadNotes(strategyId){
+    $.getJSON('functions/read_notes.php',{strategy_id:strategyId},function(resp){
+      if(resp.success){
+        if(resp.notes && resp.notes.length){
+          let html='';
+          resp.notes.forEach(n=>{ html += `<li class="list-group-item">${escapeHtml(n.note)}</li>`; });
+          $('#notesList').html(html);
+        } else {
+          $('#notesList').html('<li class="list-group-item text-body-tertiary">No notes</li>');
+        }
+      }
+    });
+  }
+  function loadFiles(strategyId){
+    $.getJSON('functions/read_files.php',{strategy_id:strategyId},function(resp){
+      if(resp.success){
+        if(resp.files && resp.files.length){
+          let html='';
+          resp.files.forEach(f=>{ html += `<li class="list-group-item"><a href="${escapeHtml(f.file_path)}" target="_blank">${escapeHtml(f.file_name)}</a></li>`; });
+          $('#filesList').html(html);
+        } else {
+          $('#filesList').html('<li class="list-group-item text-body-tertiary">No files</li>');
+        }
+      }
+    });
+  }
+  function loadKpi(strategyId){
+    $.getJSON('functions/read_key_results.php',{strategy_id:strategyId},function(resp){
+      if(resp.success){
+        if(resp.key_results && resp.key_results.length){
+          let html='';
+          resp.key_results.forEach(k=>{ html += `<li class="list-group-item">${escapeHtml(k.title || k.name || '')}</li>`; });
+          $('#kpiList').html(html);
+        } else {
+          $('#kpiList').html('<li class="list-group-item text-body-tertiary">No KPIs</li>');
+        }
+      }
+    });
+  }
   function buildObjectivesTree(items, parent=0){
     let html = '<ul class="list-unstyled" data-parent="'+parent+'">';
     items.filter(o => +o.parent_id === parent).forEach(o => {
       html += '<li data-id="'+o.id+'">'+
-        '<div class="d-flex align-items-center mb-2"><span class="flex-grow-1">'+escapeHtml(o.title)+'</span>'+ 
-        '<div class="progress flex-grow-1 ms-2" style="height:4px;"><div class="progress-bar" style="width:'+(o.progress||0)+'%"></div></div></div>'+ 
+        '<div class="d-flex align-items-center mb-2"><span class="flex-grow-1">'+escapeHtml(o.title)+'</span>'+
+        '<div class="progress flex-grow-1 ms-2" style="height:4px;"><div class="progress-bar" style="width:'+(o.progress||0)+'%"></div></div></div>'+
         buildObjectivesTree(items, o.id)+
       '</li>';
     });


### PR DESCRIPTION
## Summary
- Add toolbar buttons and empty list components to each strategy tab
- Extract modals for objectives, collaborators, notes, files, and KPIs into partials
- Wire modal forms with AJAX and Phoenix toasts to refresh tab data

## Testing
- `php -l admin/corporate/strategy/index.php`
- `php -l admin/corporate/strategy/includes/objective_modal.php`
- `php -l admin/corporate/strategy/includes/collaborator_modal.php`
- `php -l admin/corporate/strategy/includes/note_modal.php`
- `php -l admin/corporate/strategy/includes/file_modal.php`
- `php -l admin/corporate/strategy/includes/kpi_modal.php`

------
https://chatgpt.com/codex/tasks/task_e_68b2b81efb4483338ed012abd9b13c54