### PR TITLE
Refactor organization hierarchy and modal person assignments

### DIFF
--- a/admin/orgs/agency_edit.php
+++ b/admin/orgs/agency_edit.php
@@ -157,58 +157,71 @@ require '../admin_header.php';
 </div>
 <?php if ($id): ?>
   <div class="card" id="persons">
-    <div class="card-header"><h4 class="mb-0">Assigned Persons</h4></div>
+    <div class="card-header d-flex justify-content-between align-items-center">
+      <h4 class="mb-0">Assigned Persons</h4>
+      <button class="btn btn-sm btn-primary" data-bs-toggle="modal" data-bs-target="#assignAgencyPersonModal">Assign Person</button>
+    </div>
     <div class="card-body">
       <table class="table table-sm">
         <thead>
           <tr><th>Name</th><th>Role</th><th>Lead</th><th></th></tr>
         </thead>
-        <tbody>
+        <tbody id="agency-persons-body">
           <?php foreach($assignedPersons as $ap): ?>
             <tr>
               <td><?= e($ap['name']); ?></td>
               <td><?= e($ap['role_label'] ?? ''); ?></td>
               <td><?= $ap['is_lead'] ? 'Yes' : 'No'; ?></td>
               <td>
-                <form method="post" action="functions/agency_remove_person.php" class="d-inline">
-                  <input type="hidden" name="assignment_id" value="<?= $ap['id']; ?>">
-                  <input type="hidden" name="agency_id" value="<?= $id; ?>">
-                  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
-                  <button class="btn btn-sm btn-danger" onclick="return confirm('Remove this person?');">Remove</button>
-                </form>
+                <button class="btn btn-sm btn-danger remove-person" data-url="functions/agency_remove_person.php" data-assignment-id="<?= $ap['id']; ?>" data-csrf="<?= $token; ?>">Remove</button>
               </td>
             </tr>
           <?php endforeach; ?>
         </tbody>
       </table>
-      <form method="post" action="functions/agency_assign_person.php" class="row g-2">
-        <input type="hidden" name="csrf_token" value="<?= $token; ?>">
-        <input type="hidden" name="agency_id" value="<?= $id; ?>">
-        <div class="col-md-4">
-          <select name="person_id" class="form-select" required>
-            <option value="">-- Person --</option>
-            <?php foreach($personOptions as $pid=>$pname): ?>
-              <option value="<?= $pid; ?>"><?= e($pname); ?></option>
-            <?php endforeach; ?>
-          </select>
-        </div>
-        <div class="col-md-4">
-          <select name="role_id" class="form-select">
-            <option value="">-- Role --</option>
-            <?php foreach($roleOptions as $rid=>$rlabel): ?>
-              <option value="<?= $rid; ?>"><?= e($rlabel); ?></option>
-            <?php endforeach; ?>
-          </select>
-        </div>
-        <div class="col-md-2 form-check d-flex align-items-center">
-          <input class="form-check-input" type="checkbox" value="1" name="is_lead" id="agencyLeadChk">
-          <label class="form-check-label ms-2" for="agencyLeadChk">Lead</label>
-        </div>
-        <div class="col-md-2">
-          <button class="btn btn-primary" type="submit">Assign</button>
-        </div>
-      </form>
+    </div>
+  </div>
+
+  <div class="modal fade" id="assignAgencyPersonModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <form class="assign-person-form" action="functions/agency_assign_person.php" data-target="agency-persons-body" data-modal="assignAgencyPersonModal" method="post">
+          <div class="modal-header">
+            <h5 class="modal-title">Assign Person</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+            <input type="hidden" name="agency_id" value="<?= $id; ?>">
+            <div class="mb-3">
+              <select name="person_id" class="form-select" required>
+                <option value="">-- Person --</option>
+                <?php foreach($personOptions as $pid=>$pname): ?>
+                  <option value="<?= $pid; ?>"><?= e($pname); ?></option>
+                <?php endforeach; ?>
+              </select>
+            </div>
+            <div class="mb-3">
+              <select name="role_id" class="form-select">
+                <option value="">-- Role --</option>
+                <?php foreach($roleOptions as $rid=>$rlabel): ?>
+                  <option value="<?= $rid; ?>"><?= e($rlabel); ?></option>
+                <?php endforeach; ?>
+              </select>
+            </div>
+            <div class="form-check mb-3">
+              <input class="form-check-input" type="checkbox" value="1" name="is_lead" id="agencyLeadChk">
+              <label class="form-check-label" for="agencyLeadChk">Lead</label>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button class="btn btn-primary" type="submit">Assign</button>
+          </div>
+        </form>
+      </div>
     </div>
   </div>
 <?php endif; ?>
+<?php $loadFsLightbox = true; ?>
+<script src="assets/orgs.js"></script>
 <?php require '../admin_footer.php'; ?>

--- a/admin/orgs/assets/orgs.js
+++ b/admin/orgs/assets/orgs.js
@@ -1,0 +1,83 @@
+// Handles hierarchy loading, filters, and person assignment modals
+
+document.addEventListener('DOMContentLoaded', () => {
+  const listEl = document.getElementById('orgList');
+  if (listEl) {
+    const orgList = new List('orgList', { valueNames: ['org-name', 'org-status'] });
+    const statusFilter = document.getElementById('statusFilter');
+    const orgFilter = document.getElementById('orgFilter');
+    const applyFilters = () => {
+      const status = statusFilter ? statusFilter.value : '';
+      const orgId = orgFilter ? orgFilter.value : '';
+      orgList.filter(item => {
+        const matchesStatus = !status || item.values()['org-status'] === status;
+        const matchesOrg = !orgId || item.elm.dataset.orgId === orgId;
+        return matchesStatus && matchesOrg;
+      });
+    };
+    if (statusFilter) statusFilter.addEventListener('change', applyFilters);
+    if (orgFilter) orgFilter.addEventListener('change', applyFilters);
+  }
+
+  document.addEventListener('show.bs.collapse', e => {
+    const target = e.target;
+    const type = target.dataset.type;
+    if (!type || target.dataset.loaded) return;
+    const parentId = target.dataset.parentId;
+    fetch(`index.php?ajax=${type}&parent_id=${parentId}`)
+      .then(r => r.text())
+      .then(html => {
+        const body = target.querySelector('.accordion-body');
+        if (body) body.innerHTML = html;
+        target.dataset.loaded = 1;
+        if (typeof refreshFsLightbox === 'function') {
+          refreshFsLightbox();
+        }
+      });
+  });
+
+  document.querySelectorAll('.assign-person-form').forEach(form => {
+    form.addEventListener('submit', function (e) {
+      e.preventDefault();
+      fetch(form.action, { method: 'POST', body: new FormData(form) })
+        .then(r => r.json())
+        .then(data => {
+          if (data.success && data.row) {
+            const targetBody = document.getElementById(form.dataset.target);
+            if (targetBody) {
+              targetBody.insertAdjacentHTML('beforeend', data.row);
+            }
+            form.reset();
+            const modalEl = document.getElementById(form.dataset.modal);
+            if (modalEl) {
+              const modal = bootstrap.Modal.getInstance(modalEl);
+              if (modal) modal.hide();
+            }
+          } else if (data.error) {
+            alert(data.error);
+          }
+        });
+    });
+  });
+
+  document.addEventListener('click', e => {
+    if (e.target.classList.contains('remove-person')) {
+      e.preventDefault();
+      const btn = e.target;
+      const url = btn.dataset.url;
+      const formData = new FormData();
+      formData.append('assignment_id', btn.dataset.assignmentId);
+      formData.append('csrf_token', btn.dataset.csrf);
+      fetch(url, { method: 'POST', body: formData })
+        .then(r => r.json())
+        .then(data => {
+          if (data.success) {
+            const row = btn.closest('tr');
+            if (row) row.remove();
+          } else if (data.error) {
+            alert(data.error);
+          }
+        });
+    }
+  });
+});

--- a/admin/orgs/division_edit.php
+++ b/admin/orgs/division_edit.php
@@ -155,58 +155,71 @@ require '../admin_header.php';
 </div>
 <?php if ($id): ?>
   <div class="card" id="persons">
-    <div class="card-header"><h4 class="mb-0">Assigned Persons</h4></div>
+    <div class="card-header d-flex justify-content-between align-items-center">
+      <h4 class="mb-0">Assigned Persons</h4>
+      <button class="btn btn-sm btn-primary" data-bs-toggle="modal" data-bs-target="#assignDivisionPersonModal">Assign Person</button>
+    </div>
     <div class="card-body">
       <table class="table table-sm">
         <thead>
           <tr><th>Name</th><th>Role</th><th>Lead</th><th></th></tr>
         </thead>
-        <tbody>
+        <tbody id="division-persons-body">
           <?php foreach($assignedPersons as $ap): ?>
             <tr>
               <td><?= e($ap['name']); ?></td>
               <td><?= e($ap['role_label'] ?? ''); ?></td>
               <td><?= $ap['is_lead'] ? 'Yes' : 'No'; ?></td>
               <td>
-                <form method="post" action="functions/division_remove_person.php" class="d-inline">
-                  <input type="hidden" name="assignment_id" value="<?= $ap['id']; ?>">
-                  <input type="hidden" name="division_id" value="<?= $id; ?>">
-                  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
-                  <button class="btn btn-sm btn-danger" onclick="return confirm('Remove this person?');">Remove</button>
-                </form>
+                <button class="btn btn-sm btn-danger remove-person" data-url="functions/division_remove_person.php" data-assignment-id="<?= $ap['id']; ?>" data-csrf="<?= $token; ?>">Remove</button>
               </td>
             </tr>
           <?php endforeach; ?>
         </tbody>
       </table>
-      <form method="post" action="functions/division_assign_person.php" class="row g-2">
-        <input type="hidden" name="csrf_token" value="<?= $token; ?>">
-        <input type="hidden" name="division_id" value="<?= $id; ?>">
-        <div class="col-md-4">
-          <select name="person_id" class="form-select" required>
-            <option value="">-- Person --</option>
-            <?php foreach($personOptions as $pid=>$pname): ?>
-              <option value="<?= $pid; ?>"><?= e($pname); ?></option>
-            <?php endforeach; ?>
-          </select>
-        </div>
-        <div class="col-md-4">
-          <select name="role_id" class="form-select">
-            <option value="">-- Role --</option>
-            <?php foreach($roleOptions as $rid=>$rlabel): ?>
-              <option value="<?= $rid; ?>"><?= e($rlabel); ?></option>
-            <?php endforeach; ?>
-          </select>
-        </div>
-        <div class="col-md-2 form-check d-flex align-items-center">
-          <input class="form-check-input" type="checkbox" value="1" name="is_lead" id="divisionLeadChk">
-          <label class="form-check-label ms-2" for="divisionLeadChk">Lead</label>
-        </div>
-        <div class="col-md-2">
-          <button class="btn btn-primary" type="submit">Assign</button>
-        </div>
-      </form>
+    </div>
+  </div>
+
+  <div class="modal fade" id="assignDivisionPersonModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <form class="assign-person-form" action="functions/division_assign_person.php" data-target="division-persons-body" data-modal="assignDivisionPersonModal" method="post">
+          <div class="modal-header">
+            <h5 class="modal-title">Assign Person</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+            <input type="hidden" name="division_id" value="<?= $id; ?>">
+            <div class="mb-3">
+              <select name="person_id" class="form-select" required>
+                <option value="">-- Person --</option>
+                <?php foreach($personOptions as $pid=>$pname): ?>
+                  <option value="<?= $pid; ?>"><?= e($pname); ?></option>
+                <?php endforeach; ?>
+              </select>
+            </div>
+            <div class="mb-3">
+              <select name="role_id" class="form-select">
+                <option value="">-- Role --</option>
+                <?php foreach($roleOptions as $rid=>$rlabel): ?>
+                  <option value="<?= $rid; ?>"><?= e($rlabel); ?></option>
+                <?php endforeach; ?>
+              </select>
+            </div>
+            <div class="form-check mb-3">
+              <input class="form-check-input" type="checkbox" value="1" name="is_lead" id="divisionLeadChk">
+              <label class="form-check-label" for="divisionLeadChk">Lead</label>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button class="btn btn-primary" type="submit">Assign</button>
+          </div>
+        </form>
+      </div>
     </div>
   </div>
 <?php endif; ?>
+<?php $loadFsLightbox = true; ?>
+<script src="assets/orgs.js"></script>
 <?php require '../admin_footer.php'; ?>

--- a/admin/orgs/functions/agency_assign_person.php
+++ b/admin/orgs/functions/agency_assign_person.php
@@ -1,23 +1,37 @@
 <?php
 require '../../../includes/php_header.php';
+header('Content-Type: application/json');
+
 $agency_id = (int)($_POST['agency_id'] ?? 0);
 $person_id = (int)($_POST['person_id'] ?? 0);
-$role_id = $_POST['role_id'] !== '' ? (int)$_POST['role_id'] : null;
-$is_lead = isset($_POST['is_lead']) ? 1 : 0;
-$token = $_POST['csrf_token'] ?? '';
-require_permission('agency','update');
-if($token !== ($_SESSION['csrf_token'] ?? '')){
-  header('Location: ../agency_edit.php?id='.$agency_id);
+$role_id   = $_POST['role_id'] !== '' ? (int)$_POST['role_id'] : null;
+$is_lead   = isset($_POST['is_lead']) ? 1 : 0;
+$token     = $_POST['csrf_token'] ?? '';
+
+require_permission('agency', 'update');
+
+if ($token !== ($_SESSION['csrf_token'] ?? '')) {
+  echo json_encode(['success' => false, 'error' => 'Invalid CSRF token']);
   exit;
 }
-if($agency_id && $person_id){
-  if($is_lead){
-    $pdo->prepare('UPDATE module_agency_persons SET is_lead=0 WHERE agency_id=:id')->execute([':id'=>$agency_id]);
+
+if ($agency_id && $person_id) {
+  if ($is_lead) {
+    $pdo->prepare('UPDATE module_agency_persons SET is_lead=0 WHERE agency_id=:id')->execute([':id' => $agency_id]);
   }
   $stmt = $pdo->prepare('INSERT INTO module_agency_persons (user_id,user_updated,agency_id,person_id,role_id,is_lead) VALUES (:uid,:uid,:aid,:pid,:role,:lead)');
-  $stmt->execute([':uid'=>$this_user_id,':aid'=>$agency_id,':pid'=>$person_id,':role'=>$role_id,':lead'=>$is_lead]);
+  $stmt->execute([':uid' => $this_user_id, ':aid' => $agency_id, ':pid' => $person_id, ':role' => $role_id, ':lead' => $is_lead]);
   $assignId = $pdo->lastInsertId();
-  admin_audit_log($pdo,$this_user_id,'module_agency_persons',$assignId,'CREATE',null,json_encode(['agency_id'=>$agency_id,'person_id'=>$person_id,'role_id'=>$role_id,'is_lead'=>$is_lead]),'Assigned person');
+  admin_audit_log($pdo, $this_user_id, 'module_agency_persons', $assignId, 'CREATE', null, json_encode(['agency_id' => $agency_id, 'person_id' => $person_id, 'role_id' => $role_id, 'is_lead' => $is_lead]), 'Assigned person');
+
+  $infoStmt = $pdo->prepare('SELECT CONCAT(p.first_name," ",p.last_name) AS name, li.label AS role_label FROM person p LEFT JOIN lookup_list_items li ON li.id = :rid WHERE p.id = :pid');
+  $infoStmt->execute([':rid' => $role_id, ':pid' => $person_id]);
+  $info = $infoStmt->fetch(PDO::FETCH_ASSOC);
+
+  $row = '<tr><td>' . e($info['name'] ?? '') . '</td><td>' . e($info['role_label'] ?? '') . '</td><td>' . ($is_lead ? 'Yes' : 'No') . '</td><td><button class="btn btn-sm btn-danger remove-person" data-url="functions/agency_remove_person.php" data-assignment-id="' . $assignId . '" data-csrf="' . e($token) . '">Remove</button></td></tr>';
+
+  echo json_encode(['success' => true, 'row' => $row]);
+  exit;
 }
-header('Location: ../agency_edit.php?id='.$agency_id.'#persons');
-exit;
+
+echo json_encode(['success' => false]);

--- a/admin/orgs/functions/agency_remove_person.php
+++ b/admin/orgs/functions/agency_remove_person.php
@@ -1,17 +1,23 @@
 <?php
 require '../../../includes/php_header.php';
+header('Content-Type: application/json');
+
 $assignment_id = (int)($_POST['assignment_id'] ?? 0);
-$agency_id = (int)($_POST['agency_id'] ?? 0);
-$token = $_POST['csrf_token'] ?? '';
-require_permission('agency','update');
-if($token !== ($_SESSION['csrf_token'] ?? '')){
-  header('Location: ../agency_edit.php?id='.$agency_id);
+$token         = $_POST['csrf_token'] ?? '';
+
+require_permission('agency', 'update');
+
+if ($token !== ($_SESSION['csrf_token'] ?? '')) {
+  echo json_encode(['success' => false, 'error' => 'Invalid CSRF token']);
   exit;
 }
-if($assignment_id){
+
+if ($assignment_id) {
   $stmt = $pdo->prepare('DELETE FROM module_agency_persons WHERE id=:id');
-  $stmt->execute([':id'=>$assignment_id]);
-  admin_audit_log($pdo,$this_user_id,'module_agency_persons',$assignment_id,'DELETE',null,null,'Removed person');
+  $stmt->execute([':id' => $assignment_id]);
+  admin_audit_log($pdo, $this_user_id, 'module_agency_persons', $assignment_id, 'DELETE', null, null, 'Removed person');
+  echo json_encode(['success' => true]);
+  exit;
 }
-header('Location: ../agency_edit.php?id='.$agency_id.'#persons');
-exit;
+
+echo json_encode(['success' => false]);

--- a/admin/orgs/functions/division_assign_person.php
+++ b/admin/orgs/functions/division_assign_person.php
@@ -1,23 +1,37 @@
 <?php
 require '../../../includes/php_header.php';
+header('Content-Type: application/json');
+
 $division_id = (int)($_POST['division_id'] ?? 0);
-$person_id = (int)($_POST['person_id'] ?? 0);
-$role_id = $_POST['role_id'] !== '' ? (int)$_POST['role_id'] : null;
-$is_lead = isset($_POST['is_lead']) ? 1 : 0;
-$token = $_POST['csrf_token'] ?? '';
-require_permission('division','update');
-if($token !== ($_SESSION['csrf_token'] ?? '')){
-  header('Location: ../division_edit.php?id='.$division_id);
+$person_id   = (int)($_POST['person_id'] ?? 0);
+$role_id     = $_POST['role_id'] !== '' ? (int)$_POST['role_id'] : null;
+$is_lead     = isset($_POST['is_lead']) ? 1 : 0;
+$token       = $_POST['csrf_token'] ?? '';
+
+require_permission('division', 'update');
+
+if ($token !== ($_SESSION['csrf_token'] ?? '')) {
+  echo json_encode(['success' => false, 'error' => 'Invalid CSRF token']);
   exit;
 }
-if($division_id && $person_id){
-  if($is_lead){
-    $pdo->prepare('UPDATE module_division_persons SET is_lead=0 WHERE division_id=:id')->execute([':id'=>$division_id]);
+
+if ($division_id && $person_id) {
+  if ($is_lead) {
+    $pdo->prepare('UPDATE module_division_persons SET is_lead=0 WHERE division_id=:id')->execute([':id' => $division_id]);
   }
   $stmt = $pdo->prepare('INSERT INTO module_division_persons (user_id,user_updated,division_id,person_id,role_id,is_lead) VALUES (:uid,:uid,:did,:pid,:role,:lead)');
-  $stmt->execute([':uid'=>$this_user_id,':did'=>$division_id,':pid'=>$person_id,':role'=>$role_id,':lead'=>$is_lead]);
+  $stmt->execute([':uid' => $this_user_id, ':did' => $division_id, ':pid' => $person_id, ':role' => $role_id, ':lead' => $is_lead]);
   $assignId = $pdo->lastInsertId();
-  admin_audit_log($pdo,$this_user_id,'module_division_persons',$assignId,'CREATE',null,json_encode(['division_id'=>$division_id,'person_id'=>$person_id,'role_id'=>$role_id,'is_lead'=>$is_lead]),'Assigned person');
+  admin_audit_log($pdo, $this_user_id, 'module_division_persons', $assignId, 'CREATE', null, json_encode(['division_id' => $division_id, 'person_id' => $person_id, 'role_id' => $role_id, 'is_lead' => $is_lead]), 'Assigned person');
+
+  $infoStmt = $pdo->prepare('SELECT CONCAT(p.first_name," ",p.last_name) AS name, li.label AS role_label FROM person p LEFT JOIN lookup_list_items li ON li.id = :rid WHERE p.id = :pid');
+  $infoStmt->execute([':rid' => $role_id, ':pid' => $person_id]);
+  $info = $infoStmt->fetch(PDO::FETCH_ASSOC);
+
+  $row = '<tr><td>' . e($info['name'] ?? '') . '</td><td>' . e($info['role_label'] ?? '') . '</td><td>' . ($is_lead ? 'Yes' : 'No') . '</td><td><button class="btn btn-sm btn-danger remove-person" data-url="functions/division_remove_person.php" data-assignment-id="' . $assignId . '" data-csrf="' . e($token) . '">Remove</button></td></tr>';
+
+  echo json_encode(['success' => true, 'row' => $row]);
+  exit;
 }
-header('Location: ../division_edit.php?id='.$division_id.'#persons');
-exit;
+
+echo json_encode(['success' => false]);

--- a/admin/orgs/functions/division_remove_person.php
+++ b/admin/orgs/functions/division_remove_person.php
@@ -1,17 +1,23 @@
 <?php
 require '../../../includes/php_header.php';
+header('Content-Type: application/json');
+
 $assignment_id = (int)($_POST['assignment_id'] ?? 0);
-$division_id = (int)($_POST['division_id'] ?? 0);
-$token = $_POST['csrf_token'] ?? '';
-require_permission('division','update');
-if($token !== ($_SESSION['csrf_token'] ?? '')){
-  header('Location: ../division_edit.php?id='.$division_id);
+$token         = $_POST['csrf_token'] ?? '';
+
+require_permission('division', 'update');
+
+if ($token !== ($_SESSION['csrf_token'] ?? '')) {
+  echo json_encode(['success' => false, 'error' => 'Invalid CSRF token']);
   exit;
 }
-if($assignment_id){
+
+if ($assignment_id) {
   $stmt = $pdo->prepare('DELETE FROM module_division_persons WHERE id=:id');
-  $stmt->execute([':id'=>$assignment_id]);
-  admin_audit_log($pdo,$this_user_id,'module_division_persons',$assignment_id,'DELETE',null,null,'Removed person');
+  $stmt->execute([':id' => $assignment_id]);
+  admin_audit_log($pdo, $this_user_id, 'module_division_persons', $assignment_id, 'DELETE', null, null, 'Removed person');
+  echo json_encode(['success' => true]);
+  exit;
 }
-header('Location: ../division_edit.php?id='.$division_id.'#persons');
-exit;
+
+echo json_encode(['success' => false]);

--- a/admin/orgs/functions/organization_assign_person.php
+++ b/admin/orgs/functions/organization_assign_person.php
@@ -1,24 +1,38 @@
 <?php
 require '../../../includes/php_header.php';
+header('Content-Type: application/json');
+
 $organization_id = (int)($_POST['organization_id'] ?? 0);
-$person_id = (int)($_POST['person_id'] ?? 0);
-$role_id = $_POST['role_id'] !== '' ? (int)$_POST['role_id'] : null;
-$is_lead = isset($_POST['is_lead']) ? 1 : 0;
-$token = $_POST['csrf_token'] ?? '';
+$person_id      = (int)($_POST['person_id'] ?? 0);
+$role_id        = $_POST['role_id'] !== '' ? (int)$_POST['role_id'] : null;
+$is_lead        = isset($_POST['is_lead']) ? 1 : 0;
+$token          = $_POST['csrf_token'] ?? '';
+
 require_permission('organization','update');
-if($token !== ($_SESSION['csrf_token'] ?? '')){
-  header('Location: ../organization_edit.php?id='.$organization_id);
+
+if ($token !== ($_SESSION['csrf_token'] ?? '')) {
+  echo json_encode(['success' => false, 'error' => 'Invalid CSRF token']);
   exit;
 }
-if($organization_id && $person_id){
-  if($is_lead){
+
+if ($organization_id && $person_id) {
+  if ($is_lead) {
     $stmt = $pdo->prepare('UPDATE module_organization_persons SET is_lead=0 WHERE organization_id=:id');
-    $stmt->execute([':id'=>$organization_id]);
+    $stmt->execute([':id' => $organization_id]);
   }
   $stmt = $pdo->prepare('INSERT INTO module_organization_persons (user_id,user_updated,organization_id,person_id,role_id,is_lead) VALUES (:uid,:uid,:org,:pid,:role,:lead)');
-  $stmt->execute([':uid'=>$this_user_id,':org'=>$organization_id,':pid'=>$person_id,':role'=>$role_id,':lead'=>$is_lead]);
+  $stmt->execute([':uid' => $this_user_id, ':org' => $organization_id, ':pid' => $person_id, ':role' => $role_id, ':lead' => $is_lead]);
   $assignId = $pdo->lastInsertId();
-  admin_audit_log($pdo,$this_user_id,'module_organization_persons',$assignId,'CREATE',null,json_encode(['organization_id'=>$organization_id,'person_id'=>$person_id,'role_id'=>$role_id,'is_lead'=>$is_lead]),'Assigned person');
+  admin_audit_log($pdo, $this_user_id, 'module_organization_persons', $assignId, 'CREATE', null, json_encode(['organization_id' => $organization_id, 'person_id' => $person_id, 'role_id' => $role_id, 'is_lead' => $is_lead]), 'Assigned person');
+
+  $infoStmt = $pdo->prepare('SELECT CONCAT(p.first_name," ",p.last_name) AS name, li.label AS role_label FROM person p LEFT JOIN lookup_list_items li ON li.id = :rid WHERE p.id = :pid');
+  $infoStmt->execute([':rid' => $role_id, ':pid' => $person_id]);
+  $info = $infoStmt->fetch(PDO::FETCH_ASSOC);
+
+  $row = '<tr><td>' . e($info['name'] ?? '') . '</td><td>' . e($info['role_label'] ?? '') . '</td><td>' . ($is_lead ? 'Yes' : 'No') . '</td><td><button class="btn btn-sm btn-danger remove-person" data-url="functions/organization_remove_person.php" data-assignment-id="' . $assignId . '" data-csrf="' . e($token) . '">Remove</button></td></tr>';
+
+  echo json_encode(['success' => true, 'row' => $row]);
+  exit;
 }
-header('Location: ../organization_edit.php?id='.$organization_id.'#persons');
-exit;
+
+echo json_encode(['success' => false]);

--- a/admin/orgs/functions/organization_remove_person.php
+++ b/admin/orgs/functions/organization_remove_person.php
@@ -1,17 +1,24 @@
 <?php
 require '../../../includes/php_header.php';
-$assignment_id = (int)($_POST['assignment_id'] ?? 0);
+header('Content-Type: application/json');
+
+$assignment_id   = (int)($_POST['assignment_id'] ?? 0);
 $organization_id = (int)($_POST['organization_id'] ?? 0);
-$token = $_POST['csrf_token'] ?? '';
-require_permission('organization','update');
-if($token !== ($_SESSION['csrf_token'] ?? '')){
-  header('Location: ../organization_edit.php?id='.$organization_id);
+$token           = $_POST['csrf_token'] ?? '';
+
+require_permission('organization', 'update');
+
+if ($token !== ($_SESSION['csrf_token'] ?? '')) {
+  echo json_encode(['success' => false, 'error' => 'Invalid CSRF token']);
   exit;
 }
-if($assignment_id){
+
+if ($assignment_id) {
   $stmt = $pdo->prepare('DELETE FROM module_organization_persons WHERE id=:id');
-  $stmt->execute([':id'=>$assignment_id]);
-  admin_audit_log($pdo,$this_user_id,'module_organization_persons',$assignment_id,'DELETE',null,null,'Removed person');
+  $stmt->execute([':id' => $assignment_id]);
+  admin_audit_log($pdo, $this_user_id, 'module_organization_persons', $assignment_id, 'DELETE', null, null, 'Removed person');
+  echo json_encode(['success' => true]);
+  exit;
 }
-header('Location: ../organization_edit.php?id='.$organization_id.'#persons');
-exit;
+
+echo json_encode(['success' => false]);

--- a/admin/orgs/organization_edit.php
+++ b/admin/orgs/organization_edit.php
@@ -141,58 +141,71 @@ require '../admin_header.php';
 </div>
 <?php if ($id): ?>
   <div class="card" id="persons">
-    <div class="card-header"><h4 class="mb-0">Assigned Persons</h4></div>
+    <div class="card-header d-flex justify-content-between align-items-center">
+      <h4 class="mb-0">Assigned Persons</h4>
+      <button class="btn btn-sm btn-primary" data-bs-toggle="modal" data-bs-target="#assignOrgPersonModal">Assign Person</button>
+    </div>
     <div class="card-body">
       <table class="table table-sm">
         <thead>
           <tr><th>Name</th><th>Role</th><th>Lead</th><th></th></tr>
         </thead>
-        <tbody>
+        <tbody id="org-persons-body">
           <?php foreach($assignedPersons as $ap): ?>
             <tr>
               <td><?= e($ap['name']); ?></td>
               <td><?= e($ap['role_label'] ?? ''); ?></td>
               <td><?= $ap['is_lead'] ? 'Yes' : 'No'; ?></td>
               <td>
-                <form method="post" action="functions/organization_remove_person.php" class="d-inline">
-                  <input type="hidden" name="assignment_id" value="<?= $ap['id']; ?>">
-                  <input type="hidden" name="organization_id" value="<?= $id; ?>">
-                  <input type="hidden" name="csrf_token" value="<?= $token; ?>">
-                  <button class="btn btn-sm btn-danger" onclick="return confirm('Remove this person?');">Remove</button>
-                </form>
+                <button class="btn btn-sm btn-danger remove-person" data-url="functions/organization_remove_person.php" data-assignment-id="<?= $ap['id']; ?>" data-csrf="<?= $token; ?>">Remove</button>
               </td>
             </tr>
           <?php endforeach; ?>
         </tbody>
       </table>
-      <form method="post" action="functions/organization_assign_person.php" class="row g-2">
-        <input type="hidden" name="csrf_token" value="<?= $token; ?>">
-        <input type="hidden" name="organization_id" value="<?= $id; ?>">
-        <div class="col-md-4">
-          <select name="person_id" class="form-select" required>
-            <option value="">-- Person --</option>
-            <?php foreach($personOptions as $pid=>$pname): ?>
-              <option value="<?= $pid; ?>"><?= e($pname); ?></option>
-            <?php endforeach; ?>
-          </select>
-        </div>
-        <div class="col-md-4">
-          <select name="role_id" class="form-select">
-            <option value="">-- Role --</option>
-            <?php foreach($roleOptions as $rid=>$rlabel): ?>
-              <option value="<?= $rid; ?>"><?= e($rlabel); ?></option>
-            <?php endforeach; ?>
-          </select>
-        </div>
-        <div class="col-md-2 form-check d-flex align-items-center">
-          <input class="form-check-input" type="checkbox" value="1" name="is_lead" id="orgLeadChk">
-          <label class="form-check-label ms-2" for="orgLeadChk">Lead</label>
-        </div>
-        <div class="col-md-2">
-          <button class="btn btn-primary" type="submit">Assign</button>
-        </div>
-      </form>
+    </div>
+  </div>
+
+  <div class="modal fade" id="assignOrgPersonModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <form class="assign-person-form" action="functions/organization_assign_person.php" data-target="org-persons-body" data-modal="assignOrgPersonModal" method="post">
+          <div class="modal-header">
+            <h5 class="modal-title">Assign Person</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+            <input type="hidden" name="organization_id" value="<?= $id; ?>">
+            <div class="mb-3">
+              <select name="person_id" class="form-select" required>
+                <option value="">-- Person --</option>
+                <?php foreach($personOptions as $pid=>$pname): ?>
+                  <option value="<?= $pid; ?>"><?= e($pname); ?></option>
+                <?php endforeach; ?>
+              </select>
+            </div>
+            <div class="mb-3">
+              <select name="role_id" class="form-select">
+                <option value="">-- Role --</option>
+                <?php foreach($roleOptions as $rid=>$rlabel): ?>
+                  <option value="<?= $rid; ?>"><?= e($rlabel); ?></option>
+                <?php endforeach; ?>
+              </select>
+            </div>
+            <div class="form-check mb-3">
+              <input class="form-check-input" type="checkbox" value="1" name="is_lead" id="orgLeadChk">
+              <label class="form-check-label" for="orgLeadChk">Lead</label>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button class="btn btn-primary" type="submit">Assign</button>
+          </div>
+        </form>
+      </div>
     </div>
   </div>
 <?php endif; ?>
+<?php $loadFsLightbox = true; ?>
+<script src="assets/orgs.js"></script>
 <?php require '../admin_footer.php'; ?>


### PR DESCRIPTION
## Summary
- Load agencies and divisions on demand with new `index.php?ajax=` endpoints and accordions
- Add client-side filter bar for organization hierarchy and enhance file attachments with lightbox + download icon
- Move person assignment into Bootstrap modals with AJAX JSON endpoints
- Implement `assets/orgs.js` to handle hierarchy, modals, and lightbox refresh

## Testing
- `php -l admin/orgs/functions/organization_assign_person.php`
- `php -l admin/orgs/functions/organization_remove_person.php`
- `php -l admin/orgs/functions/agency_assign_person.php`
- `php -l admin/orgs/functions/agency_remove_person.php`
- `php -l admin/orgs/functions/division_assign_person.php`
- `php -l admin/orgs/functions/division_remove_person.php`
- `php -l admin/orgs/index.php`
- `php -l admin/orgs/organization_edit.php`
- `php -l admin/orgs/agency_edit.php`
- `php -l admin/orgs/division_edit.php`


------
https://chatgpt.com/codex/tasks/task_e_68b2b8f9f6dc8333a414dbbba9bc6a36