### PR TITLE
Enable meeting deletion for authorized users

### DIFF
--- a/_SQL/2024-05-09_meeting_delete_permission.sql
+++ b/_SQL/2024-05-09_meeting_delete_permission.sql
@@ -1,0 +1,26 @@
+-- Ensure meeting delete permission exists and is assigned
+INSERT INTO admin_permissions (user_id, user_updated, module, action)
+SELECT 1, 1, 'meeting', 'delete'
+WHERE NOT EXISTS (
+  SELECT 1 FROM admin_permissions WHERE module='meeting' AND action='delete'
+);
+
+INSERT INTO admin_permission_group_permissions (user_id, user_updated, permission_group_id, permission_id)
+SELECT 1, 1, pg.id, p.id
+FROM admin_permission_groups pg
+JOIN admin_permissions p ON p.module='meeting' AND p.action='delete'
+WHERE pg.name='Meetings'
+  AND NOT EXISTS (
+    SELECT 1 FROM admin_permission_group_permissions g
+    WHERE g.permission_group_id = pg.id AND g.permission_id = p.id
+);
+
+INSERT INTO admin_role_permissions (user_id, user_updated, role_id, permission_group_id)
+SELECT 1, 1, r.id, pg.id
+FROM admin_roles r
+JOIN admin_permission_groups pg ON pg.name='Meetings'
+WHERE r.name='Admin'
+  AND NOT EXISTS (
+    SELECT 1 FROM admin_role_permissions rp
+    WHERE rp.role_id = r.id AND rp.permission_group_id = pg.id
+);

--- a/admin/meetings/include/details_view.php
+++ b/admin/meetings/include/details_view.php
@@ -25,9 +25,14 @@ $_SESSION['csrf_token'] = $token;
             <span class="badge bg-<?= h($meetingTypeColor); ?> ms-1"><?php echo h($meetingTypeLabel); ?></span>
           <?php endif; ?>
         </h2>
-        <?php if (user_has_permission('meeting','update')): ?>
-          <a href="index.php?action=edit&id=<?php echo (int)$meeting['id']; ?>" class="btn btn-warning btn-sm">Edit Meeting</a>
-        <?php endif; ?>
+        <div class="ms-2">
+          <?php if (user_has_permission('meeting','update')): ?>
+            <a href="index.php?action=edit&id=<?php echo (int)$meeting['id']; ?>" class="btn btn-warning btn-sm">Edit Meeting</a>
+          <?php endif; ?>
+          <?php if (user_has_permission('meeting','delete')): ?>
+            <button class="btn btn-danger btn-sm ms-1 delete-meeting" id="deleteMeetingBtn" data-id="<?php echo (int)$meeting['id']; ?>" data-token="<?= h($token); ?>">Delete</button>
+          <?php endif; ?>
+        </div>
       </div>
       <?php if (!empty($meeting['description'])): ?>
       <p class="text-body-secondary mb-1"><?php echo h($meeting['description']); ?></p>
@@ -328,6 +333,28 @@ document.addEventListener('DOMContentLoaded', function(){
     toastEl.innerHTML = '<div class="d-flex"><div class="toast-body">'+esc(message)+'</div><button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button></div>';
     container.appendChild(toastEl);
     new bootstrap.Toast(toastEl).show();
+  }
+
+  var deleteBtn = document.getElementById('deleteMeetingBtn');
+  if(deleteBtn){
+    deleteBtn.addEventListener('click', async function(){
+      if(!confirm('Delete this meeting?')) return;
+      var fd = new FormData();
+      fd.append('id', meetingId);
+      fd.append('csrf_token', csrfToken);
+      try{
+        var res = await fetch('functions/delete.php', {method:'POST', body: fd});
+        var data = await res.json();
+        if(data.success){
+          window.location = 'index.php';
+        } else {
+          showToast(data.message || 'Failed to delete meeting');
+        }
+      } catch(err){
+        console.error(err);
+        showToast('Failed to delete meeting');
+      }
+    });
   }
 
   function fetchJson(url, opts){

--- a/admin/meetings/include/list_view.php
+++ b/admin/meetings/include/list_view.php
@@ -34,6 +34,11 @@
           <a class="meeting-title fw-bold" href="index.php?action=details&id=<?= (int)$m['id'] ?>"><?= h($m['title'] ?? '') ?></a>
         </div>
         <div class="col-auto text-body-tertiary start-time"><?= !empty($m['start_time']) ? h(date('d M, Y g:i A', strtotime($m['start_time']))) : '' ?></div>
+        <?php if (user_has_permission('meeting','delete')): ?>
+        <div class="col-auto ms-2">
+          <button class="btn btn-sm btn-danger delete-meeting" data-id="<?= (int)$m['id'] ?>" data-token="<?= h($token) ?>">Delete</button>
+        </div>
+        <?php endif; ?>
       </div>
     <?php endforeach; ?>
     <?php if (empty($meetings)): ?>
@@ -65,6 +70,8 @@ document.addEventListener('DOMContentLoaded', function(){
   var originalListHTML = listContainer ? listContainer.innerHTML : '';
   var countSpan = document.getElementById('meetingCount');
   var originalCount = countSpan ? countSpan.textContent : '';
+  var canDelete = <?php echo user_has_permission('meeting','delete') ? 'true' : 'false'; ?>;
+  var csrfToken = '<?= h($token); ?>';
   if(searchInput){
     searchInput.addEventListener('input', function(){
       clearTimeout(searchTimeout);
@@ -88,11 +95,12 @@ document.addEventListener('DOMContentLoaded', function(){
               if(countSpan){ countSpan.textContent = res.count || 0; }
               if(res.meetings && res.meetings.length){
                 res.meetings.forEach(function(m){
-                  var row = `<div class="row align-items-center border-top py-3 gx-0 meeting-row" data-id="${m.id}">`+
+              var del = canDelete ? `<div class="col-auto ms-2"><button class="btn btn-sm btn-danger delete-meeting" data-id="${m.id}" data-token="${csrfToken}">Delete</button></div>` : '';
+              var row = `<div class="row align-items-center border-top py-3 gx-0 meeting-row" data-id="${m.id}">`+
                             `<div class="col"><a class="meeting-title fw-bold" href="index.php?action=details&id=${m.id}">${m.title}</a></div>`+
-                            `<div class="col-auto text-body-tertiary start-time">${m.start_time || ''}</div></div>`;
+                            `<div class="col-auto text-body-tertiary start-time">${m.start_time || ''}</div>`+del+`</div>`;
                   listContainer.insertAdjacentHTML('beforeend', row);
-                });
+              });
               } else {
                 listContainer.innerHTML = '<p class="fs-9 text-body-secondary mb-0">No meetings found.</p>';
               }
@@ -102,6 +110,30 @@ document.addEventListener('DOMContentLoaded', function(){
       },300);
     });
   }
+
+  listContainer.addEventListener('click', function(e){
+    var btn = e.target.closest('.delete-meeting');
+    if(btn){
+      if(!confirm('Delete this meeting?')) return;
+      var id = btn.dataset.id;
+      var token = btn.dataset.token;
+      var params = new URLSearchParams();
+      params.append('id', id);
+      params.append('csrf_token', token);
+      fetch('functions/delete.php', {method:'POST', body: params})
+        .then(function(r){ return r.json(); })
+        .then(function(res){
+          if(res.success){
+            var row = btn.closest('.meeting-row');
+            if(row){ row.remove(); }
+            if(countSpan){ countSpan.textContent = document.querySelectorAll('.meeting-row').length; }
+          } else {
+            showToast(res.message || 'Delete failed','danger');
+          }
+        })
+        .catch(function(){ showToast('Delete failed','danger'); });
+    }
+  });
 
   var form = document.getElementById('meetingQuickAdd');
   if(form){


### PR DESCRIPTION
## Summary
- add conditional delete button to meeting list with CSRF protection
- allow deleting a meeting from its detail page
- ensure `meeting/delete` permission and role assignments in SQL seed

## Testing
- `php -l admin/meetings/include/list_view.php`
- `php -l admin/meetings/include/details_view.php`
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68b2bbf47b08833390c198c5fefbd8ed