### PR TITLE
Add project sorting and drag-and-drop ordering

### DIFF
--- a/_SQL/atlis.sql
+++ b/_SQL/atlis.sql
@@ -4496,26 +4496,27 @@ CREATE TABLE `module_projects_pins` (
   `date_created` datetime DEFAULT current_timestamp(),
   `date_updated` datetime DEFAULT current_timestamp() ON UPDATE current_timestamp(),
   `memo` text DEFAULT NULL,
-  `project_id` int(11) NOT NULL
+  `project_id` int(11) NOT NULL,
+  `sort_order` int(11) NOT NULL DEFAULT 0
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --
 -- Dumping data for table `module_projects_pins`
 --
 
-INSERT INTO `module_projects_pins` (`id`, `user_id`, `user_updated`, `date_created`, `date_updated`, `memo`, `project_id`) VALUES
-(1, 1, 1, '2025-08-23 01:39:13', '2025-08-23 01:39:13', NULL, 15),
-(2, 1, 1, '2025-08-23 01:45:35', '2025-08-23 01:45:35', NULL, 12),
-(3, 1, 1, '2025-08-23 01:48:03', '2025-08-23 01:48:03', NULL, 4),
-(9, 1, 1, '2025-08-23 02:26:45', '2025-08-23 02:26:45', NULL, 2),
-(11, 1, 1, '2025-08-24 00:24:23', '2025-08-24 00:24:23', NULL, 22),
-(12, 1, 1, '2025-08-24 00:25:39', '2025-08-24 00:25:39', NULL, 20),
-(15, 1, 1, '2025-08-24 01:37:42', '2025-08-24 01:37:42', NULL, 21),
-(18, 1, 1, '2025-08-24 01:47:02', '2025-08-24 01:47:02', NULL, 11),
-(19, 1, 1, '2025-08-24 01:47:07', '2025-08-24 01:47:07', NULL, 13),
-(23, 1, 1, '2025-08-26 22:39:01', '2025-08-26 22:39:01', NULL, 24),
-(24, 1, 1, '2025-08-26 22:41:37', '2025-08-26 22:41:37', NULL, 10),
-(25, 1, 1, '2025-08-30 01:27:13', '2025-08-30 01:27:13', NULL, 1);
+INSERT INTO `module_projects_pins` (`id`, `user_id`, `user_updated`, `date_created`, `date_updated`, `memo`, `project_id`, `sort_order`) VALUES
+(1, 1, 1, '2025-08-23 01:39:13', '2025-08-23 01:39:13', NULL, 15, 0),
+(2, 1, 1, '2025-08-23 01:45:35', '2025-08-23 01:45:35', NULL, 12, 0),
+(3, 1, 1, '2025-08-23 01:48:03', '2025-08-23 01:48:03', NULL, 4, 0),
+(9, 1, 1, '2025-08-23 02:26:45', '2025-08-23 02:26:45', NULL, 2, 0),
+(11, 1, 1, '2025-08-24 00:24:23', '2025-08-24 00:24:23', NULL, 22, 0),
+(12, 1, 1, '2025-08-24 00:25:39', '2025-08-24 00:25:39', NULL, 20, 0),
+(15, 1, 1, '2025-08-24 01:37:42', '2025-08-24 01:37:42', NULL, 21, 0),
+(18, 1, 1, '2025-08-24 01:47:02', '2025-08-24 01:47:02', NULL, 11, 0),
+(19, 1, 1, '2025-08-24 01:47:07', '2025-08-24 01:47:07', NULL, 13, 0),
+(23, 1, 1, '2025-08-26 22:39:01', '2025-08-26 22:39:01', NULL, 24, 0),
+(24, 1, 1, '2025-08-26 22:41:37', '2025-08-26 22:41:37', NULL, 10, 0),
+(25, 1, 1, '2025-08-30 01:27:13', '2025-08-30 01:27:13', NULL, 1, 0);
 
 -- --------------------------------------------------------
 
@@ -4542,6 +4543,28 @@ INSERT INTO `module_projects_questions` (`id`, `user_id`, `user_updated`, `date_
 (2, 1, 1, '2025-08-23 11:04:30', '2025-08-23 11:04:30', NULL, 4, 'What was was the color of George Washington\'s white horse?'),
 (3, 1, 1, '2025-08-24 01:18:09', '2025-08-24 01:18:09', NULL, 10, 'Who is Dave Wilkins ?'),
 (5, 1, 1, '2025-08-24 02:09:04', '2025-08-24 02:09:04', NULL, 2, 'test');
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `module_projects_sort`
+--
+
+CREATE TABLE `module_projects_sort` (
+  `id` int(11) NOT NULL,
+  `user_id` int(11) NOT NULL,
+  `user_updated` int(11) DEFAULT NULL,
+  `date_created` datetime DEFAULT current_timestamp(),
+  `date_updated` datetime DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  `memo` text DEFAULT NULL,
+  `project_id` int(11) NOT NULL,
+  `sort_order` int(11) NOT NULL DEFAULT 0
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+--
+-- Dumping data for table `module_projects_sort`
+--
+
 
 -- --------------------------------------------------------
 
@@ -6249,6 +6272,16 @@ ALTER TABLE `module_projects_questions`
   ADD KEY `fk_module_projects_questions_project_id` (`project_id`);
 
 --
+-- Indexes for table `module_projects_sort`
+--
+ALTER TABLE `module_projects_sort`
+  ADD PRIMARY KEY (`id`),
+  ADD UNIQUE KEY `uq_user_project` (`user_id`,`project_id`),
+  ADD KEY `fk_module_projects_sort_user_id` (`user_id`),
+  ADD KEY `fk_module_projects_sort_user_updated` (`user_updated`),
+  ADD KEY `fk_module_projects_sort_project_id` (`project_id`);
+
+--
 -- Indexes for table `module_strategy`
 --
 ALTER TABLE `module_strategy`
@@ -7038,6 +7071,12 @@ ALTER TABLE `module_projects_questions`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=6;
 
 --
+-- AUTO_INCREMENT for table `module_projects_sort`
+--
+ALTER TABLE `module_projects_sort`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
 -- AUTO_INCREMENT for table `module_strategy`
 --
 ALTER TABLE `module_strategy`
@@ -7770,6 +7809,13 @@ ALTER TABLE `module_projects_notes`
 --
 ALTER TABLE `module_projects_questions`
   ADD CONSTRAINT `fk_module_projects_questions_project_id` FOREIGN KEY (`project_id`) REFERENCES `module_projects` (`id`);
+
+--
+-- Constraints for table `module_projects_sort`
+--
+ALTER TABLE `module_projects_sort`
+  ADD CONSTRAINT `fk_module_projects_sort_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+  ADD CONSTRAINT `fk_module_projects_sort_project_id` FOREIGN KEY (`project_id`) REFERENCES `module_projects` (`id`);
 
 --
 -- Constraints for table `module_strategy`

--- a/module/project/functions/update_sort.php
+++ b/module/project/functions/update_sort.php
@@ -1,0 +1,34 @@
+<?php
+require '../../../includes/php_header.php';
+require_permission('project','update');
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!empty($_POST['pinned']) && is_array($_POST['pinned'])) {
+        $order = 1;
+        $stmt = $pdo->prepare('UPDATE module_projects_pins SET sort_order = :sort, user_updated = :uid WHERE user_id = :uid AND project_id = :pid');
+        foreach ($_POST['pinned'] as $pid) {
+            $pid = (int)$pid;
+            $stmt->execute([
+                ':sort' => $order++,
+                ':uid' => $this_user_id,
+                ':pid' => $pid
+            ]);
+        }
+    }
+    if (!empty($_POST['unpinned']) && is_array($_POST['unpinned'])) {
+        $order = 1;
+        $stmt = $pdo->prepare('INSERT INTO module_projects_sort (user_id,user_updated,project_id,sort_order) VALUES (:uid,:uid,:pid,:sort) ON DUPLICATE KEY UPDATE sort_order = VALUES(sort_order), user_updated = VALUES(user_updated)');
+        foreach ($_POST['unpinned'] as $pid) {
+            $pid = (int)$pid;
+            $stmt->execute([
+                ':uid' => $this_user_id,
+                ':pid' => $pid,
+                ':sort' => $order++
+            ]);
+        }
+    }
+}
+
+echo json_encode(['success' => true]);

--- a/module/project/include/list_view.php
+++ b/module/project/include/list_view.php
@@ -6,7 +6,7 @@
     <li class="breadcrumb-item active" aria-current="page">List View</li>
   </ol>
 </nav>
-<div id="projectSummary" data-list='{"valueNames":["project","assignees","start","deadline","projectprogress","status","priority","action"],"page":50,"pagination":true}'>
+<div id="projectSummary" data-list='{"valueNames":["project","assignees","start","deadline","projectprogress","status","priority","action"],"page":10,"pagination":true}'>
   <div class="row align-items-end justify-content-between pb-4 g-3">
     <div class="col-auto">
       <h3>Projects</h3>
@@ -59,18 +59,19 @@
           <th class="sort align-middle text-end" scope="col" style="width:10%;"></th>
         </tr>
       </thead>
-      <tbody class="list" id="project-summary-table-body">
+      <tbody class="list" id="pinnedProjects">
         <?php foreach ($projects as $project): ?>
-
-        <tr class="position-static <?= $project['pinned'] ? 'pinned-row bg-body-tertiary border-start border-atlis border-3' : ''; ?>" data-pinned="<?= $project['pinned'] ? 1 : 0; ?>">
+          <?php if ($project['pinned']): ?>
+        <tr class="position-static pinned-row bg-body-tertiary border-start border-atlis border-3" data-project-id="<?= (int)$project['id']; ?>">
           <td class="align-middle text-center">
             <?php if (user_has_permission('project','read')): ?>
             <button class="bg-transparent border-0 p-0 text-warning pin-toggle" data-project-id="<?= (int)$project['id']; ?>" aria-label="Pin project">
-              <span class="fa-solid <?= $project['pinned'] ? 'fa-thumbtack' : 'fa-thumbtack fa-rotate-90'; ?>"></span>
+              <span class="fa-solid fa-thumbtack"></span>
             </button>
             <?php endif; ?>
           </td>
           <td class="align-middle time white-space-nowrap ps-0 project">
+            <span class="svg-inline--fa fa-grip-vertical drag-handle me-2"></span>
             <a class="fw-bold fs-8" href="index.php?action=details&id=<?php echo $project['id']; ?>"><?php echo h($project['name']); ?></a>
             <span class="d-none priority"><?php echo h($project['priority_label'] ?? ''); ?></span>
           </td>
@@ -103,12 +104,67 @@
           <td class="align-middle text-end">
             <div class="btn-reveal-trigger position-static d-flex justify-content-end align-items-center gap-2">
               <button class="btn btn-link p-0 pin-toggle" data-project-id="<?php echo (int)$project['id']; ?>" title="Toggle pin">
-                <span class="fa-solid fa-thumbtack <?php echo $project['pinned'] ? 'text-warning' : 'text-body-tertiary'; ?>"></span>
+                <span class="fa-solid fa-thumbtack text-warning"></span>
               </button>
               <a class="btn btn-sm dropdown-toggle dropdown-caret-none transition-none btn-reveal fs-10" href="index.php?action=details&id=<?php echo $project['id']; ?>"><span class="fas fa-chevron-right fs-10"></span></a>
             </div>
           </td>
         </tr>
+          <?php endif; ?>
+        <?php endforeach; ?>
+      </tbody>
+      <tbody class="list" id="regularProjects">
+        <?php foreach ($projects as $project): ?>
+          <?php if (!$project['pinned']): ?>
+        <tr class="position-static" data-project-id="<?= (int)$project['id']; ?>">
+          <td class="align-middle text-center">
+            <?php if (user_has_permission('project','read')): ?>
+            <button class="bg-transparent border-0 p-0 text-warning pin-toggle" data-project-id="<?= (int)$project['id']; ?>" aria-label="Pin project">
+              <span class="fa-solid fa-thumbtack fa-rotate-90"></span>
+            </button>
+            <?php endif; ?>
+          </td>
+          <td class="align-middle time white-space-nowrap ps-0 project">
+            <span class="svg-inline--fa fa-grip-vertical drag-handle me-2"></span>
+            <a class="fw-bold fs-8" href="index.php?action=details&id=<?php echo $project['id']; ?>"><?php echo h($project['name']); ?></a>
+            <span class="d-none priority"><?php echo h($project['priority_label'] ?? ''); ?></span>
+          </td>
+          <td class="align-middle white-space-nowrap assignees ps-3">
+            <div class="avatar-group avatar-group-dense">
+              <?php foreach ($project['assignees'] as $assignee): ?>
+                <?php $pic = !empty($assignee['file_path']) ? $assignee['file_path'] : 'assets/img/team/avatar.webp'; ?>
+                <div class="avatar avatar-s rounded-circle">
+                  <img class="rounded-circle" src="<?php echo getURLDir() . h($pic); ?>" alt="<?= h($assignee['name']); ?>" />
+                </div>
+              <?php endforeach; ?>
+            </div>
+          </td>
+          <td class="align-middle ps-3 start"><?php echo !empty($project['start_date']) ? h(date('F jS, Y', strtotime($project['start_date']))) : ''; ?></td>
+          <td class="align-middle ps-3 deadline"><?php echo !empty($project['complete_date']) ? h(date('F jS, Y', strtotime($project['complete_date']))) : ''; ?></td>
+          <td class="align-middle ps-3 projectprogress">
+            <div class="d-flex align-items-center gap-2">
+              <div class="progress flex-grow-1" style="height:4px;">
+                <div class="progress-bar" style="width:<?= $project['total_tasks'] ? ($project['completed_tasks']/$project['total_tasks']*100) : 0; ?>%"></div>
+              </div>
+              <span class="fs-9"><?= h($project['completed_tasks']); ?>/<?= h($project['total_tasks']); ?></span>
+            </div>
+          </td>
+          <td class="align-middle ps-8 status"><span class="badge badge-phoenix fs-10 badge-phoenix-<?php echo h($project['status_color']); ?>"><?php echo h($project['status_label']); ?></span></td>
+          <td class="align-middle ps-3 priority">
+            <span class="badge badge-phoenix fs-10 badge-phoenix-<?php echo h($project['priority_color']); ?>">
+              <?php echo h($project['priority_label']); ?>
+            </span>
+          </td>
+          <td class="align-middle text-end">
+            <div class="btn-reveal-trigger position-static d-flex justify-content-end align-items-center gap-2">
+              <button class="btn btn-link p-0 pin-toggle" data-project-id="<?php echo (int)$project['id']; ?>" title="Toggle pin">
+                <span class="fa-solid fa-thumbtack text-body-tertiary"></span>
+              </button>
+              <a class="btn btn-sm dropdown-toggle dropdown-caret-none transition-none btn-reveal fs-10" href="index.php?action=details&id=<?php echo $project['id']; ?>"><span class="fas fa-chevron-right fs-10"></span></a>
+            </div>
+          </td>
+        </tr>
+          <?php endif; ?>
         <?php endforeach; ?>
       </tbody>
     </table>
@@ -127,75 +183,100 @@
 <script>
   const csrfToken = '<?= csrf_token(); ?>';
   function setupProjectList() {
-  const projectSummaryEl = document.getElementById('projectSummary');
-  const options = window.phoenix.utils.getData(projectSummaryEl, 'list');
-  const projectList = new List(projectSummaryEl, options);
-  window.projectList = projectList;
+    const projectSummaryEl = document.getElementById('projectSummary');
+    const options = window.phoenix.utils.getData(projectSummaryEl, 'list');
+    const projectList = new List(projectSummaryEl, options);
+    window.projectList = projectList;
 
-  const statusFilter = document.getElementById('filter-status');
-  const priorityFilter = document.getElementById('filter-priority');
+    const statusFilter = document.getElementById('filter-status');
+    const priorityFilter = document.getElementById('filter-priority');
 
-  function applyFilters() {
-    const s = statusFilter.value;
-    const p = priorityFilter.value;
-    projectList.filter(item => {
-      const v = item.values();
-      const statusMatch = !s || v.status === s;
-      const priorityMatch = !p || v.priority === p;
-      return statusMatch && priorityMatch;
-    });
-  }
+    function applyFilters() {
+      const s = statusFilter.value;
+      const p = priorityFilter.value;
+      projectList.filter(item => {
+        const v = item.values();
+        const statusMatch = !s || v.status === s;
+        const priorityMatch = !p || v.priority === p;
+        return statusMatch && priorityMatch;
+      });
+    }
 
-  statusFilter.addEventListener('change', applyFilters);
-  priorityFilter.addEventListener('change', applyFilters);
+    statusFilter.addEventListener('change', applyFilters);
+    priorityFilter.addEventListener('change', applyFilters);
 
-  function sortRows() {
-    projectList.sort('', {
-      sortFunction: (a, b) => {
-        const pinnedA = Number(a.elm.dataset.pinned) === 1;
-        const pinnedB = Number(b.elm.dataset.pinned) === 1;
-        if (pinnedA !== pinnedB) {
-          return pinnedA ? -1 : 1;
+    const pinnedBody = document.getElementById('pinnedProjects');
+    const regularBody = document.getElementById('regularProjects');
+
+    function sendOrder(type){
+      const ids=[...document.querySelectorAll(`#${type}Projects tr`)].map((tr,i)=>`${type}[]=${tr.dataset.projectId}`);
+      fetch('functions/update_sort.php',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:ids.join('&')});
+    }
+
+    document.querySelectorAll('.pin-toggle').forEach(btn => {
+      btn.addEventListener('click', async e => {
+        e.preventDefault();
+        const projectId = btn.dataset.projectId;
+        const row = btn.closest('tr');
+        if (!projectId || !row) return;
+        try {
+          const res = await fetch('functions/toggle_pin.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: new URLSearchParams({ project_id: projectId, csrf_token: csrfToken })
+          });
+          const data = await res.json();
+          const pinned = !!data.pinned;
+          row.querySelectorAll('.pin-toggle span.fa-thumbtack').forEach(icon => {
+            icon.classList.toggle('fa-rotate-90', !pinned);
+            icon.classList.toggle('text-warning', pinned);
+            icon.classList.toggle('text-body-tertiary', !pinned);
+          });
+          ['pinned-row', 'bg-body-tertiary', 'border-start', 'border-atlis', 'border-3'].forEach(cls => row.classList.toggle(cls, pinned));
+          if (pinned) {
+            pinnedBody.appendChild(row);
+          } else {
+            regularBody.appendChild(row);
+          }
+          projectList.reindex();
+          sendOrder('pinned');
+          sendOrder('unpinned');
+        } catch (err) {
+          console.error(err);
         }
-        return a.values().project.localeCompare(b.values().project);
-      }
+      });
     });
+
+    new Sortable(pinnedBody, {
+      handle: '.drag-handle', animation: 150, group: { name:'pinned', pull:false, put:false },
+      onEnd: () => { sendOrder('pinned'); projectList.reindex(); }
+    });
+    new Sortable(regularBody, {
+      handle: '.drag-handle', animation: 150, group: { name:'regular', pull:false, put:false },
+      onEnd: () => { sendOrder('unpinned'); projectList.reindex(); }
+    });
+
+    const viewAll = projectSummaryEl.querySelector('[data-list-view="*"]');
+    const viewLess = projectSummaryEl.querySelector('[data-list-view="less"]');
+    if(viewAll && viewLess){
+      viewAll.addEventListener('click', e => {
+        e.preventDefault();
+        projectList.show(projectList.size());
+        viewAll.classList.add('d-none');
+        viewLess.classList.remove('d-none');
+      });
+      viewLess.addEventListener('click', e => {
+        e.preventDefault();
+        projectList.show(options.page);
+        viewLess.classList.add('d-none');
+        viewAll.classList.remove('d-none');
+      });
+    }
   }
 
-  document.querySelectorAll('.pin-toggle').forEach(btn => {
-    btn.addEventListener('click', async e => {
-      e.preventDefault();
-      const projectId = btn.dataset.projectId;
-      const row = btn.closest('tr');
-      if (!projectId || !row) return;
-      try {
-        const res = await fetch('functions/toggle_pin.php', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-          body: new URLSearchParams({ project_id: projectId, csrf_token: csrfToken })
-        });
-        const data = await res.json();
-        const pinned = !!data.pinned;
-        row.dataset.pinned = pinned ? '1' : '0';
-        row.querySelectorAll('.pin-toggle span.fa-thumbtack').forEach(icon => {
-          icon.classList.toggle('fa-rotate-90', !pinned);
-          icon.classList.toggle('text-warning', pinned);
-          icon.classList.toggle('text-body-tertiary', !pinned);
-        });
-        ['pinned-row', 'bg-body-tertiary', 'border-start', 'border-atlis', 'border-3'].forEach(cls => row.classList.toggle(cls, pinned));
-        sortRows();
-      } catch (err) {
-        console.error(err);
-      }
-    });
-  });
-  sortRows();
-}
-
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', setupProjectList);
-} else {
-  setupProjectList();
-}
-
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', setupProjectList);
+  } else {
+    setupProjectList();
+  }
 </script>

--- a/module/project/index.php
+++ b/module/project/index.php
@@ -46,7 +46,8 @@ $sql = "SELECT p.id,
                COUNT(t.id) AS total_tasks,
                SUM(CASE WHEN t.completed = 1 THEN 1 ELSE 0 END) AS completed_tasks,
                SUM(CASE WHEN t.completed = 0 OR t.completed IS NULL THEN 1 ELSE 0 END) AS in_progress,
-               pp.id AS pinned
+               pp.id AS pinned,
+               ps.sort_order AS user_sort_order
         FROM module_projects p
         LEFT JOIN lookup_list_items li ON p.status = li.id
         LEFT JOIN lookup_list_item_attributes attr ON li.id = attr.item_id AND attr.attr_code = 'COLOR-CLASS'
@@ -55,9 +56,10 @@ $sql = "SELECT p.id,
         LEFT JOIN module_agency a ON p.agency_id = a.id
         LEFT JOIN module_division d ON p.division_id = d.id
         LEFT JOIN module_projects_pins pp ON pp.project_id = p.id AND pp.user_id = :uid
+        LEFT JOIN module_projects_sort ps ON ps.project_id = p.id AND ps.user_id = :uid
         LEFT JOIN module_tasks t ON t.project_id = p.id
         GROUP BY p.id
-        ORDER BY (pp.id IS NOT NULL) DESC, p.name";
+        ORDER BY (pp.id IS NOT NULL) DESC, CASE WHEN pp.id IS NOT NULL THEN pp.sort_order ELSE ps.sort_order END, p.name";
 
 $stmt = $pdo->prepare($sql);
 $stmt->execute([':uid' => $this_user_id]);


### PR DESCRIPTION
## Summary
- allow user-specific project ordering with new module_projects_sort table and pin sort orders
- expose update_sort.php endpoint to persist pinned and unpinned order
- enable drag-and-drop reordering of projects with Sortable.js

## Testing
- `php -l module/project/functions/update_sort.php`
- `php -l module/project/index.php`
- `php -l module/project/include/list_view.php`


------
https://chatgpt.com/codex/tasks/task_e_68b330a66ec08333844ea0409a49db50