### PR TITLE
Enhance strategy modals with AJAX selects and badges

### DIFF
--- a/admin/corporate/strategy/includes/collaborator_modal.php
+++ b/admin/corporate/strategy/includes/collaborator_modal.php
@@ -7,12 +7,12 @@
       </div>
       <div class="modal-body">
         <div class="mb-3">
-          <label for="collaboratorPerson" class="form-label">Person ID</label>
-          <input type="number" class="form-control" id="collaboratorPerson" name="person_id" required>
+          <label for="collaboratorPerson" class="form-label">Person</label>
+          <select class="form-select" id="collaboratorPerson" name="person_id" data-choices="data-choices" required></select>
         </div>
         <div class="mb-3">
-          <label for="collaboratorRole" class="form-label">Role ID</label>
-          <input type="number" class="form-control" id="collaboratorRole" name="role_id">
+          <label for="collaboratorRole" class="form-label">Role</label>
+          <select class="form-select" id="collaboratorRole" name="role_id" data-choices="data-choices"></select>
         </div>
         <input type="hidden" name="strategy_id" class="strategy-id-input">
         <?= csrf_field(); ?>

--- a/admin/corporate/strategy/includes/kpi_modal.php
+++ b/admin/corporate/strategy/includes/kpi_modal.php
@@ -10,6 +10,22 @@
           <label for="kpiTitle" class="form-label">Title</label>
           <input type="text" class="form-control" id="kpiTitle" name="title" required>
         </div>
+        <div class="mb-3">
+          <label for="kpiObjective" class="form-label">Objective</label>
+          <select class="form-select" id="kpiObjective" name="objective_id" data-choices="data-choices"></select>
+        </div>
+        <div class="mb-3">
+          <label for="kpiTarget" class="form-label">Target Value</label>
+          <input type="number" class="form-control" id="kpiTarget" name="target_value">
+        </div>
+        <div class="mb-3">
+          <label for="kpiCurrent" class="form-label">Current Value</label>
+          <input type="number" class="form-control" id="kpiCurrent" name="current_value">
+        </div>
+        <div class="mb-3">
+          <label for="kpiUnit" class="form-label">Unit</label>
+          <input type="text" class="form-control" id="kpiUnit" name="unit">
+        </div>
         <input type="hidden" name="strategy_id" class="strategy-id-input">
         <?= csrf_field(); ?>
       </div>

--- a/admin/corporate/strategy/includes/objective_modal.php
+++ b/admin/corporate/strategy/includes/objective_modal.php
@@ -16,6 +16,14 @@
           <label for="objectiveTitle" class="form-label">Objective</label>
           <input type="text" class="form-control" id="objectiveTitle" name="objective" required>
         </div>
+        <div class="mb-3">
+          <label for="objectiveOwner" class="form-label">Owner</label>
+          <select class="form-select" id="objectiveOwner" name="owner_id" data-choices="data-choices"></select>
+        </div>
+        <div class="mb-3">
+          <label for="objectiveProgress" class="form-label">Progress</label>
+          <input type="number" class="form-control" id="objectiveProgress" name="progress" min="0" max="100">
+        </div>
         <input type="hidden" name="strategy_id" class="strategy-id-input">
         <?= csrf_field(); ?>
       </div>


### PR DESCRIPTION
## Summary
- Use Choices-based AJAX selects for collaborators, objective owners, and KPI objective links
- Expand objective and KPI modals with ownership, progress, and measurement fields
- Show colored status, priority, and category badges and load related data on tab activation

## Testing
- `php -l admin/corporate/strategy/index.php`
- `php -l admin/corporate/strategy/includes/collaborator_modal.php`
- `php -l admin/corporate/strategy/includes/objective_modal.php`
- `php -l admin/corporate/strategy/includes/kpi_modal.php`


------
https://chatgpt.com/codex/tasks/task_e_68b336f3ac088333a79ec8c4762c91bf